### PR TITLE
[DOC-430][DOC-448] versions.yaml and version variable in pages, metrics migration and rendering

### DIFF
--- a/migration-tools/scripts/automata.py
+++ b/migration-tools/scripts/automata.py
@@ -437,7 +437,7 @@ def processFile(page, content):
                 continue
 
             if "{% include metrics.md" in line:
-                line = "{{< metrics >}}\n"
+                line = "{{% metrics %}}\n"
 
             buffer.append(line)
             page.content = page.content + line

--- a/migration-tools/scripts/automata.py
+++ b/migration-tools/scripts/automata.py
@@ -436,9 +436,8 @@ def processFile(page, content):
             if flags["assign-ver"]["active"] and not flags["assign-ver"]["isValid"]:
                 continue
 
-            
-
-
+            if "{% include metrics.md" in line:
+                line = "{{< metrics >}}\n"
 
             buffer.append(line)
             page.content = page.content + line

--- a/migration-tools/scripts/migrate_file.py
+++ b/migration-tools/scripts/migrate_file.py
@@ -257,6 +257,8 @@ class FrontMatter():
         return str.replace("`", "").lstrip(" ")
 
     def toString(self):
+        if "site.data.versions[page.version.name]" in self.title:
+            self.title = self.title.replace("site.data.versions[page.version.name]", "pageVersion")
         description = yaml.dump(self.description, sort_keys=False, default_flow_style=False)
         description = description.replace(">-", "").replace("|-", ">-")
         return f"---\ntitle: {self.clean(self.title)}\nweight: {self.weight}\ndescription: {description}\nlayout: default\n---\n"

--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -57,6 +57,7 @@ caches:
     maxAge: -1
 
 params:
+  stableVersion:  '3.10'
   arangoproxyUrl: "http://192.168.129.4:8080"
   pygmentsUseClassic: false
   description: "Documentation for ArangoDB"

--- a/site/data/versions.yaml
+++ b/site/data/versions.yaml
@@ -1,0 +1,9 @@
+- name: '3.11'
+  version: '3.11.0'
+  alias: "devel"
+  deprecated: false
+
+- name: '3.10'
+  version: '3.10.5'
+  alias: "stable"
+  deprecated: false

--- a/site/themes/hugo-theme-relearn/layouts/partials/_main.hugo
+++ b/site/themes/hugo-theme-relearn/layouts/partials/_main.hugo
@@ -1,4 +1,7 @@
 {{- partial "page-meta.hugo" . }}
+{{- partial "shortcodes/version.html" (dict
+  "page" .Page
+) }}
 {{- partial "output-partial.hugo" (dict "base" "header" "page" . "parameter" .) }}
 {{- if not .File }}
   {{- partial "output-partial.hugo" (dict "base" "body" "page" . "parameter" (dict "page" . "content" (partial "output-partial.hugo" (dict "base" "initial" "page" . "parameter" .)))) }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/archetypes/chapter/article.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/archetypes/chapter/article.html
@@ -2,8 +2,9 @@
 {{- $content := .content }}
 {{- with $page }}
           <article class="chapter">
+            {{- partial "deprecated.html" . }}
+            {{- partial "in-development.html" . }}
           {{ partial "heading-post.html" . }}
-ASFASFASFSF
 {{ $content | safeHTML }}
             <footer class="footline">
               {{- partial "content-footer.html" . }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/archetypes/default/article.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/archetypes/default/article.html
@@ -3,7 +3,8 @@
 {{- with $page }}
     <article class="default">
       <hgroup>
-      <h1>{{ .Title | markdownify }}</h1>
+        {{ $pageVersion := $page.Page.Scratch.Get "pageVersion"  }}
+      <h1>{{ replace .Title "{{ pageVersion }}" $pageVersion | markdownify }}</h1>
       <p>
         {{ .Description }}
       </p>

--- a/site/themes/hugo-theme-relearn/layouts/partials/archetypes/default/article.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/archetypes/default/article.html
@@ -1,9 +1,13 @@
 {{- $page := .page }}
 {{- $content := .content }}
+{{ $pageVersion := $page.Page.Scratch.Get "version" }}
+
+
 {{- with $page }}
     <article class="default">
+      {{- partial "deprecated.html" . }}
+      {{- partial "in-development.html" . }}
       <hgroup>
-        {{ $pageVersion := $page.Page.Scratch.Get "pageVersion"  }}
       <h1>{{ replace .Title "{{ pageVersion }}" $pageVersion | markdownify }}</h1>
       <p>
         {{ .Description }}
@@ -14,6 +18,4 @@
         {{- partial "content-footer.html" . }}
       </nav>
     </article>
-    
-
 {{- end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/archetypes/home/article.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/archetypes/home/article.html
@@ -1,7 +1,11 @@
 {{- $page := .page }}
 {{- $content := .content }}
+
+
 {{- with $page }}
     <article class="home">
+      {{- partial "deprecated.html" . }}
+      {{- partial "in-development.html" . }}
       <h1 class="page-title">{{ .Title | markdownify }}</h1>
       <p class="lead">
         {{ .Description }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/archetypes/label/article.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/archetypes/label/article.html
@@ -1,8 +1,12 @@
 {{- $page := .page }}
 {{- $content := .content }}
+{{ $pageVersion := $page.Page.Scratch.Get "version" }}
+
+
 {{- with $page }}
     <article class="default">
-      {{ $pageVersion := $page.Page.Scratch.Get "pageVersion"  }}
+      {{- partial "deprecated.html" . }}
+      {{- partial "in-development.html" . }}
       <h1 class="page-title">{{ replace .Title "{{ pageVersion }}" $pageVersion | markdownify }}</h1>
       <p class="lead">
         {{ .Description }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/archetypes/label/article.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/archetypes/label/article.html
@@ -2,7 +2,8 @@
 {{- $content := .content }}
 {{- with $page }}
     <article class="default">
-      <h1 class="page-title">{{ .Title | markdownify }}</h1>
+      {{ $pageVersion := $page.Page.Scratch.Get "pageVersion"  }}
+      <h1 class="page-title">{{ replace .Title "{{ pageVersion }}" $pageVersion | markdownify }}</h1>
       <p class="lead">
         {{ .Description }}
       </p>

--- a/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
@@ -2,6 +2,13 @@
 {{ $shortVersion := $.Page.Scratch.Get "versionShort" }}
 
 {{ if $deprecated }}
+    {{ $href := printf "/%s" site.Params.stableVersion }}
+    {{ $nonDeprecatedPath := replace .Page.RelPermalink $shortVersion site.Params.stableVersion }}
+    {{ $nonDeprecatedPath }}
+    {{ $stablePage := .Page.GetPage $nonDeprecatedPath }}
+    {{ if $stablePage }}
+        {{ $href = $stablePage.Permalink }}
+    {{ end }}
     <div class="box notices cstyle warning">
         <div class="box-content-container">
             <div class="box-content">
@@ -9,7 +16,7 @@
                 <div class="box-text">
                     <p>ArangoDB v{{ $shortVersion }} reached End of Life (EOL) and is no longer supported.
 
-                    This documentation is outdated. Please see the most recent version here: <a href="/{{ .Site.Params.stableVersion }}">Latest Docs</a></p>
+                    This documentation is outdated. Please see the most recent version here: <a href="{{ $href }}">Latest Docs</a></p>
                 </div>
             </div>
         </div>

--- a/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
@@ -9,7 +9,7 @@
                 <div class="box-text">
                     <p>ArangoDB v{{ $shortVersion }} reached End of Life (EOL) and is no longer supported.
 
-                    This documentation is outdated. Please see the most recent version here: <a href="/">Latest Docs</a></p>
+                    This documentation is outdated. Please see the most recent version here: <a href="/{{ .Site.Params.stableVersion }}">Latest Docs</a></p>
                 </div>
             </div>
         </div>

--- a/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
@@ -1,0 +1,17 @@
+{{- $deprecated := $.Page.Scratch.Get "deprecated" }}
+{{ $shortVersion := $.Page.Scratch.Get "versionShort" }}
+
+{{ if $deprecated }}
+    <div class="box notices cstyle warning">
+        <div class="box-content-container">
+            <div class="box-content">
+                <i class="fas fa-exclamation-triangle"></i>
+                <div class="box-text">
+                    <p>ArangoDB v{{ $shortVersion }} reached End of Life (EOL) and is no longer supported.
+
+                    This documentation is outdated. Please see the most recent version here: <a href="/">Latest Docs</a></p>
+                </div>
+            </div>
+        </div>
+    </div>
+{{ end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/deprecated.html
@@ -1,10 +1,11 @@
 {{- $deprecated := $.Page.Scratch.Get "deprecated" }}
 {{ $shortVersion := $.Page.Scratch.Get "versionShort" }}
+{{ $stableVersion := $.Page.Scratch.Get "stableVersion" }}
+
 
 {{ if $deprecated }}
-    {{ $href := printf "/%s" site.Params.stableVersion }}
-    {{ $nonDeprecatedPath := replace .Page.RelPermalink $shortVersion site.Params.stableVersion }}
-    {{ $nonDeprecatedPath }}
+    {{ $href := printf "/%s" $shortVersion }}
+    {{ $nonDeprecatedPath := replace .Page.RelPermalink $shortVersion $stableVersion }}
     {{ $stablePage := .Page.GetPage $nonDeprecatedPath }}
     {{ if $stablePage }}
         {{ $href = $stablePage.Permalink }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/header.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/header.html
@@ -66,6 +66,8 @@
                 </div>
 
                {{- define "breadcrumb" }}
+               {{ $pageVersion := .page.Scratch.Get "version"  }}
+
                {{- $parent := .page.Parent }}
                {{- $ispublished := gt (int (len .page.Permalink)) 0 }}
                {{- $depth := .depth }}
@@ -82,7 +84,7 @@
                   <li itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
                     <meta itemprop="position" content="{{ $depth }}" />
                     <a itemprop="item" href="{{ .page.RelPermalink }}"{{if not .depth}} aria-disabled="true"{{end}}>
-                      <span itemprop="name" class="breadcrumb-entry">{{ .page.Title | markdownify }}</span>
+                      <span itemprop="name" class="breadcrumb-entry">{{ replace .page.Title "{{ pageVersion }}" $pageVersion | markdownify }}</span>
                     </a>{{ if .depth }} > {{ end }}
                   </li>
                   {{ end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/in-development.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/in-development.html
@@ -1,0 +1,20 @@
+{{- $isInDevelopment := $.Page.Scratch.Get "underDevelopment" }}
+{{ $shortVersion := $.Page.Scratch.Get "versionShort" }}
+
+
+{{ if $isInDevelopment }}
+    <div class="box notices cstyle warning">
+        <div class="box-content-container">
+            <div class="box-content">
+                <i class="fas fa-exclamation-triangle"></i>
+                <div class="box-text">
+                    <p>
+                        ArangoDB v{{ $shortVersion }} is under development and not released yet.
+                        
+                        This documentation is not final and potentially incomplete.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+{{ end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/menu.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/menu.html
@@ -59,6 +59,7 @@
       </div>
     {{- define "section-tree-nav" }}
       {{- $currentNode := .currentnode }}
+      {{ $pageVersion := $currentNode.Page.Scratch.Get "pageVersion"  }}
       {{- $showvisitedlinks := .showvisitedlinks }}
       {{- $alwaysopen := .alwaysopen }}
       {{- $currentFileRelPermalink := .currentnode.RelPermalink }}
@@ -92,15 +93,15 @@
             {{- $isOpen := or $currentAlwaysopen $isSelf $isAncestor }}
             {{ if and (ne .Params.menuTitle "3.10") (ne .Params.menuTitle "3.11")}}
               {{ if eq .Layout "label" }}
-              <li data-nav-id="{{.RelPermalink}}" title="{{.Title | markdownify }}" class="dd-item{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}{{if $currentAlwaysopen}} alwaysopen{{end}}"><input type="checkbox" id="section-{{ $pageHash }}" class="toggle menu-label-entry"{{ if $isOpen }} checked{{ end }}/><label for="section-{{ $pageHash }}" class="closed" >
+              <li data-nav-id="{{.RelPermalink}}" title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}{{if $currentAlwaysopen}} alwaysopen{{end}}"><input type="checkbox" id="section-{{ $pageHash }}" class="toggle menu-label-entry"{{ if $isOpen }} checked{{ end }}/><label for="section-{{ $pageHash }}" class="closed" >
               </label>
                 <a>
-                  <div>{{.Title | markdownify }}</div>
+                  <div>{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}</div>
                   </a> 
               {{ else }}
-              <li data-nav-id="{{.RelPermalink}}" title="{{.Title | markdownify }}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}{{if $currentAlwaysopen}} alwaysopen{{end}}"><input type="checkbox" id="section-{{ $pageHash }}" class="toggle"{{ if $isOpen }} checked{{ end }}/><label for="section-{{ $pageHash }}" class="closed">
+              <li data-nav-id="{{.RelPermalink}}" title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}{{if $currentAlwaysopen}} alwaysopen{{end}}"><input type="checkbox" id="section-{{ $pageHash }}" class="toggle"{{ if $isOpen }} checked{{ end }}/><label for="section-{{ $pageHash }}" class="closed">
               </label>
-                <a href="{{.Permalink}}" class="toggle menu-section-entry" onclick="event.preventDefault();menuEntryClick(event)">{{.Title | markdownify }}</a>
+                <a href="{{.Permalink}}" class="toggle menu-section-entry" onclick="event.preventDefault();menuEntryClick(event)">{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}</a>
               {{ end }}
             {{ end }}
 
@@ -113,11 +114,11 @@
               </ul>
             {{- else }}
 
-          <li data-nav-id="{{.RelPermalink}}" test1 title="{{.Title | markdownify }}" class="dd-item{{if $isActive }} active{{end}}"><a href="{{.Permalink}}" onclick="event.preventDefault();menuEntryClick(event)">{{.Title | markdownify }}{{- if $showvisitedlinks }}<i class="fas fa-check read-icon"></i>{{ end }}</a></li>
+          <li data-nav-id="{{.RelPermalink}}" test1 title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item{{if $isActive }} active{{end}}"><a href="{{.Permalink}}" onclick="event.preventDefault();menuEntryClick(event)">{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}{{- if $showvisitedlinks }}<i class="fas fa-check read-icon"></i>{{ end }}</a></li>
             {{- end }}
         {{- else }}
 
-            <li data-nav-id="{{.RelPermalink}}" test2 title="{{.Title | markdownify }}" class="dd-item{{if $isActive }} active{{end}} menu-leaf-entry"><a href="{{.Permalink}}" onclick="event.preventDefault();menuEntryClick(event)">{{.Title | markdownify }}{{- if $showvisitedlinks }}<i class="fas fa-check read-icon"></i>{{ end }}</a></li>
+            <li data-nav-id="{{.RelPermalink}}" test2 title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item{{if $isActive }} active{{end}} menu-leaf-entry"><a href="{{.Permalink}}" onclick="event.preventDefault();menuEntryClick(event)">{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}{{- if $showvisitedlinks }}<i class="fas fa-check read-icon"></i>{{ end }}</a></li>
         {{- end }}
       {{- end }}
     {{- end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/menu.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/menu.html
@@ -59,7 +59,7 @@
       </div>
     {{- define "section-tree-nav" }}
       {{- $currentNode := .currentnode }}
-      {{ $pageVersion := $currentNode.Page.Scratch.Get "pageVersion"  }}
+      {{ $pageVersion := $currentNode.Page.Scratch.Get "version"  }}
       {{- $showvisitedlinks := .showvisitedlinks }}
       {{- $alwaysopen := .alwaysopen }}
       {{- $currentFileRelPermalink := .currentnode.RelPermalink }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
@@ -6,7 +6,7 @@
         {{ $pagePath.Page.Scratch.Add "versionShort" $version.name }}
         {{ $pagePath.Page.Scratch.Add "alias" $version.alias }}
         {{ $pagePath.Page.Scratch.Set "deprecated" $version.deprecated }}
-        {{ template "checkVersionIsInDevelopment" dict "page" $pagePath "pageVersion" $version.name "versions" $versions }}
+        {{ template "checkVersionIsInDevelopment" dict "page" $pagePath "pageVersion" $version.name }}
     {{ end }}
 {{ end }}
 
@@ -15,20 +15,15 @@
 {{ $pageVersion := .pageVersion }}
 {{ $versions := .versions }}
 
-{{ range $i, $version := $versions }}
-    {{ if eq $version.alias "stable" }}
-        {{ $stableVersion := split $version.name "." }}
-        {{ $currentVersion := split $pageVersion "." }}
+    {{ $stableVersion := split site.Params.stableVersion "." }}
+    {{ $currentVersion := split $pageVersion "." }}
 
-        {{ range $j, $elem := $stableVersion }}
-            {{ $intStable := int $elem }}
-            {{ $currentVersionElement := index $currentVersion $j }}
-            {{ $intCurrent := int $currentVersionElement }}
-            {{ if gt $intCurrent $intStable }}
-                {{ $page.Page.Scratch.Set "underDevelopment" true }}
-            {{ end }}
+    {{ range $j, $elem := $stableVersion }}
+        {{ $intStable := int $elem }}
+        {{ $currentVersionElement := index $currentVersion $j }}
+        {{ $intCurrent := int $currentVersionElement }}
+        {{ if gt $intCurrent $intStable }}
+            {{ $page.Page.Scratch.Set "underDevelopment" true }}
         {{ end }}
     {{ end }}
 {{ end }}
-
-{{- end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
@@ -1,0 +1,7 @@
+{{ $pagePath := .page }}
+{{ $versions := index site.Data "versions" }}
+{{ range $i, $version := $versions }}
+    {{ if strings.Contains $pagePath $version.name }}
+        {{ $pagePath.Page.Scratch.Add "pageVersion" $version.name }}
+    {{ end }}
+{{ end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
@@ -2,20 +2,23 @@
 {{ $versions := index site.Data "versions" }}
 {{ range $i, $version := $versions }}
     {{ if strings.Contains $pagePath $version.name }}
-        {{ $pagePath.Page.Scratch.Add "version" $version.version }}
-        {{ $pagePath.Page.Scratch.Add "versionShort" $version.name }}
-        {{ $pagePath.Page.Scratch.Add "alias" $version.alias }}
+        {{ $pagePath.Page.Scratch.Set "version" $version.version }}
+        {{ $pagePath.Page.Scratch.Set "versionShort" $version.name }}
+        {{ $pagePath.Page.Scratch.Set "alias" $version.alias }}
         {{ $pagePath.Page.Scratch.Set "deprecated" $version.deprecated }}
-        {{ template "checkVersionIsInDevelopment" dict "page" $pagePath "pageVersion" $version.name }}
+
+        {{ template "checkVersionIsInDevelopment" dict "page" $pagePath "pageVersion" $version.name "versions" $versions }}
     {{ end }}
 {{ end }}
 
 {{- define "checkVersionIsInDevelopment" }}
 {{ $page := .page }}
 {{ $pageVersion := .pageVersion }}
-{{ $versions := .versions }}
+{{ $versions := index (where .versions "alias" "stable") 0 }}
+{{ $page.Page.Scratch.Set "stableVersion" $versions.name }}
 
-    {{ $stableVersion := split site.Params.stableVersion "." }}
+
+    {{ $stableVersion := split $versions.name "." }}
     {{ $currentVersion := split $pageVersion "." }}
 
     {{ range $j, $elem := $stableVersion }}
@@ -24,6 +27,7 @@
         {{ $intCurrent := int $currentVersionElement }}
         {{ if gt $intCurrent $intStable }}
             {{ $page.Page.Scratch.Set "underDevelopment" true }}
+
         {{ end }}
     {{ end }}
 {{ end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
@@ -2,7 +2,33 @@
 {{ $versions := index site.Data "versions" }}
 {{ range $i, $version := $versions }}
     {{ if strings.Contains $pagePath $version.name }}
-        {{ $pagePath.Page.Scratch.Add "pageVersion" $version.version }}
-        {{ $pagePath.Page.Scratch.Add "pageVersionShort" $version.name }}
+        {{ $pagePath.Page.Scratch.Add "version" $version.version }}
+        {{ $pagePath.Page.Scratch.Add "versionShort" $version.name }}
+        {{ $pagePath.Page.Scratch.Add "alias" $version.alias }}
+        {{ $pagePath.Page.Scratch.Set "deprecated" $version.deprecated }}
+        {{ template "checkVersionIsInDevelopment" dict "page" $pagePath "pageVersion" $version.name "versions" $versions }}
     {{ end }}
 {{ end }}
+
+{{- define "checkVersionIsInDevelopment" }}
+{{ $page := .page }}
+{{ $pageVersion := .pageVersion }}
+{{ $versions := .versions }}
+
+{{ range $i, $version := $versions }}
+    {{ if eq $version.alias "stable" }}
+        {{ $stableVersion := split $version.name "." }}
+        {{ $currentVersion := split $pageVersion "." }}
+
+        {{ range $j, $elem := $stableVersion }}
+            {{ $intStable := int $elem }}
+            {{ $currentVersionElement := index $currentVersion $j }}
+            {{ $intCurrent := int $currentVersionElement }}
+            {{ if gt $intCurrent $intStable }}
+                {{ $page.Page.Scratch.Set "underDevelopment" true }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{- end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
@@ -2,6 +2,6 @@
 {{ $versions := index site.Data "versions" }}
 {{ range $i, $version := $versions }}
     {{ if strings.Contains $pagePath $version.name }}
-        {{ $pagePath.Page.Scratch.Add "pageVersion" $version.name }}
+        {{ $pagePath.Page.Scratch.Add "pageVersion" $version.version }}
     {{ end }}
 {{ end }}

--- a/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
+++ b/site/themes/hugo-theme-relearn/layouts/partials/shortcodes/version.html
@@ -3,5 +3,6 @@
 {{ range $i, $version := $versions }}
     {{ if strings.Contains $pagePath $version.name }}
         {{ $pagePath.Page.Scratch.Add "pageVersion" $version.version }}
+        {{ $pagePath.Page.Scratch.Add "pageVersionShort" $version.name }}
     {{ end }}
 {{ end }}

--- a/site/themes/hugo-theme-relearn/layouts/shortcodes/error-codes.html
+++ b/site/themes/hugo-theme-relearn/layouts/shortcodes/error-codes.html
@@ -1,4 +1,8 @@
-{{ $data := index site.Data "errors" }}
+{{ $pageVersion := .Page.Scratch.Get "versionShort" }}
+
+{{ $dataFolderByVersion := index site.Data $pageVersion }}
+{{ $data := index $dataFolderByVersion "errors"}}
+
 {{ $basePage := .Page.RelPermalink }}
 {{ range $data }}
     {{ if index . "group" }}

--- a/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
+++ b/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
@@ -5,7 +5,18 @@
 {{ range $metric := $allMetricsFile }}
 #### {{ $metric.help }}
 
+{{ if eq $metric.type "histogram" -}}
+`{{ $metric.name }}` (basename)<br>
+`{{ $metric.name }}_bucket`<br>
+`{{ $metric.name }}_sum`<br>
+`{{ $metric.name }}_count`
+{{ else if eq $metric.type "summary" -}}
+`{{ $metric.name }}` (basename)<br>
+`{{ $metric.name }}_sum`<br>
+`{{ $metric.name }}_count`
+{{ else -}}
 `{{ $metric.name }}`
+{{ end }}
 
 {{ $metric.description }}
 

--- a/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
+++ b/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
@@ -1,0 +1,43 @@
+{{ $pageVersion := .Page.Scratch.Get "pageVersionShort" }}
+
+{{ $dataFolderByVersion := index site.Data $pageVersion }}
+{{ $allMetricsFile := index $dataFolderByVersion "allMetrics"}}
+{{ range $metric := $allMetricsFile }}
+#### {{ $metric.help }}
+
+`{{ $metric.name }}`
+
+{{ $metric.description }}
+
+{{ with $metric.introducedIn }}
+<small>
+    Introduced in: v{{ . }}
+</small>
+{{ end }}
+
+{{ with $metric.renamedFrom }}
+<small>
+    Renamed from: `{{ . }}`
+</small>
+{{ end }}
+
+{{ $exposedBy := delimit $metric.exposedBy ", " | upper }}
+
+| Type | Unit | Complexity | Exposed by |
+|:-----|:-----|:-----------|:-----------|
+| {{ $metric.type }} | {{ $metric.unit }} | {{ $metric.complexity }} | {{ $exposedBy}} |
+
+
+{{ with $metric.threshold -}}
+**Threshold:**
+{{ . }}
+{{ end -}}
+
+{{ with $metric.troubleshoot -}}
+**Troubleshoot:**
+{{ . }}
+{{ end -}}
+
+---
+
+{{ end -}}                                                                                                                

--- a/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
+++ b/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
@@ -39,15 +39,15 @@
 | {{ $metric.type }} | {{ $metric.unit }} | {{ $metric.complexity }} | {{ $exposedBy}} |
 
 
-{{ with $metric.threshold -}}
+{{ with $metric.threshold }}
 **Threshold:**
 {{ . }}
-{{ end -}}
+{{ end }}
 
-{{ with $metric.troubleshoot -}}
+{{ with $metric.troubleshoot }}
 **Troubleshoot:**
 {{ . }}
-{{ end -}}
+{{ end }}
 
 ---
 

--- a/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
+++ b/site/themes/hugo-theme-relearn/layouts/shortcodes/metrics.html
@@ -1,4 +1,4 @@
-{{ $pageVersion := .Page.Scratch.Get "pageVersionShort" }}
+{{ $pageVersion := .Page.Scratch.Get "versionShort" }}
 
 {{ $dataFolderByVersion := index site.Data $pageVersion }}
 {{ $allMetricsFile := index $dataFolderByVersion "allMetrics"}}

--- a/site/themes/hugo-theme-relearn/layouts/shortcodes/version.html
+++ b/site/themes/hugo-theme-relearn/layouts/shortcodes/version.html
@@ -1,7 +1,0 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
-
-{{ $version := .Get 0 }}
-{{ $version = replace $version "." "" }}
-<div class="version {{ $version }}" style="display: none;">
-    {{ .Inner | safeHTML }}
-</div>

--- a/site/themes/hugo-theme-relearn/static/css/theme.css
+++ b/site/themes/hugo-theme-relearn/static/css/theme.css
@@ -1054,3 +1054,7 @@ blockquote p {
 .hidden {
     display: none;
 }
+
+small {
+    font-size: 80%;
+}


### PR DESCRIPTION
**NOTE: This PR includes the DOC-448 task about metrics rendering as they are interdependent.**

A version partial has been created to assign a "pageVersion" variable to each page during build time.

The "pageVersion" variable of a page is available at {{ .Page.Scratch.Get "pageVersion" }} at any time.

The version is set by matching the page path (e.g. /3.10/...../page) against the site/data/versions.yaml file, if one of the entries has name: {pagePathFirstFolder -> e.g. 3.10), the version: value of that entry is assigned to the page.

Page can have {{ pageVersion }} variable in the title front matter that is expanded using the pageVersion variable of the page.

