### PR TITLE
[DOC-429] Convert openapi headers in summary field

### DIFF
--- a/toolchain/scripts/generators/generateApiDocs.py
+++ b/toolchain/scripts/generators/generateApiDocs.py
@@ -51,7 +51,6 @@ def generateAPIDocs():
             continue
 
         for file in files:
-            print(file)
             processFile(f"{root}/{file}".replace("\\", "/"))
 
     print("END")
@@ -88,12 +87,16 @@ def processFile(filepath):
         if not path in apiDocsRes["paths"]:
             apiDocsRes["paths"][path] = {}
 
-        summary = re.search(r"^#.*", endpoint, re.MULTILINE)
+        summary = re.search(r"^#{1,6} (.+)", endpoint, re.MULTILINE)
         if "summary" in endpointDict["paths"][path][method]:
             print(f"WARNING: Summary field already in spec {path}-{method}")
 
         if summary:
-            endpointDict["paths"][path][method]["summary"] = summary.group(0).replace("#", "").replace(" ", "", 1)
+            endpointDict["paths"][path][method]["summary"] = summary.group(1)
+        
+        if not "summary" in endpointDict["paths"][path][method] and not summary:
+            print(f"WARNING: Missing both summary field and headline in spec {path}-{method}")
+
         
         apiDocsRes["paths"][path][method] = endpointDict["paths"][path][method]
 

--- a/toolchain/scripts/generators/generateApiDocs.py
+++ b/toolchain/scripts/generators/generateApiDocs.py
@@ -89,13 +89,13 @@ def processFile(filepath):
 
         summary = re.search(r"^#{1,6} (.+)", endpoint, re.MULTILINE)
         if "summary" in endpointDict["paths"][path][method]:
-            print(f"WARNING: Summary field already in spec {path}-{method}")
+            print(f"WARNING: Summary field already in spec {method}-{path}")
 
         if summary:
             endpointDict["paths"][path][method]["summary"] = summary.group(1)
         
         if not "summary" in endpointDict["paths"][path][method] and not summary:
-            print(f"WARNING: Missing both summary field and headline in spec {path}-{method}")
+            print(f"WARNING: Missing both summary field and headline in spec {method}-{path}")
 
         
         apiDocsRes["paths"][path][method] = endpointDict["paths"][path][method]

--- a/toolchain/scripts/generators/generateApiDocs.py
+++ b/toolchain/scripts/generators/generateApiDocs.py
@@ -87,6 +87,14 @@ def processFile(filepath):
         method = next(iter(endpointDict["paths"][path]))
         if not path in apiDocsRes["paths"]:
             apiDocsRes["paths"][path] = {}
+
+        summary = re.search(r"^#.*", endpoint, re.MULTILINE)
+        if "summary" in endpointDict["paths"][path][method]:
+            print(f"WARNING: Summary field already in spec {path}-{method}")
+
+        if summary:
+            endpointDict["paths"][path][method]["summary"] = summary.group(0).replace("#", "").replace(" ", "", 1)
+        
         apiDocsRes["paths"][path][method] = endpointDict["paths"][path][method]
 
     processDescriptions(apiDocsRes, "")


### PR DESCRIPTION
The generateApiDocs script has to move the # headers in the openapi codeblocks as summary fields.