### PR TITLE
Hide version index page

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
@@ -6,7 +6,7 @@
         {{ if not .IsHome }}
         <li itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
           <meta itemprop="position" content="{{ .Params.menuTitle }}" />
-          <a itemprop="item" class="link-internal" href="{{ .RelPermalink }}">
+          <a itemprop="item" class="link-internal" href="    {{- if ne (len .Page.Ancestors) 1 }} {{ .RelPermalink }} {{ else }} {{ .RelPermalink }}introduction/ {{ end }}">
             <span itemprop="name" class="breadcrumb-entry">{{ .Params.menuTitle | markdownify }} > </span>
           </a>
         </li>

--- a/site/themes/arangodb-docs-theme/layouts/partials/content-footer.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/content-footer.html
@@ -61,10 +61,14 @@
 
 <span class="prev">
   {{ with $prev }}
-          
-          <a class="nav nav-prev link-internal" href="{{.RelPermalink}}" title="{{.Params.menuTitle}}">
-            <i class="fas fa-chevron-left fa-fw"></i><p>{{.Params.menuTitle | markdownify}}</p></a>
-          {{- end}}
+    {{- if eq (len .Ancestors) 1 }}
+      <a class="nav nav-prev link-internal" href="" title="">
+      </a>
+    {{ else }}
+        <a class="nav nav-prev link-internal" href="{{.RelPermalink}}" title="{{.Params.menuTitle}}">
+          <i class="fas fa-chevron-left fa-fw"></i><p>{{.Params.menuTitle | markdownify}}</p></a>
+        {{- end}}
+  {{ end }}
   
 </span>
 

--- a/site/themes/arangodb-docs-theme/layouts/partials/meta.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/meta.html
@@ -17,3 +17,8 @@
     {{- with .Site.Params.author }}
     <meta name="author" content="{{ . }}">
     {{- end }}
+    {{- if eq (len .Page.Ancestors) 1 }}
+        <script>
+            window.location.href = "{{ .Permalink }}/introduction"
+        </script>
+    {{ end }}


### PR DESCRIPTION
### Description

Any pointer to {version}/_index.md page is now redirected to {version}/introduction.
Affected items are url entry, breadcrumb link and footer navigation

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
