### PR TITLE
Fix moveTags() and migration of tags

### DIFF
--- a/migration-tools/scripts/automata.py
+++ b/migration-tools/scripts/automata.py
@@ -449,11 +449,7 @@ def processFile(page, content, filepath):
                 if '-arangograph.md' in line:
                     tags.append("ArangoGraph")
 
-                tagShortcode = '{{< tag '
-                for t in tags:
-                    tagShortcode = tagShortcode + f'"{t}"'
-
-                tagShortcode = tagShortcode + ' >}}' 
+                tagShortcode = "{{< tag " + " ".join(map(lambda t: t.join('""'), tags)) + " >}}\n"
                 originalSpaces = len(line) - len(line.lstrip())  
                 page.content = page.content + " "*originalSpaces + tagShortcode
                 continue

--- a/site/content/3.10/aql/functions/arangosearch.md
+++ b/site/content/3.10/aql/functions/arangosearch.md
@@ -1283,7 +1283,8 @@ FOR doc IN viewName
 
 ## Search Highlighting Functions
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ### OFFSET_INFO()
 
 `OFFSET_INFO(doc, paths) → offsetInfo`

--- a/site/content/3.10/aql/graphs/traversals.md
+++ b/site/content/3.10/aql/graphs/traversals.md
@@ -136,9 +136,11 @@ FOR vertex[, edge[, path]]
     case when a nested traversal is fed with several tens of thousands of start
     vertices, which can then be distributed randomly to worker threads for parallel
     execution.
-    {{< tag "ArangoDB Enterprise""ArangoGraph" >}}  - **maxProjections** (number, *optional*): Specifies the number of document
+    {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+  - **maxProjections** (number, *optional*): Specifies the number of document
     attributes per FOR loop to be used as projections. The default value is `5`.
-    {{< tag "ArangoDB Enterprise""ArangoGraph" >}}  - **weightAttribute** (string, *optional*): Specifies the name of an attribute
+    {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+  - **weightAttribute** (string, *optional*): Specifies the name of an attribute
     that is used to look up the weight of an edge. If no attribute is specified
     or if it is not present in the edge document then the `defaultWeight` is used.
     The attribute value must not be negative.

--- a/site/content/3.10/aql/how-to-invoke-aql/with-arangosh.md
+++ b/site/content/3.10/aql/how-to-invoke-aql/with-arangosh.md
@@ -429,7 +429,8 @@ deployment, then the Coordinator is allowed to read from any shard replica and
 not only from the leader. See [Read from followers](../../develop/http/documents.md#read-from-followers)
 for details.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 #### `skipInaccessibleCollections`
 
 Let AQL queries (especially graph traversals) treat collection to which a
@@ -439,14 +440,16 @@ This is intended to help with certain use-cases: A graph contains several collec
 and different users execute AQL queries on that graph. You can naturally limit the 
 accessible results by changing the access rights of users on collections.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 #### `satelliteSyncWait`
 
 Configure how long a DB-Server has time to bring the SatelliteCollections
 involved in the query into sync. The default value is `60.0` seconds.
 When the maximal time is reached, the query is stopped.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## With `db._createStatement()` (ArangoStatement)
 
 The `_query()` method is a shorthand for creating an `ArangoStatement` object,

--- a/site/content/3.10/arangograph/backups.md
+++ b/site/content/3.10/arangograph/backups.md
@@ -16,7 +16,7 @@ To backup data in ArangoGraph for an ArangoDB installation, navigate to the
 There are two ways to create backups. Create periodic backups using a
 **Backup policy**, or create a backup manually.
 Both ways allow you to create [backups in multiple regions](#multi-region-backups)
-as well, if your organization belongs to the Enterprise tier.
+as well.
 
 ### Periodic backups
 
@@ -35,8 +35,7 @@ These backups are not automatically uploaded. To enable this, use the
 **Upload backup to storage** option and choose a retention period that
 specifies how long backups are retained after creation. 
 
-If your organization belongs to the Enterprise tier and the
-**Upload backup to storage** option is enabled for a backup policy,
+If the **Upload backup to storage** option is enabled for a backup policy,
 you can then create backups in different regions than the default one.
 The regions where the default backup is copied are shown in the
 **Additional regions** column in the **Policies** section.
@@ -49,8 +48,7 @@ It's also possible to create a backup on demand. To do this, click **Back up now
 
 ![Back up Now Dialog](../../images/arangograph-back-up-now-dialog.png)
 
-If your organization belongs to the Enterprise tier and you want to manually
-copy a backup to a different region than the default
+If you want to manually copy a backup to a different region than the default
 one, first ensure that the **Upload backup to storage** option is enabled.
 Then, highlight the backup row and use the
 **Copy backup to a different region** button from the **Actions** column. 
@@ -104,13 +102,6 @@ alternatives such as having hourly backups with a retention period of a year.
 
 ## Multi-region backups
 
-{{< info >}}
-The multi-region backup feature is only available for the ArangoGraph
-Enterprise tier. To upgrade to the Enterprise tier,
-[get in touch](https://www.arangodb.com/contact/)
-with the ArangoDB team.
-{{< /info >}}
-
 Using the multi-region backup feature, you can store backups in multiple regions
 simultaneously either manually or automatically as part of a **Backup policy**.
 If a backup created in one region goes down, it is still available in other
@@ -146,8 +137,7 @@ During restore, the deployment is temporarily not available.
 {{< info >}}
 The cloned deployment will have the exact same features as the previous
 deployment including node size, model, and cloud provider. The region
-can stay the same or you can select a different one if your organization belongs
-to the Enterprise tier.
+can stay the same or you can select a different one.
 For restoring a deployment as quick as possible, it is recommended to create a
 deployment in the same region as where the backup resides to avoid cross-region
 data transfer.

--- a/site/content/3.10/arangograph/deployments/_index.md
+++ b/site/content/3.10/arangograph/deployments/_index.md
@@ -31,12 +31,6 @@ its projects and deployments.
 4. Click the __New deployment__ button.
 5. Set up your deployment. The configuration options are described below.
 
-   {{< info >}}
-   The configuration options depend on the tier your organization belongs to.
-   For more details about available resources and usage limits, refer to the 
-   [ArangoGraph tiers](../organizations/_index.md#arangograph-tiers) section.
-   {{< /info >}}
-
 ![ArangoGraph New Deployment](../../../images/arangograph-new-deployment1.png)
 
 {{< info >}}
@@ -95,13 +89,8 @@ provider and region in the Location section.
 
 #### OneShard
 
-1. Select the memory size of your node.
-2. Select the CPU size of your node.
-3. Select the initial disk size of your node. The available ranges for the disk size
-   depend on the selected memory size.
-4. Select the upper limit for the disk size. It defaults to twice the initial
-   disk size. You can set it to the same value as the initial disk size to
-   disable automatic disk sizing.
+- Select the memory size of your node. The disk size is automatically set for you
+  based on the selected memory size.
 
 {{< info >}}
 A deployment's node disk size is automatically increased by 25% when the maximal
@@ -115,16 +104,17 @@ the upper disk size limit already.
 
 #### Sharded
 
-- In addition to memory and disk size as in the OneShard configuration, select
+- In addition to the memory size as in the OneShard configuration, select
   the number of nodes for your deployment. The more nodes you have, the higher
-  the replication factor can be.
+  the replication factor can be. Same as in OneShard, the disk size is automatically
+  set for you.
 
 ![ArangoGraph Deployment Sharded](../../../images/arangograph-new-deployment-sharded.png)
 
 #### Single Server
 
-- Like with OneShard and Sharded deployments, you choose memory and disk size.
-  However note that the sizes you choose are for the entire deployment.
+- Like with OneShard and Sharded deployments, you can choose the memory size.
+  Note, however, that the size you choose is for the entire deployment.
   For OneShard and Sharded deployments the chosen sizes are per node.
 
 ![ArangoGraph Deployment Single Server](../../../images/arangograph-new-deployment-singleserver.png)
@@ -251,7 +241,7 @@ are using the `18529` port to avoid breaking changes.
 ## How to edit a deployment
 
 You can modify a deployment’s configuration, including the ArangoDB version
-that is being used, change the memory, CPU, and disk size, or even switch from
+that is being used, change the memory size, or even switch from
 a OneShard deployment to a Sharded one if your data set no longer fits in a
 single node. 
 
@@ -259,12 +249,6 @@ single node.
 To edit an existing deployment, you must have the necessary set of permissions
 attached to your role. Read more about [roles and permissions](../security-and-access-control/_index.md#roles).
 {{< /tip >}}
-
-{{< info >}}
-The configuration options depend on the tier your organization belongs to.
-For more details about available resources and usage limits, refer to the 
-[ArangoGraph tiers](../organizations/_index.md#arangograph-tiers) section.
-{{< /info >}}
 
 1. Go to the **Projects** section and select an existing deployment from the list. 
 2. Open the deployment you want to change. 
@@ -275,12 +259,7 @@ For more details about available resources and usage limits, refer to the
    - Select a different CA certificate.
    - Add or remove an IP allowlist.
 5. In the **Configuration** section, you can do the following:
-   - Upgrade the memory size per node. 
-   - Modify the CPU per node from General to Low or vice-versa, if made available
-     by the cloud provider.
-   - Select a different disk size per node. The available ranges for the disk size
-     depend on the selected memory size. To enable automatic disk size scaling, move
-     the slider to a value higher than the current disk size.
+   - Upgrade the memory size per node. The disk size is automatically set for you.
    - Change **OneShard** deployments into **Sharded** deployments. To do so,
      click **Sharded**. In addition to the other configuration options, you can
      select the number of nodes for your deployment. This can also be modified later on.
@@ -288,15 +267,10 @@ For more details about available resources and usage limits, refer to the
    {{< warning >}}
    Notice that you cannot switch from **Sharded** back to **OneShard**.
    {{< /warning >}}
-   
-   - AWS deployments have an additional option that allows you to select the
-     **Disk Performance** either with general settings, or optimized for large
-     and very large data sets. This option is dependent on the selected memory
-     size. For example, larger deployments have optimized settings by default.
 
    {{< warning >}}
-   When upgrading the memory size, disk size, and/or disk performance in AWS deployments,
-   the value gets locked and cannot be changed until the cloud provider rate limit is reset.  
+   When upgrading the memory size in AWS deployments, the value gets locked and
+   cannot be changed until the cloud provider rate limit is reset. 
    {{< /warning >}}
 
 6. All changes are reflected in the **Summary** section. Review the new

--- a/site/content/3.10/arangograph/deployments/private-endpoints.md
+++ b/site/content/3.10/arangograph/deployments/private-endpoints.md
@@ -12,11 +12,6 @@ securely deploy to various cloud providers such as Google Cloud Platform (GCP),
 Microsoft Azure, and Amazon Web Services (AWS). Follow the steps outlined below
 to get started.
 
-{{< info >}}
-The private endpoint feature is only available on the
-[Enterprise tier](../organizations/_index.md#arangograph-tiers) of ArangoGraph.
-{{< /info >}}
-
 {{< tip >}}
 Private endpoints on Microsoft Azure can be cross region; in AWS they should be
 located in the same region.
@@ -53,9 +48,7 @@ service attachment that you need during the creation of your private endpoint(s)
 
 1. Open the deployment you want to change.
 2. On the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier. 
+   icon. 
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment Private Endpoint Menu](../../../images/arangograph-gcp-change.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.
@@ -99,9 +92,7 @@ please contact support via **Request help** in the help menu.
 
 1. Open the deployment you want to change.
 2. On the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier.
+   icon.
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment Private Endpoint Menu](../../../images/arangograph-deployment-private-endpoint-menu.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.
@@ -156,9 +147,7 @@ that automatically connects to private endpoints that are created in those princ
 
 1. Open the deployment you want to change.
 2. In the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier.
+   icon.
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment AWS Change to Private Endpoint](../../../images/arangograph-aws-change-to-private-endpoint.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.

--- a/site/content/3.10/arangograph/deployments/upgrades-and-versioning.md
+++ b/site/content/3.10/arangograph/deployments/upgrades-and-versioning.md
@@ -115,6 +115,5 @@ ArangoGraph aims to give approximately one week’s notice prior to upgrading yo
 deployments to the latest patch release. Although in exceptional circumstances
 (such as a critical security issue) the upgrade may be triggered with less than
 one week's notice.
-The upgrade is carried out automatically. However, if your organization belongs 
-to the Enterprise tier, you contact the ArangoGraph Support team to request that
-this upgrade is manually deferred temporarily.
+The upgrade is carried out automatically. However, if you need the upgrade to be
+deferred temporarily, contact the ArangoGraph Support team to request that.

--- a/site/content/3.10/arangograph/notebooks.md
+++ b/site/content/3.10/arangograph/notebooks.md
@@ -58,8 +58,8 @@ favorite GraphML libraries with GPUs.
 
 {{< info >}}
 Depending on the tier your organization belongs to, different limitations apply:
-- Professional and Enterprise tiers: you can create up to three notebooks per deployment.
-- Free-to-try tier: you can only create one notebook per deployment.  
+- On-Demand and Committed: you can create up to three notebooks per deployment.
+- Free-to-try: you can only create one notebook per deployment.
 {{< /info >}}
 
 ![Notebooks](../../images/arangograph-notebooks.png)

--- a/site/content/3.10/arangograph/organizations/_index.md
+++ b/site/content/3.10/arangograph/organizations/_index.md
@@ -30,50 +30,57 @@ member of one _Free-to-try_ tier organization at a time.
 
 ![ArangoGraph Organization Overview](../../../images/arangograph-organization-overview.png)
 
-## ArangoGraph tiers
+## ArangoGraph Packages
 
-With the ArangoGraph Insights Platform, your organization can belong to one of the following three tiers:
+With the ArangoGraph Insights Platform, your organization can choose one of the
+following packages.
 
-- **Free-to-try tier**: ArangoGraph comes with a free-to-try tier that lets
-you test ArangoGraph for free for 14 days. After the trial period,
-your deployments will be deleted automatically. Includes the Basic Support plan,
-which covers the availability and connectivity of the ArangoGraph Insights Platform, and general questions.
-- **Professional tier**: Allows you to create additional organizations and
-projects, and have more and larger deployments. Includes the Standard support for
-professional deployments, which covers everything from the Basic support plan
-with explicit response times.
-- **Enterprise tier**: Get unlimited access to all functionalities and resources,
-with the best available support and response times. Includes the Premium Standard
-support plan.
+### Free Trial
 
-| &nbsp;| Free-to-try  | Professional  | Enterprise  |
-|-------|:--------------:|:---------------:|:-------------:|
-| **Organizations per user** | 1 | Unlimited | Unlimited |
-| **Projects per organization** | 1 | 3 | Unlimited |
-| **Deployments per project** | 1 | 5 | Unlimited |
-| **Upload backup** | Not included | Included | Included |
-| **Private endpoint deployment** | Not included | Not included | Included |
-| **Support plan** | Basic | Standard | Premium Standard |
+ArangoGraph comes with a free-to-try tier that lets you test ArangoGraph for
+free for 14 days. You can get started quickly, without needing to enter a
+credit card.
 
-{{< info >}}
-Based on the type of tier your organization belongs to, different usage
-limits apply for memory and storage.
-{{< /info >}}
+The free trial gives you access to:
+- One small deployment (4GB) in a region of your choice for 14 days
+- Local backups
+- One ArangoGraph Notebook for learning and data science
 
-## How to upgrade to Professional tier
+After the trial period, your deployment will be deleted automatically.
 
-You can upgrade to the professional service model at any time by adding
-your billing details and at least one payment method. You can then create
-additional organizations and projects and have more and larger deployments.
+### On-Demand
+
+Add a payment payment method to gain access to ArangoGraph's full feature set.
+Pay monthly via a credit card for what you actually use.
+
+This package unlocks all ArangoGraph functionality, including:
+- Multiple and larger deployments
+- Backups to cloud storage, with multi-region support
+- Enhanced security features such as Private Endpoints
+
+### Committed
+
+Commit up-front for a year and pay via the Sales team. This package provides
+the same flexibility of On-Demand, but at a lower price. 
+
+In addition, you gain access to:
+- 24/7 Premium Support
+- ArangoDB Professional Services Engagements
+- Ability to transact via the AWS and GCP marketplaces
+
+To take advantage of this, you need to get in touch with the ArangoDB
+team. [Contact us](https://www.arangodb.com/contact/) for more details.
+
+## How to unlock all features
+
+You can unlock all features in ArangoGraph at any time by adding your billing
+details and a payment method. As soon as you have added a payment method, all
+ArangoGraph functionalities are immediately unlocked. From that point on, your
+deployments will no longer expire and you can create more and larger deployments.
 
 See [Billing: How to add billing details / payment methods](billing.md)
 
 ![ArangoGraph Billing](../../../images/arangograph-billing.png)
-
-## How to upgrade to Enterprise tier
-
-To upgrade to the Enterprise tier, you need to get in touch with the ArangoDB
-team. [Contact us](https://www.arangodb.com/contact/) for more details.
 
 ## How to create a new organization
 

--- a/site/content/3.10/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.10/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -6,10 +6,6 @@ description: >-
   Single Sign-On (SSO) using SAML 2.0
 archetype: chapter
 ---
-{{< info >}}
-This feature is only available in ArangoGraph Enterprise.
-{{< /info >}}
-
 ArangoGraph provides support to enable **Single Sign-On** (SSO) authentication
 using **Security Assertion Markup language 2.0** (SAML 2.0).
 

--- a/site/content/3.10/arangograph/security-and-access-control/single-sign-on/scim-provisioning.md
+++ b/site/content/3.10/arangograph/security-and-access-control/single-sign-on/scim-provisioning.md
@@ -6,10 +6,6 @@ description: >-
   How to enable SCIM provisioning
 archetype: default
 ---
-{{< info >}}
-This feature is only available in ArangoGraph Enterprise.
-{{< /info >}}
-
 ArangoGraph provides support to control and manage members access in
 ArangoGraph organizations with the
 **System for Cross-domain Identity Management** (SCIM) provisioning. 

--- a/site/content/3.10/components/arangodb-server/ldap.md
+++ b/site/content/3.10/components/arangodb-server/ldap.md
@@ -6,7 +6,8 @@ description: >-
   LDAP authentication options in the ArangoDB server
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## Basics Concepts
 
 The basic idea is that one can keep the user authentication setup for

--- a/site/content/3.10/components/tools/arangobackup/_index.md
+++ b/site/content/3.10/components/tools/arangobackup/_index.md
@@ -13,6 +13,7 @@ Use [_arangodump_](../arangodump/_index.md) and
 [logical backups](../../../operations/backup-and-restore.md#logical-backups) in the Community Edition.
 {{< /info >}}
 {{< tag "ArangoDB Enterprise" >}}
+
 _Arangobackup_ is a command-line client tool for instantaneous and
 consistent [hot backups](../../../operations/backup-and-restore.md#hot-backups) of the data and
 structures stored in ArangoDB.

--- a/site/content/3.10/components/tools/arangodump/examples.md
+++ b/site/content/3.10/components/tools/arangodump/examples.md
@@ -158,7 +158,8 @@ INFO [66c0e] {dump} Processed 2 collection(s) from 1 database(s) in 0.132990 s t
 
 ## Encryption
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 You can encrypt dumps using an encryption keyfile, which must contain exactly 32
 bytes of data (required by the AES block cipher).
 

--- a/site/content/3.10/components/tools/arangodump/maskings.md
+++ b/site/content/3.10/components/tools/arangodump/maskings.md
@@ -469,7 +469,8 @@ processed by a single masking function, ignoring any other rules below it.
 
 ## Masking Functions
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - [Xify Front](#xify-front)
 - [Zip](#zip)
 - [Datetime](#datetime)

--- a/site/content/3.10/data-science/pregel/_index.md
+++ b/site/content/3.10/data-science/pregel/_index.md
@@ -41,7 +41,8 @@ In cluster mode, the collections need to be sharded in a specific way to ensure
 correct results: The outgoing edges of a vertex need to be on the same DB-Server
 as the vertex. This is guaranteed by [SmartGraphs](../../graphs/smartgraphs/_index.md).
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Note that the performance may be better, if the number of your shards /
 collections matches the number of CPU cores.
 

--- a/site/content/3.10/deploy/arangosync/_index.md
+++ b/site/content/3.10/deploy/arangosync/_index.md
@@ -9,6 +9,7 @@ archetype: chapter
 {{< description >}}
 
 {{< tag "ArangoDB Enterprise" >}}
+
 This chapter introduces ArangoDB's _Datacenter-to-Datacenter Replication_ (DC2DC).
 
 At some point in the grows of a database, there comes a need for replicating it

--- a/site/content/3.10/deploy/arangosync/administration.md
+++ b/site/content/3.10/deploy/arangosync/administration.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the synchronization process
 of the _Datacenter-to-Datacenter Replication_.
 

--- a/site/content/3.10/deploy/arangosync/deployment/_index.md
+++ b/site/content/3.10/deploy/arangosync/deployment/_index.md
@@ -7,6 +7,7 @@ description: >-
 archetype: chapter
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This chapter describes how to deploy all the components needed for
 _Datacenter-to-Datacenter Replication (DC2DC)_.
 

--- a/site/content/3.10/deploy/arangosync/monitoring.md
+++ b/site/content/3.10/deploy/arangosync/monitoring.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the monitoring of the
 _Datacenter-to-Datacenter Replication_.
 

--- a/site/content/3.10/deploy/arangosync/operations-and-maintenance.md
+++ b/site/content/3.10/deploy/arangosync/operations-and-maintenance.md
@@ -9,6 +9,7 @@ archetype: default
 ## Operations & Maintenance
 
 {{< tag "ArangoDB Enterprise" >}}
+
 ArangoSync is a distributed system with a lot different components.
 As with any such system, it requires some, but not a lot of operational
 support.

--- a/site/content/3.10/deploy/arangosync/security.md
+++ b/site/content/3.10/deploy/arangosync/security.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the _Datacenter-to-Datacenter Replication_
 security.
 

--- a/site/content/3.10/deploy/arangosync/troubleshooting.md
+++ b/site/content/3.10/deploy/arangosync/troubleshooting.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 The _Datacenter-to-Datacenter Replication_ is a distributed system with a lot
 different components. As with any such system, it requires some, but not a lot,
 of operational support.

--- a/site/content/3.10/deploy/deployment/kubernetes/deployment-replication-resource-reference.md
+++ b/site/content/3.10/deploy/deployment/kubernetes/deployment-replication-resource-reference.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 The ArangoDB Replication Operator creates and maintains ArangoDB
 `arangosync` configurations in a Kubernetes cluster, given a replication specification.
 This replication specification is a `CustomResource` following

--- a/site/content/3.10/deploy/deployment/oneshard.md
+++ b/site/content/3.10/deploy/deployment/oneshard.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 The OneShard option for ArangoDB clusters restricts all collections of a
 database to a single shard and places them on one DB-Server node. This way,
 whole queries can be pushed to and executed on that server, massively reducing

--- a/site/content/3.10/develop/http/authentication.md
+++ b/site/content/3.10/develop/http/authentication.md
@@ -277,6 +277,7 @@ curl -v -H "Authorization: bearer $(jwtgen -s <my-secret> -e 3600 -a "HS256" -c 
 <small>Introduced in: v3.7.0</small>
 
 {{< tag "ArangoDB Enterprise" >}}
+
 To reload the JWT secrets of a local arangod process without a restart, you
 may use the following RESTful API. A `POST` request reloads the secret, a
 `GET` request may be used to load information about the currently used secrets.

--- a/site/content/3.10/develop/http/documents.md
+++ b/site/content/3.10/develop/http/documents.md
@@ -2523,7 +2523,8 @@ name: RestDocumentHandlerDeleteDocumentRevConflictMulti
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 In an ArangoDB cluster, all reads and writes are performed via
 the shard leaders. Shard replicas replicate all operations, but are
 only on hot standby to take over in case of a failure. This is to ensure

--- a/site/content/3.10/develop/http/hot-backups.md
+++ b/site/content/3.10/develop/http/hot-backups.md
@@ -10,6 +10,7 @@ archetype: default
 {{< description >}}
 
 {{< tag "ArangoDB Enterprise" >}}
+
 Hot Backups are near instantaneous consistent snapshots of an
 **entire** ArangoDB deployment. This includes all databases, collections,
 indexes, Views, graphs, and users at any given time.

--- a/site/content/3.10/develop/satellitecollections.md
+++ b/site/content/3.10/develop/satellitecollections.md
@@ -6,7 +6,8 @@ description: >-
   Collections synchronously replicated to all servers, available in the Enterprise Edition
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 When doing joins in an ArangoDB cluster data has to be exchanged between different servers.
 
 Joins are executed on a Coordinator. It prepares an execution plan

--- a/site/content/3.10/develop/smartjoins.md
+++ b/site/content/3.10/develop/smartjoins.md
@@ -6,7 +6,8 @@ description: >-
   SmartJoins allow to execute co-located join operations among identically sharded collections.
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 SmartJoins allow to execute co-located join operations among identically
 sharded collections.
 

--- a/site/content/3.10/get-started/set-up-a-cloud-instance.md
+++ b/site/content/3.10/get-started/set-up-a-cloud-instance.md
@@ -138,14 +138,16 @@ Alternatively, follow the steps of the linked guides:
 - [Access your deployment](../arangograph/deployments/_index.md#how-to-access-your-deployment)
 - [Delete your deployment](../arangograph/deployments/_index.md#how-to-delete-a-deployment)
 
-## Free-to-Try vs. Professional Service
+## Free-to-Try vs. Paid
 
-The ArangoGraph Insights Platform comes with a free-to-try tier that lets you test our ArangoDB
-Cloud for free for 14 days. It includes one project and one deployment.
-After the trial period, your deployments are automatically deleted.
+The ArangoGraph Insights Platform comes with a free-to-try tier that lets you test
+the ArangoDB Cloud for free for 14 days. It includes one project and one small
+deployment of 4GB, local backups, and one notebook for learning and data science.
+After the trial period, your deployment is automatically deleted.
 
-You can convert to the professional service model at any time by adding 
+You can unlock all features in ArangoGraph at any time by adding 
 your billing details and at least one payment method. See:
+- [ArangoGraph Packages](../arangograph/organizations/_index.md#arangograph-packages)
 - [How to add billing details to organizations](../arangograph/organizations/billing.md#how-to-add-billing-details)
 - [How to add a payment method to an organization](../arangograph/organizations/billing.md#how-to-add-a-payment-method)
 

--- a/site/content/3.10/graphs/enterprisegraphs/_index.md
+++ b/site/content/3.10/graphs/enterprisegraphs/_index.md
@@ -8,7 +8,8 @@ archetype: chapter
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 This chapter describes the `enterprise-graph` module, a specialized version of
 [SmartGraphs](../smartgraphs/_index.md).
 It will give a vast performance benefit for all graphs sharded

--- a/site/content/3.10/graphs/satellitegraphs/_index.md
+++ b/site/content/3.10/graphs/satellitegraphs/_index.md
@@ -8,7 +8,8 @@ archetype: chapter
 ---
 <small>Introduced in: v3.7.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## What is a SatelliteGraph?
 
 _SatelliteGraphs_ are a specialized _named graph_ type available for cluster

--- a/site/content/3.10/graphs/smartgraphs/_index.md
+++ b/site/content/3.10/graphs/smartgraphs/_index.md
@@ -6,7 +6,8 @@ description: >-
   SmartGraphs enable you to manage graphs at scale.
 archetype: chapter
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 SmartGraphs are specifically targeted at graphs that need scalability and
 high performance. The way SmartGraphs use the ArangoDB cluster sharding makes it
 extremely useful for distributing data across multiple servers with minimal

--- a/site/content/3.10/graphs/smartgraphs/testing-graphs-on-single-server.md
+++ b/site/content/3.10/graphs/smartgraphs/testing-graphs-on-single-server.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## General idea
 
 You can create SmartGraphs and SatelliteGraphs in a single server instance and

--- a/site/content/3.10/index-and-search/analyzers.md
+++ b/site/content/3.10/index-and-search/analyzers.md
@@ -1054,7 +1054,8 @@ description: ''
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 An Analyzer that computes so called MinHash signatures using a
 locality-sensitive hash function. It applies an Analyzer of your choice before
 the hashing, for example, to break up text into words.
@@ -1096,7 +1097,8 @@ description: ''
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 {{< warning >}}
 This feature is experimental and under active development.
 The naming and interfaces may change at any time.
@@ -1155,7 +1157,8 @@ db._query(`LET str = "Which baking dish is best to bake a banana bread ?"
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 {{< warning >}}
 This feature is experimental and under active development.
 The naming and interfaces may change at any time.
@@ -1334,7 +1337,8 @@ description: ''
 
 <small>Introduced in: v3.10.5</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 An Analyzer capable of breaking up a GeoJSON object or coordinate array in
 `[longitude, latitude]` order into a set of indexable tokens for further usage
 with [ArangoSearch Geo functions](../aql/functions/arangosearch.md#geo-functions).

--- a/site/content/3.10/index-and-search/arangosearch/arangosearch-views-reference.md
+++ b/site/content/3.10/index-and-search/arangosearch/arangosearch-views-reference.md
@@ -200,7 +200,8 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ### View Properties
 
 {{< info >}}
@@ -244,7 +245,8 @@ cache-related options and thus recreate inverted indexes and Views. See
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}  
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+  
 - **primaryKeyCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
 
   <small>Introduced in: v3.9.6, v3.10.2</small>
@@ -261,7 +263,8 @@ cache-related options and thus recreate inverted indexes and Views. See
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - **storedValues** (_optional_; type: `array`; default: `[]`; _immutable_)
 
   <small>Introduced in: v3.7.1</small>

--- a/site/content/3.10/index-and-search/arangosearch/nested-search.md
+++ b/site/content/3.10/index-and-search/arangosearch/nested-search.md
@@ -10,7 +10,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 By default, `arangosearch` Views index arrays as if the parent attribute had
 multiple values at once. This is also supported for `search-alias` Views by enabling
 the `searchField` option. With `trackListPositions` set to `true`, every array

--- a/site/content/3.10/index-and-search/arangosearch/performance.md
+++ b/site/content/3.10/index-and-search/arangosearch/performance.md
@@ -473,7 +473,8 @@ Also see [Faceted Search with ArangoSearch](faceted-search.md).
 
 <small>Introduced in: v3.9.5, v3.10.2</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Normalization values are computed for fields which are processed with Analyzers
 that have the [`"norm"` feature](../analyzers.md#analyzer-features) enabled.
 These values are used to score fairer if the same tokens occur repeatedly, to

--- a/site/content/3.10/index-and-search/arangosearch/search-highlighting.md
+++ b/site/content/3.10/index-and-search/arangosearch/search-highlighting.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ArangoSearch lets you search for terms and phrases in full-text, and more.
 It only returns matching documents, however. With search highlighting, you can
 get the exact locations of the matches.

--- a/site/content/3.10/operations/administration/user-management/_index.md
+++ b/site/content/3.10/operations/administration/user-management/_index.md
@@ -329,7 +329,8 @@ database. All changes to the access levels must be done using the
 
 ### LDAP Users
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ArangoDB supports LDAP as an external authentication system. For detailed
 information please have look into the
 [LDAP configuration guide](../../../components/arangodb-server/ldap.md).

--- a/site/content/3.10/operations/backup-and-restore.md
+++ b/site/content/3.10/operations/backup-and-restore.md
@@ -73,7 +73,8 @@ Hot backup and restore associated operations can be performed with the
 [_arangobackup_](../components/tools/arangobackup/_index.md) client tool and the
 [Hot Backup HTTP API](../develop/http/hot-backups.md).
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Many operations cannot afford downtimes and thus require administrators and
 operators to create consistent freezes of the data during normal operation.
 Such use cases imply that near instantaneous hot backups must be

--- a/site/content/3.10/operations/security/audit-logging.md
+++ b/site/content/3.10/operations/security/audit-logging.md
@@ -18,6 +18,7 @@ A similar feature is also available in the
 [ArangoGraph Insights Platform](../../arangograph/security-and-access-control/_index.md#using-an-audit-log).
 {{< /info >}}
 {{< tag "ArangoDB Enterprise" >}}
+
 ## Configuration
 
 To enable audit logging, set the `--audit.output` startup option to either a

--- a/site/content/3.10/operations/security/encryption-at-rest.md
+++ b/site/content/3.10/operations/security/encryption-at-rest.md
@@ -6,7 +6,8 @@ description: >-
   Securing physical storage media, available in the Enterprise Edition
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 When you store sensitive data in your ArangoDB database, you want to protect
 that data under all circumstances. At runtime you will protect it with SSL
 transport encryption and strong authentication, but when the data is already

--- a/site/content/3.10/release-notes/version-3.6/whats-new-in-3-6.md
+++ b/site/content/3.10/release-notes/version-3.6/whats-new-in-3-6.md
@@ -562,7 +562,8 @@ operand can be a collection or another View.
 
 ## OneShard
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Not all use cases require horizontal scalability. In such cases, a OneShard
 deployment offers a practicable solution that enables significant performance
 improvements by massively reducing cluster-internal communication.

--- a/site/content/3.11/aql/functions/arangosearch.md
+++ b/site/content/3.11/aql/functions/arangosearch.md
@@ -1273,7 +1273,8 @@ FOR doc IN viewName
 
 ## Search Highlighting Functions
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ### OFFSET_INFO()
 
 `OFFSET_INFO(doc, paths) → offsetInfo`

--- a/site/content/3.11/aql/graphs/traversals.md
+++ b/site/content/3.11/aql/graphs/traversals.md
@@ -136,9 +136,11 @@ FOR vertex[, edge[, path]]
     case when a nested traversal is fed with several tens of thousands of start
     vertices, which can then be distributed randomly to worker threads for parallel
     execution.
-    {{< tag "ArangoDB Enterprise""ArangoGraph" >}}  - **maxProjections** (number, *optional*): Specifies the number of document
+    {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+  - **maxProjections** (number, *optional*): Specifies the number of document
     attributes per FOR loop to be used as projections. The default value is `5`.
-    {{< tag "ArangoDB Enterprise""ArangoGraph" >}}  - **weightAttribute** (string, *optional*): Specifies the name of an attribute
+    {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+  - **weightAttribute** (string, *optional*): Specifies the name of an attribute
     that is used to look up the weight of an edge. If no attribute is specified
     or if it is not present in the edge document then the `defaultWeight` is used.
     The attribute value must not be negative.

--- a/site/content/3.11/aql/how-to-invoke-aql/with-arangosh.md
+++ b/site/content/3.11/aql/how-to-invoke-aql/with-arangosh.md
@@ -489,7 +489,8 @@ deployment, then the Coordinator is allowed to read from any shard replica and
 not only from the leader. See [Read from followers](../../develop/http/documents.md#read-from-followers)
 for details.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 #### `skipInaccessibleCollections`
 
 Let AQL queries (especially graph traversals) treat collection to which a
@@ -499,14 +500,16 @@ This is intended to help with certain use-cases: A graph contains several collec
 and different users execute AQL queries on that graph. You can naturally limit the 
 accessible results by changing the access rights of users on collections.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 #### `satelliteSyncWait`
 
 Configure how long a DB-Server has time to bring the SatelliteCollections
 involved in the query into sync. The default value is `60.0` seconds.
 When the maximal time is reached, the query is stopped.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## With `db._createStatement()` (ArangoStatement)
 
 The `_query()` method is a shorthand for creating an `ArangoStatement` object,

--- a/site/content/3.11/arangograph/backups.md
+++ b/site/content/3.11/arangograph/backups.md
@@ -16,7 +16,7 @@ To backup data in ArangoGraph for an ArangoDB installation, navigate to the
 There are two ways to create backups. Create periodic backups using a
 **Backup policy**, or create a backup manually.
 Both ways allow you to create [backups in multiple regions](#multi-region-backups)
-as well, if your organization belongs to the Enterprise tier.
+as well.
 
 ### Periodic backups
 
@@ -35,8 +35,7 @@ These backups are not automatically uploaded. To enable this, use the
 **Upload backup to storage** option and choose a retention period that
 specifies how long backups are retained after creation. 
 
-If your organization belongs to the Enterprise tier and the
-**Upload backup to storage** option is enabled for a backup policy,
+If the **Upload backup to storage** option is enabled for a backup policy,
 you can then create backups in different regions than the default one.
 The regions where the default backup is copied are shown in the
 **Additional regions** column in the **Policies** section.
@@ -49,8 +48,7 @@ It's also possible to create a backup on demand. To do this, click **Back up now
 
 ![Back up Now Dialog](../../images/arangograph-back-up-now-dialog.png)
 
-If your organization belongs to the Enterprise tier and you want to manually
-copy a backup to a different region than the default
+If you want to manually copy a backup to a different region than the default
 one, first ensure that the **Upload backup to storage** option is enabled.
 Then, highlight the backup row and use the
 **Copy backup to a different region** button from the **Actions** column. 
@@ -104,13 +102,6 @@ alternatives such as having hourly backups with a retention period of a year.
 
 ## Multi-region backups
 
-{{< info >}}
-The multi-region backup feature is only available for the ArangoGraph
-Enterprise tier. To upgrade to the Enterprise tier,
-[get in touch](https://www.arangodb.com/contact/)
-with the ArangoDB team.
-{{< /info >}}
-
 Using the multi-region backup feature, you can store backups in multiple regions
 simultaneously either manually or automatically as part of a **Backup policy**.
 If a backup created in one region goes down, it is still available in other
@@ -146,8 +137,7 @@ During restore, the deployment is temporarily not available.
 {{< info >}}
 The cloned deployment will have the exact same features as the previous
 deployment including node size, model, and cloud provider. The region
-can stay the same or you can select a different one if your organization belongs
-to the Enterprise tier.
+can stay the same or you can select a different one.
 For restoring a deployment as quick as possible, it is recommended to create a
 deployment in the same region as where the backup resides to avoid cross-region
 data transfer.

--- a/site/content/3.11/arangograph/deployments/_index.md
+++ b/site/content/3.11/arangograph/deployments/_index.md
@@ -31,12 +31,6 @@ its projects and deployments.
 4. Click the __New deployment__ button.
 5. Set up your deployment. The configuration options are described below.
 
-   {{< info >}}
-   The configuration options depend on the tier your organization belongs to.
-   For more details about available resources and usage limits, refer to the 
-   [ArangoGraph tiers](../organizations/_index.md#arangograph-tiers) section.
-   {{< /info >}}
-
 ![ArangoGraph New Deployment](../../../images/arangograph-new-deployment1.png)
 
 {{< info >}}
@@ -95,13 +89,8 @@ provider and region in the Location section.
 
 #### OneShard
 
-1. Select the memory size of your node.
-2. Select the CPU size of your node.
-3. Select the initial disk size of your node. The available ranges for the disk size
-   depend on the selected memory size.
-4. Select the upper limit for the disk size. It defaults to twice the initial
-   disk size. You can set it to the same value as the initial disk size to
-   disable automatic disk sizing.
+- Select the memory size of your node. The disk size is automatically set for you
+  based on the selected memory size.
 
 {{< info >}}
 A deployment's node disk size is automatically increased by 25% when the maximal
@@ -115,16 +104,17 @@ the upper disk size limit already.
 
 #### Sharded
 
-- In addition to memory and disk size as in the OneShard configuration, select
+- In addition to the memory size as in the OneShard configuration, select
   the number of nodes for your deployment. The more nodes you have, the higher
-  the replication factor can be.
+  the replication factor can be. Same as in OneShard, the disk size is automatically
+  set for you.
 
 ![ArangoGraph Deployment Sharded](../../../images/arangograph-new-deployment-sharded.png)
 
 #### Single Server
 
-- Like with OneShard and Sharded deployments, you choose memory and disk size.
-  However note that the sizes you choose are for the entire deployment.
+- Like with OneShard and Sharded deployments, you can choose the memory size.
+  Note, however, that the size you choose is for the entire deployment.
   For OneShard and Sharded deployments the chosen sizes are per node.
 
 ![ArangoGraph Deployment Single Server](../../../images/arangograph-new-deployment-singleserver.png)
@@ -251,7 +241,7 @@ are using the `18529` port to avoid breaking changes.
 ## How to edit a deployment
 
 You can modify a deployment’s configuration, including the ArangoDB version
-that is being used, change the memory, CPU, and disk size, or even switch from
+that is being used, change the memory size, or even switch from
 a OneShard deployment to a Sharded one if your data set no longer fits in a
 single node. 
 
@@ -259,12 +249,6 @@ single node.
 To edit an existing deployment, you must have the necessary set of permissions
 attached to your role. Read more about [roles and permissions](../security-and-access-control/_index.md#roles).
 {{< /tip >}}
-
-{{< info >}}
-The configuration options depend on the tier your organization belongs to.
-For more details about available resources and usage limits, refer to the 
-[ArangoGraph tiers](../organizations/_index.md#arangograph-tiers) section.
-{{< /info >}}
 
 1. Go to the **Projects** section and select an existing deployment from the list. 
 2. Open the deployment you want to change. 
@@ -275,12 +259,7 @@ For more details about available resources and usage limits, refer to the
    - Select a different CA certificate.
    - Add or remove an IP allowlist.
 5. In the **Configuration** section, you can do the following:
-   - Upgrade the memory size per node. 
-   - Modify the CPU per node from General to Low or vice-versa, if made available
-     by the cloud provider.
-   - Select a different disk size per node. The available ranges for the disk size
-     depend on the selected memory size. To enable automatic disk size scaling, move
-     the slider to a value higher than the current disk size.
+   - Upgrade the memory size per node. The disk size is automatically set for you.
    - Change **OneShard** deployments into **Sharded** deployments. To do so,
      click **Sharded**. In addition to the other configuration options, you can
      select the number of nodes for your deployment. This can also be modified later on.
@@ -288,15 +267,10 @@ For more details about available resources and usage limits, refer to the
    {{< warning >}}
    Notice that you cannot switch from **Sharded** back to **OneShard**.
    {{< /warning >}}
-   
-   - AWS deployments have an additional option that allows you to select the
-     **Disk Performance** either with general settings, or optimized for large
-     and very large data sets. This option is dependent on the selected memory
-     size. For example, larger deployments have optimized settings by default.
 
    {{< warning >}}
-   When upgrading the memory size, disk size, and/or disk performance in AWS deployments,
-   the value gets locked and cannot be changed until the cloud provider rate limit is reset.  
+   When upgrading the memory size in AWS deployments, the value gets locked and
+   cannot be changed until the cloud provider rate limit is reset. 
    {{< /warning >}}
 
 6. All changes are reflected in the **Summary** section. Review the new

--- a/site/content/3.11/arangograph/deployments/private-endpoints.md
+++ b/site/content/3.11/arangograph/deployments/private-endpoints.md
@@ -12,11 +12,6 @@ securely deploy to various cloud providers such as Google Cloud Platform (GCP),
 Microsoft Azure, and Amazon Web Services (AWS). Follow the steps outlined below
 to get started.
 
-{{< info >}}
-The private endpoint feature is only available on the
-[Enterprise tier](../organizations/_index.md#arangograph-tiers) of ArangoGraph.
-{{< /info >}}
-
 {{< tip >}}
 Private endpoints on Microsoft Azure can be cross region; in AWS they should be
 located in the same region.
@@ -53,9 +48,7 @@ service attachment that you need during the creation of your private endpoint(s)
 
 1. Open the deployment you want to change.
 2. On the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier. 
+   icon. 
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment Private Endpoint Menu](../../../images/arangograph-gcp-change.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.
@@ -99,9 +92,7 @@ please contact support via **Request help** in the help menu.
 
 1. Open the deployment you want to change.
 2. On the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier.
+   icon.
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment Private Endpoint Menu](../../../images/arangograph-deployment-private-endpoint-menu.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.
@@ -156,9 +147,7 @@ that automatically connects to private endpoints that are created in those princ
 
 1. Open the deployment you want to change.
 2. In the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier.
+   icon.
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment AWS Change to Private Endpoint](../../../images/arangograph-aws-change-to-private-endpoint.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.

--- a/site/content/3.11/arangograph/deployments/upgrades-and-versioning.md
+++ b/site/content/3.11/arangograph/deployments/upgrades-and-versioning.md
@@ -115,6 +115,5 @@ ArangoGraph aims to give approximately one week’s notice prior to upgrading yo
 deployments to the latest patch release. Although in exceptional circumstances
 (such as a critical security issue) the upgrade may be triggered with less than
 one week's notice.
-The upgrade is carried out automatically. However, if your organization belongs 
-to the Enterprise tier, you contact the ArangoGraph Support team to request that
-this upgrade is manually deferred temporarily.
+The upgrade is carried out automatically. However, if you need the upgrade to be
+deferred temporarily, contact the ArangoGraph Support team to request that.

--- a/site/content/3.11/arangograph/notebooks.md
+++ b/site/content/3.11/arangograph/notebooks.md
@@ -58,8 +58,8 @@ favorite GraphML libraries with GPUs.
 
 {{< info >}}
 Depending on the tier your organization belongs to, different limitations apply:
-- Professional and Enterprise tiers: you can create up to three notebooks per deployment.
-- Free-to-try tier: you can only create one notebook per deployment.  
+- On-Demand and Committed: you can create up to three notebooks per deployment.
+- Free-to-try: you can only create one notebook per deployment.
 {{< /info >}}
 
 ![Notebooks](../../images/arangograph-notebooks.png)

--- a/site/content/3.11/arangograph/organizations/_index.md
+++ b/site/content/3.11/arangograph/organizations/_index.md
@@ -30,50 +30,57 @@ member of one _Free-to-try_ tier organization at a time.
 
 ![ArangoGraph Organization Overview](../../../images/arangograph-organization-overview.png)
 
-## ArangoGraph tiers
+## ArangoGraph Packages
 
-With the ArangoGraph Insights Platform, your organization can belong to one of the following three tiers:
+With the ArangoGraph Insights Platform, your organization can choose one of the
+following packages.
 
-- **Free-to-try tier**: ArangoGraph comes with a free-to-try tier that lets
-you test ArangoGraph for free for 14 days. After the trial period,
-your deployments will be deleted automatically. Includes the Basic Support plan,
-which covers the availability and connectivity of the ArangoGraph Insights Platform, and general questions.
-- **Professional tier**: Allows you to create additional organizations and
-projects, and have more and larger deployments. Includes the Standard support for
-professional deployments, which covers everything from the Basic support plan
-with explicit response times.
-- **Enterprise tier**: Get unlimited access to all functionalities and resources,
-with the best available support and response times. Includes the Premium Standard
-support plan.
+### Free Trial
 
-| &nbsp;| Free-to-try  | Professional  | Enterprise  |
-|-------|:--------------:|:---------------:|:-------------:|
-| **Organizations per user** | 1 | Unlimited | Unlimited |
-| **Projects per organization** | 1 | 3 | Unlimited |
-| **Deployments per project** | 1 | 5 | Unlimited |
-| **Upload backup** | Not included | Included | Included |
-| **Private endpoint deployment** | Not included | Not included | Included |
-| **Support plan** | Basic | Standard | Premium Standard |
+ArangoGraph comes with a free-to-try tier that lets you test ArangoGraph for
+free for 14 days. You can get started quickly, without needing to enter a
+credit card.
 
-{{< info >}}
-Based on the type of tier your organization belongs to, different usage
-limits apply for memory and storage.
-{{< /info >}}
+The free trial gives you access to:
+- One small deployment (4GB) in a region of your choice for 14 days
+- Local backups
+- One ArangoGraph Notebook for learning and data science
 
-## How to upgrade to Professional tier
+After the trial period, your deployment will be deleted automatically.
 
-You can upgrade to the professional service model at any time by adding
-your billing details and at least one payment method. You can then create
-additional organizations and projects and have more and larger deployments.
+### On-Demand
+
+Add a payment payment method to gain access to ArangoGraph's full feature set.
+Pay monthly via a credit card for what you actually use.
+
+This package unlocks all ArangoGraph functionality, including:
+- Multiple and larger deployments
+- Backups to cloud storage, with multi-region support
+- Enhanced security features such as Private Endpoints
+
+### Committed
+
+Commit up-front for a year and pay via the Sales team. This package provides
+the same flexibility of On-Demand, but at a lower price. 
+
+In addition, you gain access to:
+- 24/7 Premium Support
+- ArangoDB Professional Services Engagements
+- Ability to transact via the AWS and GCP marketplaces
+
+To take advantage of this, you need to get in touch with the ArangoDB
+team. [Contact us](https://www.arangodb.com/contact/) for more details.
+
+## How to unlock all features
+
+You can unlock all features in ArangoGraph at any time by adding your billing
+details and a payment method. As soon as you have added a payment method, all
+ArangoGraph functionalities are immediately unlocked. From that point on, your
+deployments will no longer expire and you can create more and larger deployments.
 
 See [Billing: How to add billing details / payment methods](billing.md)
 
 ![ArangoGraph Billing](../../../images/arangograph-billing.png)
-
-## How to upgrade to Enterprise tier
-
-To upgrade to the Enterprise tier, you need to get in touch with the ArangoDB
-team. [Contact us](https://www.arangodb.com/contact/) for more details.
 
 ## How to create a new organization
 

--- a/site/content/3.11/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.11/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -6,10 +6,6 @@ description: >-
   Single Sign-On (SSO) using SAML 2.0
 archetype: chapter
 ---
-{{< info >}}
-This feature is only available in ArangoGraph Enterprise.
-{{< /info >}}
-
 ArangoGraph provides support to enable **Single Sign-On** (SSO) authentication
 using **Security Assertion Markup language 2.0** (SAML 2.0).
 

--- a/site/content/3.11/arangograph/security-and-access-control/single-sign-on/scim-provisioning.md
+++ b/site/content/3.11/arangograph/security-and-access-control/single-sign-on/scim-provisioning.md
@@ -6,10 +6,6 @@ description: >-
   How to enable SCIM provisioning
 archetype: default
 ---
-{{< info >}}
-This feature is only available in ArangoGraph Enterprise.
-{{< /info >}}
-
 ArangoGraph provides support to control and manage members access in
 ArangoGraph organizations with the
 **System for Cross-domain Identity Management** (SCIM) provisioning. 

--- a/site/content/3.11/components/arangodb-server/ldap.md
+++ b/site/content/3.11/components/arangodb-server/ldap.md
@@ -6,7 +6,8 @@ description: >-
   LDAP authentication options in the ArangoDB server
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## Basics Concepts
 
 The basic idea is that one can keep the user authentication setup for

--- a/site/content/3.11/components/tools/arangobackup/_index.md
+++ b/site/content/3.11/components/tools/arangobackup/_index.md
@@ -13,6 +13,7 @@ Use [_arangodump_](../arangodump/_index.md) and
 [logical backups](../../../operations/backup-and-restore.md#logical-backups) in the Community Edition.
 {{< /info >}}
 {{< tag "ArangoDB Enterprise" >}}
+
 _Arangobackup_ is a command-line client tool for instantaneous and
 consistent [hot backups](../../../operations/backup-and-restore.md#hot-backups) of the data and
 structures stored in ArangoDB.

--- a/site/content/3.11/components/tools/arangodump/examples.md
+++ b/site/content/3.11/components/tools/arangodump/examples.md
@@ -158,7 +158,8 @@ INFO [66c0e] {dump} Processed 2 collection(s) from 1 database(s) in 0.132990 s t
 
 ## Encryption
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 You can encrypt dumps using an encryption keyfile, which must contain exactly 32
 bytes of data (required by the AES block cipher).
 

--- a/site/content/3.11/components/tools/arangodump/maskings.md
+++ b/site/content/3.11/components/tools/arangodump/maskings.md
@@ -469,7 +469,8 @@ processed by a single masking function, ignoring any other rules below it.
 
 ## Masking Functions
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - [Xify Front](#xify-front)
 - [Zip](#zip)
 - [Datetime](#datetime)

--- a/site/content/3.11/data-science/pregel/_index.md
+++ b/site/content/3.11/data-science/pregel/_index.md
@@ -41,7 +41,8 @@ In cluster mode, the collections need to be sharded in a specific way to ensure
 correct results: The outgoing edges of a vertex need to be on the same DB-Server
 as the vertex. This is guaranteed by [SmartGraphs](../../graphs/smartgraphs/_index.md).
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Note that the performance may be better, if the number of your shards /
 collections matches the number of CPU cores.
 

--- a/site/content/3.11/deploy/arangosync/_index.md
+++ b/site/content/3.11/deploy/arangosync/_index.md
@@ -9,6 +9,7 @@ archetype: chapter
 {{< description >}}
 
 {{< tag "ArangoDB Enterprise" >}}
+
 This chapter introduces ArangoDB's _Datacenter-to-Datacenter Replication_ (DC2DC).
 
 At some point in the grows of a database, there comes a need for replicating it

--- a/site/content/3.11/deploy/arangosync/administration.md
+++ b/site/content/3.11/deploy/arangosync/administration.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the synchronization process
 of the _Datacenter-to-Datacenter Replication_.
 

--- a/site/content/3.11/deploy/arangosync/deployment/_index.md
+++ b/site/content/3.11/deploy/arangosync/deployment/_index.md
@@ -7,6 +7,7 @@ description: >-
 archetype: chapter
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This chapter describes how to deploy all the components needed for
 _Datacenter-to-Datacenter Replication (DC2DC)_.
 

--- a/site/content/3.11/deploy/arangosync/monitoring.md
+++ b/site/content/3.11/deploy/arangosync/monitoring.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the monitoring of the
 _Datacenter-to-Datacenter Replication_.
 

--- a/site/content/3.11/deploy/arangosync/operations-and-maintenance.md
+++ b/site/content/3.11/deploy/arangosync/operations-and-maintenance.md
@@ -9,6 +9,7 @@ archetype: default
 ## Operations & Maintenance
 
 {{< tag "ArangoDB Enterprise" >}}
+
 ArangoSync is a distributed system with a lot different components.
 As with any such system, it requires some, but not a lot of operational
 support.

--- a/site/content/3.11/deploy/arangosync/security.md
+++ b/site/content/3.11/deploy/arangosync/security.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the _Datacenter-to-Datacenter Replication_
 security.
 

--- a/site/content/3.11/deploy/arangosync/troubleshooting.md
+++ b/site/content/3.11/deploy/arangosync/troubleshooting.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 The _Datacenter-to-Datacenter Replication_ is a distributed system with a lot
 different components. As with any such system, it requires some, but not a lot,
 of operational support.

--- a/site/content/3.11/deploy/deployment/kubernetes/deployment-replication-resource-reference.md
+++ b/site/content/3.11/deploy/deployment/kubernetes/deployment-replication-resource-reference.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 The ArangoDB Replication Operator creates and maintains ArangoDB
 `arangosync` configurations in a Kubernetes cluster, given a replication specification.
 This replication specification is a `CustomResource` following

--- a/site/content/3.11/deploy/deployment/oneshard.md
+++ b/site/content/3.11/deploy/deployment/oneshard.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 The OneShard option for ArangoDB clusters restricts all collections of a
 database to a single shard and places them on one DB-Server node. This way,
 whole queries can be pushed to and executed on that server, massively reducing

--- a/site/content/3.11/develop/http/authentication.md
+++ b/site/content/3.11/develop/http/authentication.md
@@ -275,6 +275,7 @@ curl -v -H "Authorization: bearer $(jwtgen -s <my-secret> -e 3600 -a "HS256" -c 
 ## Hot-reload JWT secrets
 
 {{< tag "ArangoDB Enterprise" >}}
+
 To reload the JWT secrets of a local arangod process without a restart, you
 may use the following RESTful API. A `POST` request reloads the secret, a
 `GET` request may be used to load information about the currently used secrets.

--- a/site/content/3.11/develop/http/documents.md
+++ b/site/content/3.11/develop/http/documents.md
@@ -2621,7 +2621,8 @@ name: RestDocumentHandlerDeleteDocumentRevConflictMulti
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 In an ArangoDB cluster, all reads and writes are performed via
 the shard leaders. Shard replicas replicate all operations, but are
 only on hot standby to take over in case of a failure. This is to ensure

--- a/site/content/3.11/develop/http/hot-backups.md
+++ b/site/content/3.11/develop/http/hot-backups.md
@@ -10,6 +10,7 @@ archetype: default
 {{< description >}}
 
 {{< tag "ArangoDB Enterprise" >}}
+
 Hot Backups are near instantaneous consistent snapshots of an
 **entire** ArangoDB deployment. This includes all databases, collections,
 indexes, Views, graphs, and users at any given time.

--- a/site/content/3.11/develop/satellitecollections.md
+++ b/site/content/3.11/develop/satellitecollections.md
@@ -6,7 +6,8 @@ description: >-
   Collections synchronously replicated to all servers, available in the Enterprise Edition
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 When doing joins in an ArangoDB cluster data has to be exchanged between different servers.
 
 Joins are executed on a Coordinator. It prepares an execution plan

--- a/site/content/3.11/develop/smartjoins.md
+++ b/site/content/3.11/develop/smartjoins.md
@@ -6,7 +6,8 @@ description: >-
   SmartJoins allow to execute co-located join operations among identically sharded collections.
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 SmartJoins allow to execute co-located join operations among identically
 sharded collections.
 

--- a/site/content/3.11/get-started/set-up-a-cloud-instance.md
+++ b/site/content/3.11/get-started/set-up-a-cloud-instance.md
@@ -138,14 +138,16 @@ Alternatively, follow the steps of the linked guides:
 - [Access your deployment](../arangograph/deployments/_index.md#how-to-access-your-deployment)
 - [Delete your deployment](../arangograph/deployments/_index.md#how-to-delete-a-deployment)
 
-## Free-to-Try vs. Professional Service
+## Free-to-Try vs. Paid
 
-The ArangoGraph Insights Platform comes with a free-to-try tier that lets you test our ArangoDB
-Cloud for free for 14 days. It includes one project and one deployment.
-After the trial period, your deployments are automatically deleted.
+The ArangoGraph Insights Platform comes with a free-to-try tier that lets you test
+the ArangoDB Cloud for free for 14 days. It includes one project and one small
+deployment of 4GB, local backups, and one notebook for learning and data science.
+After the trial period, your deployment is automatically deleted.
 
-You can convert to the professional service model at any time by adding 
+You can unlock all features in ArangoGraph at any time by adding 
 your billing details and at least one payment method. See:
+- [ArangoGraph Packages](../arangograph/organizations/_index.md#arangograph-packages)
 - [How to add billing details to organizations](../arangograph/organizations/billing.md#how-to-add-billing-details)
 - [How to add a payment method to an organization](../arangograph/organizations/billing.md#how-to-add-a-payment-method)
 

--- a/site/content/3.11/graphs/enterprisegraphs/_index.md
+++ b/site/content/3.11/graphs/enterprisegraphs/_index.md
@@ -8,7 +8,8 @@ archetype: chapter
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 This chapter describes the `enterprise-graph` module, a specialized version of
 [SmartGraphs](../smartgraphs/_index.md).
 It will give a vast performance benefit for all graphs sharded

--- a/site/content/3.11/graphs/satellitegraphs/_index.md
+++ b/site/content/3.11/graphs/satellitegraphs/_index.md
@@ -6,7 +6,8 @@ description: >-
   Graphs synchronously replicated to all servers, available in the Enterprise Edition
 archetype: chapter
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## What is a SatelliteGraph?
 
 _SatelliteGraphs_ are a specialized _named graph_ type available for cluster

--- a/site/content/3.11/graphs/smartgraphs/_index.md
+++ b/site/content/3.11/graphs/smartgraphs/_index.md
@@ -6,7 +6,8 @@ description: >-
   SmartGraphs enable you to manage graphs at scale.
 archetype: chapter
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 SmartGraphs are specifically targeted at graphs that need scalability and
 high performance. The way SmartGraphs use the ArangoDB cluster sharding makes it
 extremely useful for distributing data across multiple servers with minimal

--- a/site/content/3.11/graphs/smartgraphs/testing-graphs-on-single-server.md
+++ b/site/content/3.11/graphs/smartgraphs/testing-graphs-on-single-server.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## General idea
 
 You can create SmartGraphs and SatelliteGraphs in a single server instance and

--- a/site/content/3.11/index-and-search/analyzers.md
+++ b/site/content/3.11/index-and-search/analyzers.md
@@ -1054,7 +1054,8 @@ description: ''
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 An Analyzer that computes so called MinHash signatures using a
 locality-sensitive hash function. It applies an Analyzer of your choice before
 the hashing, for example, to break up text into words.
@@ -1096,7 +1097,8 @@ description: ''
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 {{< warning >}}
 This feature is experimental and under active development.
 The naming and interfaces may change at any time.
@@ -1155,7 +1157,8 @@ db._query(`LET str = "Which baking dish is best to bake a banana bread ?"
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 {{< warning >}}
 This feature is experimental and under active development.
 The naming and interfaces may change at any time.
@@ -1334,7 +1337,8 @@ description: ''
 
 <small>Introduced in: v3.10.5</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 An Analyzer capable of breaking up a GeoJSON object or coordinate array in
 `[longitude, latitude]` order into a set of indexable tokens for further usage
 with [ArangoSearch Geo functions](../aql/functions/arangosearch.md#geo-functions).

--- a/site/content/3.11/index-and-search/arangosearch/arangosearch-views-reference.md
+++ b/site/content/3.11/index-and-search/arangosearch/arangosearch-views-reference.md
@@ -237,7 +237,8 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ### View Properties
 
 - **primarySort** (_optional_; type: `array`; default: `[]`; _immutable_)
@@ -272,7 +273,8 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - **primaryKeyCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
 
   <small>Introduced in: v3.9.6, v3.10.2</small>
@@ -289,7 +291,8 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - **storedValues** (_optional_; type: `array`; default: `[]`; _immutable_)
 
   An array of objects to describe which document attributes to store in the

--- a/site/content/3.11/index-and-search/arangosearch/nested-search.md
+++ b/site/content/3.11/index-and-search/arangosearch/nested-search.md
@@ -10,7 +10,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 By default, `arangosearch` Views index arrays as if the parent attribute had
 multiple values at once. This is also supported for `search-alias` Views by enabling
 the `searchField` option. With `trackListPositions` set to `true`, every array

--- a/site/content/3.11/index-and-search/arangosearch/performance.md
+++ b/site/content/3.11/index-and-search/arangosearch/performance.md
@@ -473,7 +473,8 @@ Also see [Faceted Search with ArangoSearch](faceted-search.md).
 
 <small>Introduced in: v3.9.5, v3.10.2</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Normalization values are computed for fields which are processed with Analyzers
 that have the [`"norm"` feature](../analyzers.md#analyzer-features) enabled.
 These values are used to score fairer if the same tokens occur repeatedly, to

--- a/site/content/3.11/index-and-search/arangosearch/search-highlighting.md
+++ b/site/content/3.11/index-and-search/arangosearch/search-highlighting.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ArangoSearch lets you search for terms and phrases in full-text, and more.
 It only returns matching documents, however. With search highlighting, you can
 get the exact locations of the matches.

--- a/site/content/3.11/operations/administration/user-management/_index.md
+++ b/site/content/3.11/operations/administration/user-management/_index.md
@@ -329,7 +329,8 @@ database. All changes to the access levels must be done using the
 
 ### LDAP Users
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ArangoDB supports LDAP as an external authentication system. For detailed
 information please have look into the
 [LDAP configuration guide](../../../components/arangodb-server/ldap.md).

--- a/site/content/3.11/operations/backup-and-restore.md
+++ b/site/content/3.11/operations/backup-and-restore.md
@@ -67,7 +67,8 @@ Hot backup and restore associated operations can be performed with the
 [_arangobackup_](../components/tools/arangobackup/_index.md) client tool and the
 [Hot Backup HTTP API](../develop/http/hot-backups.md).
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Many operations cannot afford downtimes and thus require administrators and
 operators to create consistent freezes of the data during normal operation.
 Such use cases imply that near instantaneous hot backups must be

--- a/site/content/3.11/operations/security/audit-logging.md
+++ b/site/content/3.11/operations/security/audit-logging.md
@@ -18,6 +18,7 @@ A similar feature is also available in the
 [ArangoGraph Insights Platform](../../arangograph/security-and-access-control/_index.md#using-an-audit-log).
 {{< /info >}}
 {{< tag "ArangoDB Enterprise" >}}
+
 ## Configuration
 
 To enable audit logging, set the `--audit.output` startup option to either a

--- a/site/content/3.11/operations/security/encryption-at-rest.md
+++ b/site/content/3.11/operations/security/encryption-at-rest.md
@@ -6,7 +6,8 @@ description: >-
   Securing physical storage media, available in the Enterprise Edition
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 When you store sensitive data in your ArangoDB database, you want to protect
 that data under all circumstances. At runtime you will protect it with SSL
 transport encryption and strong authentication, but when the data is already

--- a/site/content/3.11/release-notes/version-3.6/whats-new-in-3-6.md
+++ b/site/content/3.11/release-notes/version-3.6/whats-new-in-3-6.md
@@ -562,7 +562,8 @@ operand can be a collection or another View.
 
 ## OneShard
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Not all use cases require horizontal scalability. In such cases, a OneShard
 deployment offers a practicable solution that enables significant performance
 improvements by massively reducing cluster-internal communication.

--- a/site/content/3.12/aql/functions/arangosearch.md
+++ b/site/content/3.12/aql/functions/arangosearch.md
@@ -1273,7 +1273,8 @@ FOR doc IN viewName
 
 ## Search Highlighting Functions
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ### OFFSET_INFO()
 
 `OFFSET_INFO(doc, paths) → offsetInfo`

--- a/site/content/3.12/aql/graphs/traversals.md
+++ b/site/content/3.12/aql/graphs/traversals.md
@@ -136,9 +136,11 @@ FOR vertex[, edge[, path]]
     case when a nested traversal is fed with several tens of thousands of start
     vertices, which can then be distributed randomly to worker threads for parallel
     execution.
-    {{< tag "ArangoDB Enterprise""ArangoGraph" >}}  - **maxProjections** (number, *optional*): Specifies the number of document
+    {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+  - **maxProjections** (number, *optional*): Specifies the number of document
     attributes per FOR loop to be used as projections. The default value is `5`.
-    {{< tag "ArangoDB Enterprise""ArangoGraph" >}}  - **weightAttribute** (string, *optional*): Specifies the name of an attribute
+    {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+  - **weightAttribute** (string, *optional*): Specifies the name of an attribute
     that is used to look up the weight of an edge. If no attribute is specified
     or if it is not present in the edge document then the `defaultWeight` is used.
     The attribute value must not be negative.

--- a/site/content/3.12/aql/how-to-invoke-aql/with-arangosh.md
+++ b/site/content/3.12/aql/how-to-invoke-aql/with-arangosh.md
@@ -489,7 +489,8 @@ deployment, then the Coordinator is allowed to read from any shard replica and
 not only from the leader. See [Read from followers](../../develop/http/documents.md#read-from-followers)
 for details.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 #### `skipInaccessibleCollections`
 
 Let AQL queries (especially graph traversals) treat collection to which a
@@ -499,14 +500,16 @@ This is intended to help with certain use-cases: A graph contains several collec
 and different users execute AQL queries on that graph. You can naturally limit the 
 accessible results by changing the access rights of users on collections.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 #### `satelliteSyncWait`
 
 Configure how long a DB-Server has time to bring the SatelliteCollections
 involved in the query into sync. The default value is `60.0` seconds.
 When the maximal time is reached, the query is stopped.
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## With `db._createStatement()` (ArangoStatement)
 
 The `_query()` method is a shorthand for creating an `ArangoStatement` object,

--- a/site/content/3.12/arangograph/backups.md
+++ b/site/content/3.12/arangograph/backups.md
@@ -16,7 +16,7 @@ To backup data in ArangoGraph for an ArangoDB installation, navigate to the
 There are two ways to create backups. Create periodic backups using a
 **Backup policy**, or create a backup manually.
 Both ways allow you to create [backups in multiple regions](#multi-region-backups)
-as well, if your organization belongs to the Enterprise tier.
+as well.
 
 ### Periodic backups
 
@@ -35,8 +35,7 @@ These backups are not automatically uploaded. To enable this, use the
 **Upload backup to storage** option and choose a retention period that
 specifies how long backups are retained after creation. 
 
-If your organization belongs to the Enterprise tier and the
-**Upload backup to storage** option is enabled for a backup policy,
+If the **Upload backup to storage** option is enabled for a backup policy,
 you can then create backups in different regions than the default one.
 The regions where the default backup is copied are shown in the
 **Additional regions** column in the **Policies** section.
@@ -49,8 +48,7 @@ It's also possible to create a backup on demand. To do this, click **Back up now
 
 ![Back up Now Dialog](../../images/arangograph-back-up-now-dialog.png)
 
-If your organization belongs to the Enterprise tier and you want to manually
-copy a backup to a different region than the default
+If you want to manually copy a backup to a different region than the default
 one, first ensure that the **Upload backup to storage** option is enabled.
 Then, highlight the backup row and use the
 **Copy backup to a different region** button from the **Actions** column. 
@@ -104,13 +102,6 @@ alternatives such as having hourly backups with a retention period of a year.
 
 ## Multi-region backups
 
-{{< info >}}
-The multi-region backup feature is only available for the ArangoGraph
-Enterprise tier. To upgrade to the Enterprise tier,
-[get in touch](https://www.arangodb.com/contact/)
-with the ArangoDB team.
-{{< /info >}}
-
 Using the multi-region backup feature, you can store backups in multiple regions
 simultaneously either manually or automatically as part of a **Backup policy**.
 If a backup created in one region goes down, it is still available in other
@@ -146,8 +137,7 @@ During restore, the deployment is temporarily not available.
 {{< info >}}
 The cloned deployment will have the exact same features as the previous
 deployment including node size, model, and cloud provider. The region
-can stay the same or you can select a different one if your organization belongs
-to the Enterprise tier.
+can stay the same or you can select a different one.
 For restoring a deployment as quick as possible, it is recommended to create a
 deployment in the same region as where the backup resides to avoid cross-region
 data transfer.

--- a/site/content/3.12/arangograph/deployments/_index.md
+++ b/site/content/3.12/arangograph/deployments/_index.md
@@ -31,12 +31,6 @@ its projects and deployments.
 4. Click the __New deployment__ button.
 5. Set up your deployment. The configuration options are described below.
 
-   {{< info >}}
-   The configuration options depend on the tier your organization belongs to.
-   For more details about available resources and usage limits, refer to the 
-   [ArangoGraph tiers](../organizations/_index.md#arangograph-tiers) section.
-   {{< /info >}}
-
 ![ArangoGraph New Deployment](../../../images/arangograph-new-deployment1.png)
 
 {{< info >}}
@@ -95,13 +89,8 @@ provider and region in the Location section.
 
 #### OneShard
 
-1. Select the memory size of your node.
-2. Select the CPU size of your node.
-3. Select the initial disk size of your node. The available ranges for the disk size
-   depend on the selected memory size.
-4. Select the upper limit for the disk size. It defaults to twice the initial
-   disk size. You can set it to the same value as the initial disk size to
-   disable automatic disk sizing.
+- Select the memory size of your node. The disk size is automatically set for you
+  based on the selected memory size.
 
 {{< info >}}
 A deployment's node disk size is automatically increased by 25% when the maximal
@@ -115,16 +104,17 @@ the upper disk size limit already.
 
 #### Sharded
 
-- In addition to memory and disk size as in the OneShard configuration, select
+- In addition to the memory size as in the OneShard configuration, select
   the number of nodes for your deployment. The more nodes you have, the higher
-  the replication factor can be.
+  the replication factor can be. Same as in OneShard, the disk size is automatically
+  set for you.
 
 ![ArangoGraph Deployment Sharded](../../../images/arangograph-new-deployment-sharded.png)
 
 #### Single Server
 
-- Like with OneShard and Sharded deployments, you choose memory and disk size.
-  However note that the sizes you choose are for the entire deployment.
+- Like with OneShard and Sharded deployments, you can choose the memory size.
+  Note, however, that the size you choose is for the entire deployment.
   For OneShard and Sharded deployments the chosen sizes are per node.
 
 ![ArangoGraph Deployment Single Server](../../../images/arangograph-new-deployment-singleserver.png)
@@ -251,7 +241,7 @@ are using the `18529` port to avoid breaking changes.
 ## How to edit a deployment
 
 You can modify a deployment’s configuration, including the ArangoDB version
-that is being used, change the memory, CPU, and disk size, or even switch from
+that is being used, change the memory size, or even switch from
 a OneShard deployment to a Sharded one if your data set no longer fits in a
 single node. 
 
@@ -259,12 +249,6 @@ single node.
 To edit an existing deployment, you must have the necessary set of permissions
 attached to your role. Read more about [roles and permissions](../security-and-access-control/_index.md#roles).
 {{< /tip >}}
-
-{{< info >}}
-The configuration options depend on the tier your organization belongs to.
-For more details about available resources and usage limits, refer to the 
-[ArangoGraph tiers](../organizations/_index.md#arangograph-tiers) section.
-{{< /info >}}
 
 1. Go to the **Projects** section and select an existing deployment from the list. 
 2. Open the deployment you want to change. 
@@ -275,12 +259,7 @@ For more details about available resources and usage limits, refer to the
    - Select a different CA certificate.
    - Add or remove an IP allowlist.
 5. In the **Configuration** section, you can do the following:
-   - Upgrade the memory size per node. 
-   - Modify the CPU per node from General to Low or vice-versa, if made available
-     by the cloud provider.
-   - Select a different disk size per node. The available ranges for the disk size
-     depend on the selected memory size. To enable automatic disk size scaling, move
-     the slider to a value higher than the current disk size.
+   - Upgrade the memory size per node. The disk size is automatically set for you.
    - Change **OneShard** deployments into **Sharded** deployments. To do so,
      click **Sharded**. In addition to the other configuration options, you can
      select the number of nodes for your deployment. This can also be modified later on.
@@ -288,15 +267,10 @@ For more details about available resources and usage limits, refer to the
    {{< warning >}}
    Notice that you cannot switch from **Sharded** back to **OneShard**.
    {{< /warning >}}
-   
-   - AWS deployments have an additional option that allows you to select the
-     **Disk Performance** either with general settings, or optimized for large
-     and very large data sets. This option is dependent on the selected memory
-     size. For example, larger deployments have optimized settings by default.
 
    {{< warning >}}
-   When upgrading the memory size, disk size, and/or disk performance in AWS deployments,
-   the value gets locked and cannot be changed until the cloud provider rate limit is reset.  
+   When upgrading the memory size in AWS deployments, the value gets locked and
+   cannot be changed until the cloud provider rate limit is reset. 
    {{< /warning >}}
 
 6. All changes are reflected in the **Summary** section. Review the new

--- a/site/content/3.12/arangograph/deployments/private-endpoints.md
+++ b/site/content/3.12/arangograph/deployments/private-endpoints.md
@@ -12,11 +12,6 @@ securely deploy to various cloud providers such as Google Cloud Platform (GCP),
 Microsoft Azure, and Amazon Web Services (AWS). Follow the steps outlined below
 to get started.
 
-{{< info >}}
-The private endpoint feature is only available on the
-[Enterprise tier](../organizations/_index.md#arangograph-tiers) of ArangoGraph.
-{{< /info >}}
-
 {{< tip >}}
 Private endpoints on Microsoft Azure can be cross region; in AWS they should be
 located in the same region.
@@ -53,9 +48,7 @@ service attachment that you need during the creation of your private endpoint(s)
 
 1. Open the deployment you want to change.
 2. On the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier. 
+   icon. 
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment Private Endpoint Menu](../../../images/arangograph-gcp-change.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.
@@ -99,9 +92,7 @@ please contact support via **Request help** in the help menu.
 
 1. Open the deployment you want to change.
 2. On the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier.
+   icon.
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment Private Endpoint Menu](../../../images/arangograph-deployment-private-endpoint-menu.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.
@@ -156,9 +147,7 @@ that automatically connects to private endpoints that are created in those princ
 
 1. Open the deployment you want to change.
 2. In the **Overview** tab, click the **Edit** button with an ellipsis (`…`)
-   icon. If you see a pencil icon and no menu opens, then you are on the
-   Free-to-try or Professional tier. The private endpoint service is only available
-   if your organization belongs to the Enterprise tier.
+   icon.
 3. Click **Change to private endpoint** in the menu.
    ![ArangoGraph Deployment AWS Change to Private Endpoint](../../../images/arangograph-aws-change-to-private-endpoint.png)
 4. In the configuration wizard, click **Next** to enter your configuration details.

--- a/site/content/3.12/arangograph/deployments/upgrades-and-versioning.md
+++ b/site/content/3.12/arangograph/deployments/upgrades-and-versioning.md
@@ -115,6 +115,5 @@ ArangoGraph aims to give approximately one week’s notice prior to upgrading yo
 deployments to the latest patch release. Although in exceptional circumstances
 (such as a critical security issue) the upgrade may be triggered with less than
 one week's notice.
-The upgrade is carried out automatically. However, if your organization belongs 
-to the Enterprise tier, you contact the ArangoGraph Support team to request that
-this upgrade is manually deferred temporarily.
+The upgrade is carried out automatically. However, if you need the upgrade to be
+deferred temporarily, contact the ArangoGraph Support team to request that.

--- a/site/content/3.12/arangograph/notebooks.md
+++ b/site/content/3.12/arangograph/notebooks.md
@@ -58,8 +58,8 @@ favorite GraphML libraries with GPUs.
 
 {{< info >}}
 Depending on the tier your organization belongs to, different limitations apply:
-- Professional and Enterprise tiers: you can create up to three notebooks per deployment.
-- Free-to-try tier: you can only create one notebook per deployment.  
+- On-Demand and Committed: you can create up to three notebooks per deployment.
+- Free-to-try: you can only create one notebook per deployment.
 {{< /info >}}
 
 ![Notebooks](../../images/arangograph-notebooks.png)

--- a/site/content/3.12/arangograph/organizations/_index.md
+++ b/site/content/3.12/arangograph/organizations/_index.md
@@ -30,50 +30,57 @@ member of one _Free-to-try_ tier organization at a time.
 
 ![ArangoGraph Organization Overview](../../../images/arangograph-organization-overview.png)
 
-## ArangoGraph tiers
+## ArangoGraph Packages
 
-With the ArangoGraph Insights Platform, your organization can belong to one of the following three tiers:
+With the ArangoGraph Insights Platform, your organization can choose one of the
+following packages.
 
-- **Free-to-try tier**: ArangoGraph comes with a free-to-try tier that lets
-you test ArangoGraph for free for 14 days. After the trial period,
-your deployments will be deleted automatically. Includes the Basic Support plan,
-which covers the availability and connectivity of the ArangoGraph Insights Platform, and general questions.
-- **Professional tier**: Allows you to create additional organizations and
-projects, and have more and larger deployments. Includes the Standard support for
-professional deployments, which covers everything from the Basic support plan
-with explicit response times.
-- **Enterprise tier**: Get unlimited access to all functionalities and resources,
-with the best available support and response times. Includes the Premium Standard
-support plan.
+### Free Trial
 
-| &nbsp;| Free-to-try  | Professional  | Enterprise  |
-|-------|:--------------:|:---------------:|:-------------:|
-| **Organizations per user** | 1 | Unlimited | Unlimited |
-| **Projects per organization** | 1 | 3 | Unlimited |
-| **Deployments per project** | 1 | 5 | Unlimited |
-| **Upload backup** | Not included | Included | Included |
-| **Private endpoint deployment** | Not included | Not included | Included |
-| **Support plan** | Basic | Standard | Premium Standard |
+ArangoGraph comes with a free-to-try tier that lets you test ArangoGraph for
+free for 14 days. You can get started quickly, without needing to enter a
+credit card.
 
-{{< info >}}
-Based on the type of tier your organization belongs to, different usage
-limits apply for memory and storage.
-{{< /info >}}
+The free trial gives you access to:
+- One small deployment (4GB) in a region of your choice for 14 days
+- Local backups
+- One ArangoGraph Notebook for learning and data science
 
-## How to upgrade to Professional tier
+After the trial period, your deployment will be deleted automatically.
 
-You can upgrade to the professional service model at any time by adding
-your billing details and at least one payment method. You can then create
-additional organizations and projects and have more and larger deployments.
+### On-Demand
+
+Add a payment payment method to gain access to ArangoGraph's full feature set.
+Pay monthly via a credit card for what you actually use.
+
+This package unlocks all ArangoGraph functionality, including:
+- Multiple and larger deployments
+- Backups to cloud storage, with multi-region support
+- Enhanced security features such as Private Endpoints
+
+### Committed
+
+Commit up-front for a year and pay via the Sales team. This package provides
+the same flexibility of On-Demand, but at a lower price. 
+
+In addition, you gain access to:
+- 24/7 Premium Support
+- ArangoDB Professional Services Engagements
+- Ability to transact via the AWS and GCP marketplaces
+
+To take advantage of this, you need to get in touch with the ArangoDB
+team. [Contact us](https://www.arangodb.com/contact/) for more details.
+
+## How to unlock all features
+
+You can unlock all features in ArangoGraph at any time by adding your billing
+details and a payment method. As soon as you have added a payment method, all
+ArangoGraph functionalities are immediately unlocked. From that point on, your
+deployments will no longer expire and you can create more and larger deployments.
 
 See [Billing: How to add billing details / payment methods](billing.md)
 
 ![ArangoGraph Billing](../../../images/arangograph-billing.png)
-
-## How to upgrade to Enterprise tier
-
-To upgrade to the Enterprise tier, you need to get in touch with the ArangoDB
-team. [Contact us](https://www.arangodb.com/contact/) for more details.
 
 ## How to create a new organization
 

--- a/site/content/3.12/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.12/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -6,10 +6,6 @@ description: >-
   Single Sign-On (SSO) using SAML 2.0
 archetype: chapter
 ---
-{{< info >}}
-This feature is only available in ArangoGraph Enterprise.
-{{< /info >}}
-
 ArangoGraph provides support to enable **Single Sign-On** (SSO) authentication
 using **Security Assertion Markup language 2.0** (SAML 2.0).
 

--- a/site/content/3.12/arangograph/security-and-access-control/single-sign-on/scim-provisioning.md
+++ b/site/content/3.12/arangograph/security-and-access-control/single-sign-on/scim-provisioning.md
@@ -6,10 +6,6 @@ description: >-
   How to enable SCIM provisioning
 archetype: default
 ---
-{{< info >}}
-This feature is only available in ArangoGraph Enterprise.
-{{< /info >}}
-
 ArangoGraph provides support to control and manage members access in
 ArangoGraph organizations with the
 **System for Cross-domain Identity Management** (SCIM) provisioning. 

--- a/site/content/3.12/components/arangodb-server/ldap.md
+++ b/site/content/3.12/components/arangodb-server/ldap.md
@@ -6,7 +6,8 @@ description: >-
   LDAP authentication options in the ArangoDB server
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## Basics Concepts
 
 The basic idea is that one can keep the user authentication setup for

--- a/site/content/3.12/components/tools/arangobackup/_index.md
+++ b/site/content/3.12/components/tools/arangobackup/_index.md
@@ -13,6 +13,7 @@ Use [_arangodump_](../arangodump/_index.md) and
 [logical backups](../../../operations/backup-and-restore.md#logical-backups) in the Community Edition.
 {{< /info >}}
 {{< tag "ArangoDB Enterprise" >}}
+
 _Arangobackup_ is a command-line client tool for instantaneous and
 consistent [hot backups](../../../operations/backup-and-restore.md#hot-backups) of the data and
 structures stored in ArangoDB.

--- a/site/content/3.12/components/tools/arangodump/examples.md
+++ b/site/content/3.12/components/tools/arangodump/examples.md
@@ -158,7 +158,8 @@ INFO [66c0e] {dump} Processed 2 collection(s) from 1 database(s) in 0.132990 s t
 
 ## Encryption
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 You can encrypt dumps using an encryption keyfile, which must contain exactly 32
 bytes of data (required by the AES block cipher).
 

--- a/site/content/3.12/components/tools/arangodump/maskings.md
+++ b/site/content/3.12/components/tools/arangodump/maskings.md
@@ -469,7 +469,8 @@ processed by a single masking function, ignoring any other rules below it.
 
 ## Masking Functions
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - [Xify Front](#xify-front)
 - [Zip](#zip)
 - [Datetime](#datetime)

--- a/site/content/3.12/data-science/pregel/_index.md
+++ b/site/content/3.12/data-science/pregel/_index.md
@@ -41,7 +41,8 @@ In cluster mode, the collections need to be sharded in a specific way to ensure
 correct results: The outgoing edges of a vertex need to be on the same DB-Server
 as the vertex. This is guaranteed by [SmartGraphs](../../graphs/smartgraphs/_index.md).
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Note that the performance may be better, if the number of your shards /
 collections matches the number of CPU cores.
 

--- a/site/content/3.12/deploy/arangosync/_index.md
+++ b/site/content/3.12/deploy/arangosync/_index.md
@@ -9,6 +9,7 @@ archetype: chapter
 {{< description >}}
 
 {{< tag "ArangoDB Enterprise" >}}
+
 This chapter introduces ArangoDB's _Datacenter-to-Datacenter Replication_ (DC2DC).
 
 At some point in the grows of a database, there comes a need for replicating it

--- a/site/content/3.12/deploy/arangosync/administration.md
+++ b/site/content/3.12/deploy/arangosync/administration.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the synchronization process
 of the _Datacenter-to-Datacenter Replication_.
 

--- a/site/content/3.12/deploy/arangosync/deployment/_index.md
+++ b/site/content/3.12/deploy/arangosync/deployment/_index.md
@@ -7,6 +7,7 @@ description: >-
 archetype: chapter
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This chapter describes how to deploy all the components needed for
 _Datacenter-to-Datacenter Replication (DC2DC)_.
 

--- a/site/content/3.12/deploy/arangosync/monitoring.md
+++ b/site/content/3.12/deploy/arangosync/monitoring.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the monitoring of the
 _Datacenter-to-Datacenter Replication_.
 

--- a/site/content/3.12/deploy/arangosync/operations-and-maintenance.md
+++ b/site/content/3.12/deploy/arangosync/operations-and-maintenance.md
@@ -9,6 +9,7 @@ archetype: default
 ## Operations & Maintenance
 
 {{< tag "ArangoDB Enterprise" >}}
+
 ArangoSync is a distributed system with a lot different components.
 As with any such system, it requires some, but not a lot of operational
 support.

--- a/site/content/3.12/deploy/arangosync/security.md
+++ b/site/content/3.12/deploy/arangosync/security.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 This section includes information related to the _Datacenter-to-Datacenter Replication_
 security.
 

--- a/site/content/3.12/deploy/arangosync/troubleshooting.md
+++ b/site/content/3.12/deploy/arangosync/troubleshooting.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 The _Datacenter-to-Datacenter Replication_ is a distributed system with a lot
 different components. As with any such system, it requires some, but not a lot,
 of operational support.

--- a/site/content/3.12/deploy/deployment/kubernetes/deployment-replication-resource-reference.md
+++ b/site/content/3.12/deploy/deployment/kubernetes/deployment-replication-resource-reference.md
@@ -7,6 +7,7 @@ description: >-
 archetype: default
 ---
 {{< tag "ArangoDB Enterprise" >}}
+
 The ArangoDB Replication Operator creates and maintains ArangoDB
 `arangosync` configurations in a Kubernetes cluster, given a replication specification.
 This replication specification is a `CustomResource` following

--- a/site/content/3.12/deploy/deployment/oneshard.md
+++ b/site/content/3.12/deploy/deployment/oneshard.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 The OneShard option for ArangoDB clusters restricts all collections of a
 database to a single shard and places them on one DB-Server node. This way,
 whole queries can be pushed to and executed on that server, massively reducing

--- a/site/content/3.12/develop/http/administration.md
+++ b/site/content/3.12/develop/http/administration.md
@@ -556,6 +556,11 @@ paths:
       description: |
         Return availability information about a server.
 
+        The response is a JSON object with an attribute "mode". The "mode" can either
+        be "readonly", if the server is in read-only mode, or "default", if it is not.
+        Please note that the JSON object with "mode" is only returned in case the server
+        does not respond with HTTP response code 503.
+
         This is a public API so it does *not* require authentication. It is meant to be
         used only in the context of server monitoring.
       responses:
@@ -568,23 +573,6 @@ paths:
           description: |
             HTTP 503 will be returned in case the server is during startup or during shutdown,
             is set to read-only mode or is currently a follower in an Active Failover deployment setup.
-      tags:
-        - Administration
-```
-```openapi
-### Get the required database version
-
-paths:
-  /_admin/database/target-version:
-    get:
-      operationId: getDatabaseVersion
-      description: |
-        Returns the database version that this server requires.
-        The version is returned in the `version` attribute of the result.
-      responses:
-        '200':
-          description: |
-            Is returned in all cases.
       tags:
         - Administration
 ```

--- a/site/content/3.12/develop/http/authentication.md
+++ b/site/content/3.12/develop/http/authentication.md
@@ -275,6 +275,7 @@ curl -v -H "Authorization: bearer $(jwtgen -s <my-secret> -e 3600 -a "HS256" -c 
 ## Hot-reload JWT secrets
 
 {{< tag "ArangoDB Enterprise" >}}
+
 To reload the JWT secrets of a local arangod process without a restart, you
 may use the following RESTful API. A `POST` request reloads the secret, a
 `GET` request may be used to load information about the currently used secrets.

--- a/site/content/3.12/develop/http/collections.md
+++ b/site/content/3.12/develop/http/collections.md
@@ -1179,7 +1179,7 @@ paths:
                 shardingStrategy:
                   description: |
                     This attribute specifies the name of the sharding strategy to use for
-                    the collection. Since ArangoDB 3.4 there are different sharding strategies
+                    the collection. There are different sharding strategies
                     to select from when creating a new collection. The selected `shardingStrategy`
                     value remains fixed for the collection and cannot be changed afterwards.
                     This is important to make the collection keep its sharding settings and

--- a/site/content/3.12/develop/http/documents.md
+++ b/site/content/3.12/develop/http/documents.md
@@ -385,16 +385,6 @@ paths:
             Name of the `collection` in which the document is to be created.
           schema:
             type: string
-        - name: collection
-          in: query
-          required: false
-          description: |
-            The name of the collection. This query parameter is only for backward compatibility.
-            In ArangoDB versions < 3.0, the URL path was `/_api/document` and
-            this query parameter was required. This combination still works, but
-            the recommended way is to specify the collection in the URL path.
-          schema:
-            type: string
         - name: waitForSync
           in: query
           required: false
@@ -1697,16 +1687,6 @@ paths:
             Name of the `collection` in which the documents are to be created.
           schema:
             type: string
-        - name: collection
-          in: query
-          required: false
-          description: |
-            The name of the collection. This is only for backward compatibility.
-            In ArangoDB versions < 3.0, the URL path was `/_api/document` and
-            this query parameter was required. This combination still works, but
-            the recommended way is to specify the collection in the URL path.
-          schema:
-            type: string
         - name: waitForSync
           in: query
           required: false
@@ -2621,7 +2601,8 @@ name: RestDocumentHandlerDeleteDocumentRevConflictMulti
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 In an ArangoDB cluster, all reads and writes are performed via
 the shard leaders. Shard replicas replicate all operations, but are
 only on hot standby to take over in case of a failure. This is to ensure

--- a/site/content/3.12/develop/http/hot-backups.md
+++ b/site/content/3.12/develop/http/hot-backups.md
@@ -10,6 +10,7 @@ archetype: default
 {{< description >}}
 
 {{< tag "ArangoDB Enterprise" >}}
+
 Hot Backups are near instantaneous consistent snapshots of an
 **entire** ArangoDB deployment. This includes all databases, collections,
 indexes, Views, graphs, and users at any given time.

--- a/site/content/3.12/develop/http/indexes/inverted.md
+++ b/site/content/3.12/develop/http/indexes/inverted.md
@@ -398,6 +398,32 @@ paths:
                     cache in cluster deployments by only using the cache for leader shards, see the
                     `--arangosearch.columns-cache-only-leader` startup option (introduced in v3.10.6).
                   type: boolean
+                optimizeTopK:
+                  description: |
+                    This option only applies if you use the inverted index in a `search-alias` Views.
+
+                    An array of strings defining sort expressions that you want to optimize.
+                    This is also known as _WAND optimization_ (introduced in v3.12.0).
+
+                    If you query a View with the `SEARCH` operation in combination with a
+                    `SORT` and `LIMIT` operation, search results can be retrieved faster if the
+                    `SORT` expression matches one of the optimized expressions.
+
+                    Only sorting by highest rank is supported, that is, sorting by the result
+                    of a scoring function in descending order (`DESC`). Use `@doc` in the expression
+                    where you would normally pass the document variable emitted by the `SEARCH`
+                    operation to the scoring function.
+
+                    You can define up to 64 expressions per View.
+
+                    Example: `["BM25(@doc) DESC", "TFIDF(@doc, true) DESC"]`
+
+                    Default: `[]`
+
+                    This property is available in the Enterprise Edition only.
+                  type: array
+                  items:
+                    type: string
                 analyzer:
                   description: |
                     The name of an Analyzer to use by default. This Analyzer is applied to the

--- a/site/content/3.12/develop/http/pregel.md
+++ b/site/content/3.12/develop/http/pregel.md
@@ -216,24 +216,24 @@ paths:
                   state:
                     description: |
                       The state of the execution. The following values can be returned:
-                      - `"none"`: The Pregel run did not yet start.
-                      - `"loading"`: The graph is loaded from the database into memory before the execution of the algorithm.
+                      - `"none"`: The Pregel run has not started yet.
+                      - `"loading"`: The graph is being loaded from the database into memory before
+                        executing the algorithm.
                       - `"running"`: The algorithm is executing normally.
                       - `"storing"`: The algorithm finished, but the results are still being written
-                        back into the collections. Occurs only if the store parameter is set to true.
-                      - `"done"`: The execution is done. In version 3.7.1 and later, this means that
-                        storing is also done. In earlier versions, the results may not be written back
-                        into the collections yet. This event is announced in the server log (requires
-                        at least info log level for the `pregel` log topic).
+                        back into the collections. Only occurs if the `store` parameter is set to `true`.
+                      - `"done"`: The execution is done. This means that storing is also done.
+                        This event is announced in the server log (requires at least the `info`
+                        log level for the `pregel` log topic).
                       - `"canceled"`: The execution was permanently canceled, either by the user or by
                         an error.
-                      - `"fatal error"`: The execution has failed and cannot recover.
-                      - `"in error"`: The execution is in an error state. This can be
-                        caused by DB-Servers being not reachable or being non responsive. The execution
-                        might recover later, or switch to `"canceled"` if it was not able to recover
+                      - `"in error"`: The execution is in an error state. This can be caused by
+                        primary DB-Servers being unreachable or unresponsive. The execution
+                        might recover later, or switch to `"canceled"` if it is not able to recover
                         successfully.
-                      - `"recovering"` (currently unused): The execution is actively recovering and
+                      - `"recovering"`: The execution is actively recovering and
                         switches back to `running` if the recovery is successful.
+                      - `"fatal error"`: The execution has failed and cannot recover.
                     type: string
                   gss:
                     description: |
@@ -470,24 +470,24 @@ paths:
                     state:
                       description: |
                         The state of the execution. The following values can be returned:
-                        - `"none"`: The Pregel run did not yet start.
-                        - `"loading"`: The graph is loaded from the database into memory before the execution of the algorithm.
+                        - `"none"`: The Pregel run has not started yet.
+                        - `"loading"`: The graph is being loaded from the database into memory before
+                          executing the algorithm.
                         - `"running"`: The algorithm is executing normally.
                         - `"storing"`: The algorithm finished, but the results are still being written
-                          back into the collections. Occurs only if the store parameter is set to true.
-                        - `"done"`: The execution is done. In version 3.7.1 and later, this means that
-                          storing is also done. In earlier versions, the results may not be written back
-                          into the collections yet. This event is announced in the server log (requires
-                          at least info log level for the `pregel` log topic).
+                          back into the collections. Only occurs if the `store` parameter is set to `true`.
+                        - `"done"`: The execution is done. This means that storing is also done.
+                          This event is announced in the server log (requires at least the `info`
+                          log level for the `pregel` log topic).
                         - `"canceled"`: The execution was permanently canceled, either by the user or by
                           an error.
-                        - `"fatal error"`: The execution has failed and cannot recover.
-                        - `"in error"`: The execution is in an error state. This can be
-                          caused by DB-Servers being not reachable or being non responsive. The execution
-                          might recover later, or switch to `"canceled"` if it was not able to recover
+                        - `"in error"`: The execution is in an error state. This can be caused by
+                          primary DB-Servers being unreachable or unresponsive. The execution
+                          might recover later, or switch to `"canceled"` if it is not able to recover
                           successfully.
-                        - `"recovering"` (currently unused): The execution is actively recovering and
+                        - `"recovering"`: The execution is actively recovering and
                           switches back to `running` if the recovery is successful.
+                        - `"fatal error"`: The execution has failed and cannot recover.
                       type: string
                     gss:
                       description: |
@@ -804,24 +804,24 @@ paths:
                   state:
                     description: |
                       The state of the execution. The following values can be returned:
-                      - `"none"`: The Pregel run did not yet start.
-                      - `"loading"`: The graph is loaded from the database into memory before the execution of the algorithm.
+                      - `"none"`: The Pregel run has not started yet.
+                      - `"loading"`: The graph is being loaded from the database into memory before
+                        executing the algorithm.
                       - `"running"`: The algorithm is executing normally.
                       - `"storing"`: The algorithm finished, but the results are still being written
-                        back into the collections. Occurs only if the store parameter is set to true.
-                      - `"done"`: The execution is done. In version 3.7.1 and later, this means that
-                        storing is also done. In earlier versions, the results may not be written back
-                        into the collections yet. This event is announced in the server log (requires
-                        at least info log level for the `pregel` log topic).
+                        back into the collections. Only occurs if the `store` parameter is set to `true`.
+                      - `"done"`: The execution is done. This means that storing is also done.
+                        This event is announced in the server log (requires at least the `info`
+                        log level for the `pregel` log topic).
                       - `"canceled"`: The execution was permanently canceled, either by the user or by
                         an error.
-                      - `"fatal error"`: The execution has failed and cannot recover.
-                      - `"in error"`: The execution is in an error state. This can be
-                        caused by DB-Servers being not reachable or being non responsive. The execution
-                        might recover later, or switch to `"canceled"` if it was not able to recover
+                      - `"in error"`: The execution is in an error state. This can be caused by
+                        primary DB-Servers being unreachable or unresponsive. The execution
+                        might recover later, or switch to `"canceled"` if it is not able to recover
                         successfully.
-                      - `"recovering"` (currently unused): The execution is actively recovering and
+                      - `"recovering"`: The execution is actively recovering and
                         switches back to `running` if the recovery is successful.
+                      - `"fatal error"`: The execution has failed and cannot recover.
                     type: string
                   gss:
                     description: |
@@ -1064,24 +1064,24 @@ paths:
                     state:
                       description: |
                         The state of the execution. The following values can be returned:
-                        - `"none"`: The Pregel run did not yet start.
-                        - `"loading"`: The graph is loaded from the database into memory before the execution of the algorithm.
+                        - `"none"`: The Pregel run has not started yet.
+                        - `"loading"`: The graph is being loaded from the database into memory before
+                          executing the algorithm.
                         - `"running"`: The algorithm is executing normally.
                         - `"storing"`: The algorithm finished, but the results are still being written
-                          back into the collections. Occurs only if the store parameter is set to true.
-                        - `"done"`: The execution is done. In version 3.7.1 and later, this means that
-                          storing is also done. In earlier versions, the results may not be written back
-                          into the collections yet. This event is announced in the server log (requires
-                          at least info log level for the `pregel` log topic).
+                          back into the collections. Only occurs if the `store` parameter is set to `true`.
+                        - `"done"`: The execution is done. This means that storing is also done.
+                          This event is announced in the server log (requires at least the `info`
+                          log level for the `pregel` log topic).
                         - `"canceled"`: The execution was permanently canceled, either by the user or by
                           an error.
-                        - `"fatal error"`: The execution has failed and cannot recover.
-                        - `"in error"`: The execution is in an error state. This can be
-                          caused by DB-Servers being not reachable or being non responsive. The execution
-                          might recover later, or switch to `"canceled"` if it was not able to recover
+                        - `"in error"`: The execution is in an error state. This can be caused by
+                          primary DB-Servers being unreachable or unresponsive. The execution
+                          might recover later, or switch to `"canceled"` if it is not able to recover
                           successfully.
-                        - `"recovering"` (currently unused): The execution is actively recovering and
+                        - `"recovering"`: The execution is actively recovering and
                           switches back to `running` if the recovery is successful.
+                        - `"fatal error"`: The execution has failed and cannot recover.
                       type: string
                     gss:
                       description: |

--- a/site/content/3.12/develop/http/queries/aql-queries.md
+++ b/site/content/3.12/develop/http/queries/aql-queries.md
@@ -337,6 +337,7 @@ paths:
                     after the specified amount of time. This is useful to ensure garbage collection
                     of cursors that are not fully fetched by clients. If not set, a server-defined
                     value will be used (default: 30 seconds).
+                    The time-to-live is renewed upon every access to the cursor.
                   type: integer
                 cache:
                   description: |
@@ -1349,6 +1350,9 @@ paths:
       operationId: getNextAqlQueryCursorBatch
       description: |
         If the cursor is still alive, returns an object with the next query result batch.
+
+        If the cursor is not fully consumed, the time-to-live for the cursor
+        is renewed by this API call.
       parameters:
         - name: cursor-identifier
           in: path
@@ -1856,6 +1860,9 @@ paths:
         still return no documents. If, however, `hasMore` is `false`, then
         the cursor is exhausted.  Once the `hasMore` attribute has a value of
         `false`, the client can stop.
+
+        If the cursor is not fully consumed, the time-to-live for the cursor
+        is renewed by this API call.
       parameters:
         - name: cursor-identifier
           in: path
@@ -1991,6 +1998,8 @@ paths:
         application, it should explicitly delete the cursor to inform the server that it
         successfully received and processed the batch so that the server can free up
         resources.
+
+        The time-to-live for the cursor is renewed by this API call.
       parameters:
         - name: cursor-identifier
           in: path

--- a/site/content/3.12/develop/http/views/arangosearch-views.md
+++ b/site/content/3.12/develop/http/views/arangosearch-views.md
@@ -56,8 +56,7 @@ paths:
                     type: object
                 primarySortCompression:
                   description: |
-                    Defines how to compress the primary sort data (introduced in v3.7.1).
-                    ArangoDB v3.5 and v3.6 always compress the index using LZ4.
+                    Defines how to compress the primary sort data.
 
                     This option is immutable.
 
@@ -94,10 +93,34 @@ paths:
                     cache in cluster deployments by only using the cache for leader shards, see the
                     `--arangosearch.columns-cache-only-leader` startup option (introduced in v3.10.6).
                   type: boolean
+                optimizeTopK:
+                  description: |
+                    An array of strings defining sort expressions that you want to optimize.
+                    This is also known as _WAND optimization_ (introduced in v3.12.0).
+
+                    If you query a View with the `SEARCH` operation in combination with a
+                    `SORT` and `LIMIT` operation, search results can be retrieved faster if the
+                    `SORT` expression matches one of the optimized expressions.
+
+                    Only sorting by highest rank is supported, that is, sorting by the result
+                    of a scoring function in descending order (`DESC`). Use `@doc` in the expression
+                    where you would normally pass the document variable emitted by the `SEARCH`
+                    operation to the scoring function.
+
+                    You can define up to 64 expressions per View.
+
+                    Example: `["BM25(@doc) DESC", "TFIDF(@doc, true) DESC"]`
+
+                    Default: `[]`
+
+                    This property is available in the Enterprise Edition only.
+                  type: array
+                  items:
+                    type: string
                 storedValues:
                   description: |
                     An array of objects to describe which document attributes to store in the View
-                    index (introduced in v3.7.1). It can then cover search queries, which means the
+                    index. It can then cover search queries, which means the
                     data can be taken from the index directly and accessing the storage engine can
                     be avoided.
 

--- a/site/content/3.12/develop/satellitecollections.md
+++ b/site/content/3.12/develop/satellitecollections.md
@@ -6,7 +6,8 @@ description: >-
   Collections synchronously replicated to all servers, available in the Enterprise Edition
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 When doing joins in an ArangoDB cluster data has to be exchanged between different servers.
 
 Joins are executed on a Coordinator. It prepares an execution plan

--- a/site/content/3.12/develop/smartjoins.md
+++ b/site/content/3.12/develop/smartjoins.md
@@ -6,7 +6,8 @@ description: >-
   SmartJoins allow to execute co-located join operations among identically sharded collections.
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 SmartJoins allow to execute co-located join operations among identically
 sharded collections.
 

--- a/site/content/3.12/get-started/set-up-a-cloud-instance.md
+++ b/site/content/3.12/get-started/set-up-a-cloud-instance.md
@@ -138,14 +138,16 @@ Alternatively, follow the steps of the linked guides:
 - [Access your deployment](../arangograph/deployments/_index.md#how-to-access-your-deployment)
 - [Delete your deployment](../arangograph/deployments/_index.md#how-to-delete-a-deployment)
 
-## Free-to-Try vs. Professional Service
+## Free-to-Try vs. Paid
 
-The ArangoGraph Insights Platform comes with a free-to-try tier that lets you test our ArangoDB
-Cloud for free for 14 days. It includes one project and one deployment.
-After the trial period, your deployments are automatically deleted.
+The ArangoGraph Insights Platform comes with a free-to-try tier that lets you test
+the ArangoDB Cloud for free for 14 days. It includes one project and one small
+deployment of 4GB, local backups, and one notebook for learning and data science.
+After the trial period, your deployment is automatically deleted.
 
-You can convert to the professional service model at any time by adding 
+You can unlock all features in ArangoGraph at any time by adding 
 your billing details and at least one payment method. See:
+- [ArangoGraph Packages](../arangograph/organizations/_index.md#arangograph-packages)
 - [How to add billing details to organizations](../arangograph/organizations/billing.md#how-to-add-billing-details)
 - [How to add a payment method to an organization](../arangograph/organizations/billing.md#how-to-add-a-payment-method)
 

--- a/site/content/3.12/graphs/enterprisegraphs/_index.md
+++ b/site/content/3.12/graphs/enterprisegraphs/_index.md
@@ -8,7 +8,8 @@ archetype: chapter
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 This chapter describes the `enterprise-graph` module, a specialized version of
 [SmartGraphs](../smartgraphs/_index.md).
 It will give a vast performance benefit for all graphs sharded

--- a/site/content/3.12/graphs/satellitegraphs/_index.md
+++ b/site/content/3.12/graphs/satellitegraphs/_index.md
@@ -6,7 +6,8 @@ description: >-
   Graphs synchronously replicated to all servers, available in the Enterprise Edition
 archetype: chapter
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## What is a SatelliteGraph?
 
 _SatelliteGraphs_ are a specialized _named graph_ type available for cluster

--- a/site/content/3.12/graphs/smartgraphs/_index.md
+++ b/site/content/3.12/graphs/smartgraphs/_index.md
@@ -6,7 +6,8 @@ description: >-
   SmartGraphs enable you to manage graphs at scale.
 archetype: chapter
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 SmartGraphs are specifically targeted at graphs that need scalability and
 high performance. The way SmartGraphs use the ArangoDB cluster sharding makes it
 extremely useful for distributing data across multiple servers with minimal

--- a/site/content/3.12/graphs/smartgraphs/testing-graphs-on-single-server.md
+++ b/site/content/3.12/graphs/smartgraphs/testing-graphs-on-single-server.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ## General idea
 
 You can create SmartGraphs and SatelliteGraphs in a single server instance and

--- a/site/content/3.12/index-and-search/analyzers.md
+++ b/site/content/3.12/index-and-search/analyzers.md
@@ -1054,7 +1054,8 @@ description: ''
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 An Analyzer that computes so called MinHash signatures using a
 locality-sensitive hash function. It applies an Analyzer of your choice before
 the hashing, for example, to break up text into words.
@@ -1096,7 +1097,8 @@ description: ''
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 {{< warning >}}
 This feature is experimental and under active development.
 The naming and interfaces may change at any time.
@@ -1155,7 +1157,8 @@ db._query(`LET str = "Which baking dish is best to bake a banana bread ?"
 
 <small>Introduced in: v3.10.0</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 {{< warning >}}
 This feature is experimental and under active development.
 The naming and interfaces may change at any time.
@@ -1334,7 +1337,8 @@ description: ''
 
 <small>Introduced in: v3.10.5</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 An Analyzer capable of breaking up a GeoJSON object or coordinate array in
 `[longitude, latitude]` order into a set of indexable tokens for further usage
 with [ArangoSearch Geo functions](../aql/functions/arangosearch.md#geo-functions).

--- a/site/content/3.12/index-and-search/arangosearch/arangosearch-views-reference.md
+++ b/site/content/3.12/index-and-search/arangosearch/arangosearch-views-reference.md
@@ -237,7 +237,8 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ### View Properties
 
 - **primarySort** (_optional_; type: `array`; default: `[]`; _immutable_)
@@ -272,7 +273,8 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - **primaryKeyCache** (_optional_; type: `boolean`; default: `false`; _immutable_)
 
   <small>Introduced in: v3.9.6, v3.10.2</small>
@@ -289,7 +291,8 @@ During view modification the following directives apply:
   [`--arangosearch.columns-cache-only-leader` startup option](../../components/arangodb-server/options.md#--arangosearchcolumns-cache-only-leader)
   (introduced in v3.10.6).
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 - **storedValues** (_optional_; type: `array`; default: `[]`; _immutable_)
 
   An array of objects to describe which document attributes to store in the
@@ -356,7 +359,8 @@ During view modification the following directives apply:
 
   Example: `["BM25(@doc) DESC", "TFIDF(@doc, true) DESC"]`
 
-  {{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+  {{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 An inverted index is the heart of `arangosearch` Views.
 The index consists of several independent segments and the index **segment**
 itself is meant to be treated as a standalone index. **Commit** is meant to be

--- a/site/content/3.12/index-and-search/arangosearch/nested-search.md
+++ b/site/content/3.12/index-and-search/arangosearch/nested-search.md
@@ -10,7 +10,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 By default, `arangosearch` Views index arrays as if the parent attribute had
 multiple values at once. This is also supported for `search-alias` Views by enabling
 the `searchField` option. With `trackListPositions` set to `true`, every array

--- a/site/content/3.12/index-and-search/arangosearch/performance.md
+++ b/site/content/3.12/index-and-search/arangosearch/performance.md
@@ -557,7 +557,8 @@ Also see [Faceted Search with ArangoSearch](faceted-search.md).
 
 <small>Introduced in: v3.9.5, v3.10.2</small>
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Normalization values are computed for fields which are processed with Analyzers
 that have the [`"norm"` feature](../analyzers.md#analyzer-features) enabled.
 These values are used to score fairer if the same tokens occur repeatedly, to

--- a/site/content/3.12/index-and-search/arangosearch/search-highlighting.md
+++ b/site/content/3.12/index-and-search/arangosearch/search-highlighting.md
@@ -9,7 +9,8 @@ archetype: default
 ---
 {{< description >}}
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ArangoSearch lets you search for terms and phrases in full-text, and more.
 It only returns matching documents, however. With search highlighting, you can
 get the exact locations of the matches.

--- a/site/content/3.12/operations/administration/user-management/_index.md
+++ b/site/content/3.12/operations/administration/user-management/_index.md
@@ -329,7 +329,8 @@ database. All changes to the access levels must be done using the
 
 ### LDAP Users
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 ArangoDB supports LDAP as an external authentication system. For detailed
 information please have look into the
 [LDAP configuration guide](../../../components/arangodb-server/ldap.md).

--- a/site/content/3.12/operations/backup-and-restore.md
+++ b/site/content/3.12/operations/backup-and-restore.md
@@ -67,7 +67,8 @@ Hot backup and restore associated operations can be performed with the
 [_arangobackup_](../components/tools/arangobackup/_index.md) client tool and the
 [Hot Backup HTTP API](../develop/http/hot-backups.md).
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Many operations cannot afford downtimes and thus require administrators and
 operators to create consistent freezes of the data during normal operation.
 Such use cases imply that near instantaneous hot backups must be

--- a/site/content/3.12/operations/security/audit-logging.md
+++ b/site/content/3.12/operations/security/audit-logging.md
@@ -18,6 +18,7 @@ A similar feature is also available in the
 [ArangoGraph Insights Platform](../../arangograph/security-and-access-control/_index.md#using-an-audit-log).
 {{< /info >}}
 {{< tag "ArangoDB Enterprise" >}}
+
 ## Configuration
 
 To enable audit logging, set the `--audit.output` startup option to either a

--- a/site/content/3.12/operations/security/encryption-at-rest.md
+++ b/site/content/3.12/operations/security/encryption-at-rest.md
@@ -6,7 +6,8 @@ description: >-
   Securing physical storage media, available in the Enterprise Edition
 archetype: default
 ---
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 When you store sensitive data in your ArangoDB database, you want to protect
 that data under all circumstances. At runtime you will protect it with SSL
 transport encryption and strong authentication, but when the data is already

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -14,6 +14,26 @@ integrations for ArangoDB 3.12.
 
 ### Behavior changes
 
+The following long-deprecated features have been removed from ArangoDB's HTTP
+server:
+
+- Overriding the HTTP method by setting one of the HTTP headers:
+  - `x-http-method`
+  - `x-http-method-override`
+  - `x-method-override`
+
+   This functionality posed a potential security risk and was thus removed.
+   Previously, it was only enabled when explicitly starting the 
+   server with the `--http.allow-method-override` startup option.
+   The functionality has now been removed and setting the startup option does
+   nothing.
+
+- Optionally hiding ArangoDB's `server` response header. This functionality
+  could optionally be enabled by starting the server with the startup option
+  `--http.hide-product-header`.
+  The functionality has now been removed and setting the startup option does
+  nothing.
+
 #### Collection API
 
 When creating a collection using the `POST /_api/collection` endpoint, the
@@ -29,7 +49,14 @@ versions.
 
 ### Endpoint return value changes
 
+#### Storage engine API
 
+- The storage engine API at `GET /_api/engine` does not return the attribute
+  `dfdb` anymore.
+
+- On single servers and DB-Servers, the `GET /_api/engine` endpoint now
+  returns an `endianness` attribute. Currently, only Little Endian is supported
+  as an architecture by ArangoDB. The value is therefore `"little"`.
 
 ### Endpoints added
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -40,6 +40,13 @@ The second option is the recommended one, as it signals the intent more clearly,
 and makes the cache behave "as expected", i.e. use up to the configured
 memory limit and not just 56% of it.
 
+## Client tools
+
+### jslint feature in arangosh
+
+The `--jslint` startup option and all of the underlying functionality has been
+removed from arangosh. The feature was mainly for internal purposes.
+
 ## HTTP RESTful API
 
 ### JavaScript-based traversal using `/_api/traversal`

--- a/site/content/3.12/release-notes/version-3.6/whats-new-in-3-6.md
+++ b/site/content/3.12/release-notes/version-3.6/whats-new-in-3-6.md
@@ -562,7 +562,8 @@ operand can be a collection or another View.
 
 ## OneShard
 
-{{< tag "ArangoDB Enterprise""ArangoGraph" >}}
+{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
+
 Not all use cases require horizontal scalability. In such cases, a OneShard
 deployment offers a practicable solution that enables significant performance
 improvements by massively reducing cluster-internal communication.

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -373,27 +373,21 @@ function toggleExpandShortcode(event) {
 }
 
 function moveTags() {
-    var tags = document.querySelectorAll(".labels")
+    var tags = document.querySelectorAll(".labels");
     for (let tag of tags) {
-        console.log(tag)
         if ($(tag).parent().is("li")) {
-            var x = $(tag).parent();
-            console.log(x)
             $(tag).parent().children()[0].after(tag);
-            //tag.remove();
-            continue
+            continue;
         }
-        if(!tag) continue;
         var prev = tag.previousSibling;
-        var isHeader = $(prev).is(':header')
-        while (!isHeader) {
-          if(!prev) break;
+        var isHeader = $(prev).is(':header, hgroup');
+        while (prev && !isHeader) {
             prev = prev.previousSibling;
-            isHeader = $(prev).is(':header')
+            isHeader = $(prev).is(':header, hgroup');
         }
-        
-        newTag = tag.outerHTML
-        prev && prev.insertAdjacentHTML('afterEnd', newTag);
+        if (!prev) continue;
+        newTag = tag.outerHTML;
+        prev.insertAdjacentHTML('afterEnd', newTag);
         tag.remove();
     }
 }


### PR DESCRIPTION
### Description

- Missing line break after a tag shortcode broke lists
  ```diff
  -{{< tag "ArangoDB Enterprise""ArangoGraph" >}}  - **maxProjections** (number, *optional*): Specifies the number of document
  +{{< tag "ArangoDB Enterprise" "ArangoGraph" >}}
  +- **maxProjections** (number, *optional*): Specifies the number of document
  ```
- Fix logic of moving tags up under headline to check for hgroup (in which our h1 titles reside in)

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
