### PR TITLE
[DOC-528] Toolchain Errors Handling, Logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,9 @@ jobs:
 
             cd docs-hugo/toolchain/docker/amd64
             docker compose up
+            if [ "$?" != "0" ]; then
+              exit "$?"
+            fi
       - run:
           name: Upload summary on GitHub
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,10 +231,8 @@ jobs:
             fi
 
             cd docs-hugo/toolchain/docker/amd64
+            set -e
             docker compose up
-            if [ "$?" != "0" ]; then
-              exit "$?"
-            fi
       - run:
           name: Upload summary on GitHub
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,8 +231,8 @@ jobs:
             fi
 
             cd docs-hugo/toolchain/docker/amd64
-            set -e
-            docker compose up --abort-on-container-exit
+            docker compose up --exit-code-from toolchain
+            exit $?
       - run:
           name: Upload summary on GitHub
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
 
             cd docs-hugo/toolchain/docker/amd64
             set -e
-            docker compose up
+            docker compose up --abort-on-container-exit
       - run:
           name: Upload summary on GitHub
           command: |

--- a/toolchain/arangoproxy/internal/arangosh/arangosh.go
+++ b/toolchain/arangoproxy/internal/arangosh/arangosh.go
@@ -3,7 +3,6 @@ package arangosh
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -24,7 +23,7 @@ func ExecRoutine(example chan map[string]interface{}, outChannel chan string) {
 			models.Logger.Printf("[%s] [CODE] %s", name, code)
 			out := Exec(name, code, repository)
 
-			checkAssertionFailed(name, code, out, repository)
+			out = checkAssertionFailed(name, code, out, repository)
 			out = checkArangoError(name, code, out, repository)
 
 			outChannel <- out
@@ -66,14 +65,15 @@ func Exec(exampleName string, code string, repository models.Repository) (output
 	return
 }
 
-func checkAssertionFailed(name, code, out string, repository models.Repository) {
+func checkAssertionFailed(name, code, out string, repository models.Repository) string {
 	if strings.Contains(out, "EXITD") {
 		models.Logger.Printf("[%s] [ERROR]: Assertion Failed", name)
 		models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, out)
-		models.Logger.Summary("<li><strong>%s</strong>  - %s <strong> ERROR </strong></li><br>", repository.Version, name)
+		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR </strong></error></li><br>", repository.Version, name)
 
-		os.Exit(1)
+		return "ERRORD"
 	}
+	return out
 }
 
 func checkArangoError(name, code, out string, repository models.Repository) string {
@@ -87,9 +87,9 @@ func checkArangoError(name, code, out string, repository models.Repository) stri
 		} else {
 			models.Logger.Printf("[%s] [ERROR]: Found ArangoError without xpError", name)
 			models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, out)
-			models.Logger.Summary("<li><strong>%s</strong>  - %s <strong> ERROR </strong></li><br>", repository.Version, name)
+			models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR </strong></error></li><br>", repository.Version, name)
 
-			os.Exit(1)
+			return "ERRORD"
 		}
 	}
 
@@ -102,9 +102,9 @@ func handleCollectionNotFound(name, code, out string, repository models.Reposito
 	if strings.Contains(output, "ArangoError") && !strings.Contains(code, "xpError") {
 		models.Logger.Printf("[%s] [ERROR]: Found ArangoError without xpError", name)
 		models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, output)
-		models.Logger.Summary("<li><strong>%s</strong>  - %s <strong> ERROR </strong></li><br>", repository.Version, name)
+		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR </strong></error></li><br>", repository.Version, name)
 
-		os.Exit(1)
+		return "ERRORD"
 	}
 
 	return output

--- a/toolchain/arangoproxy/internal/arangosh/arangosh.go
+++ b/toolchain/arangoproxy/internal/arangosh/arangosh.go
@@ -65,8 +65,11 @@ func checkAssertionFailed(name, code, out, filepath string, repository models.Re
 		models.Logger.Printf("[%s] [ERROR]: Assertion Failed", name)
 		models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, out)
 
+		re := regexp.MustCompile(`(?m)JavaScript exception.*`)
 		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR %s</strong></error></li><br>", repository.Version, name, filepath)
-		models.Logger.Summary(out)
+		for _, match := range re.FindAllString(out, -1) {
+			models.Logger.Summary(match)
+		}
 		return "ERRORD"
 	}
 	return out
@@ -88,8 +91,11 @@ func checkArangoError(name, code, out, filepath string, repository models.Reposi
 			models.Logger.Printf("[%s] [ERROR]: Found ArangoError without xpError", name)
 			models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, out)
 
+			re := regexp.MustCompile(`(?m)JavaScript exception.*`)
 			models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR %s</strong></error></li><br>", repository.Version, name, filepath)
-			models.Logger.Summary(out)
+			for _, match := range re.FindAllString(out, -1) {
+				models.Logger.Summary(match)
+			}
 			return "ERRORD"
 		}
 	}
@@ -104,8 +110,11 @@ func handleCollectionNotFound(name, code, out, filepath string, repository model
 		models.Logger.Printf("[%s] [ERROR]: Found ArangoError without xpError", name)
 		models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, output)
 
+		re := regexp.MustCompile(`(?m)JavaScript exception.*`)
 		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR %s</strong></error></li><br>", repository.Version, name, filepath)
-		models.Logger.Summary(out)
+		for _, match := range re.FindAllString(out, -1) {
+			models.Logger.Summary(match)
+		}
 		return "ERRORD"
 	}
 

--- a/toolchain/arangoproxy/internal/arangosh/arangosh.go
+++ b/toolchain/arangoproxy/internal/arangosh/arangosh.go
@@ -65,7 +65,7 @@ func checkAssertionFailed(name, code, out, filepath string, repository models.Re
 		models.Logger.Printf("[%s] [ERROR]: Assertion Failed", name)
 		models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, out)
 
-		re := regexp.MustCompile(`(?m)JavaScript exception.*`)
+		re := regexp.MustCompile(`(?m)JavaScript exception.*|ArangoError.*`)
 		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR %s</strong></error></li><br>", repository.Version, name, filepath)
 		for _, match := range re.FindAllString(out, -1) {
 			models.Logger.Summary(match)
@@ -91,7 +91,7 @@ func checkArangoError(name, code, out, filepath string, repository models.Reposi
 			models.Logger.Printf("[%s] [ERROR]: Found ArangoError without xpError", name)
 			models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, out)
 
-			re := regexp.MustCompile(`(?m)JavaScript exception.*`)
+			re := regexp.MustCompile(`(?m)JavaScript exception.*|ArangoError.*`)
 			models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR %s</strong></error></li><br>", repository.Version, name, filepath)
 			for _, match := range re.FindAllString(out, -1) {
 				models.Logger.Summary(match)
@@ -110,7 +110,7 @@ func handleCollectionNotFound(name, code, out, filepath string, repository model
 		models.Logger.Printf("[%s] [ERROR]: Found ArangoError without xpError", name)
 		models.Logger.Printf("[%s] [ERROR]: Command output: %s", name, output)
 
-		re := regexp.MustCompile(`(?m)JavaScript exception.*`)
+		re := regexp.MustCompile(`(?m)JavaScript exception.*|ArangoError.*`)
 		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR %s</strong></error></li><br>", repository.Version, name, filepath)
 		for _, match := range re.FindAllString(out, -1) {
 			models.Logger.Summary(match)

--- a/toolchain/arangoproxy/internal/controller.go
+++ b/toolchain/arangoproxy/internal/controller.go
@@ -22,7 +22,7 @@ var (
 	OpenapiGlobalChannel = make(chan map[string]interface{})
 
 	ExampleChannel = make(chan map[string]interface{})
-	OutputChannel  = make(chan map[string]interface{})
+	OutputChannel  = make(chan string)
 
 	Versions = models.LoadVersions()
 )

--- a/toolchain/arangoproxy/internal/controller.go
+++ b/toolchain/arangoproxy/internal/controller.go
@@ -22,7 +22,7 @@ var (
 	OpenapiGlobalChannel = make(chan map[string]interface{})
 
 	ExampleChannel = make(chan map[string]interface{})
-	OutputChannel  = make(chan string)
+	OutputChannel  = make(chan map[string]interface{})
 
 	Versions = models.LoadVersions()
 )
@@ -82,10 +82,6 @@ func CurlExampleHandler(w http.ResponseWriter, r *http.Request) {
 	models.Logger.Printf("[curl/CONTROLLER] Processing Example %s\n", request.Options.Name)
 
 	resp, err := CurlService.Execute(request, CacheChannel, ExampleChannel, OutputChannel)
-	if err != nil {
-		models.Logger.Printf("[HTTP] Error caused by request\n%s", request.Code)
-	}
-
 	response, err := json.Marshal(resp)
 	if err != nil {
 		models.Logger.Printf("[curl/CONTROLLER] Error marshalling response: %s\n", err.Error())

--- a/toolchain/arangoproxy/internal/models/example.go
+++ b/toolchain/arangoproxy/internal/models/example.go
@@ -85,7 +85,7 @@ func ParseExample(request io.Reader, headers http.Header) (Example, error) {
 	}
 
 	optionsYaml.Filename = headers.Get("Page")
-	optionsYaml.Position = headers.Get("Codeblock-Start")
+	optionsYaml.Position = headers.Get("Codeblock-Path")
 	optionsYaml.SaveCache = headers.Get("Cache")
 	optionsYaml.Version = headers.Get("Version")
 

--- a/toolchain/arangoproxy/internal/models/logger.go
+++ b/toolchain/arangoproxy/internal/models/logger.go
@@ -29,5 +29,5 @@ func (l *ArangoproxyLogger) Printf(s string, args ...any) {
 
 func (l *ArangoproxyLogger) Summary(s string, args ...any) {
 	s = strings.ReplaceAll(s, "\n", "\n<br>")
-	l.summary.Printf(s, args...)
+	l.summary.Printf(s+"<br>", args...)
 }

--- a/toolchain/arangoproxy/internal/models/logger.go
+++ b/toolchain/arangoproxy/internal/models/logger.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 )
 
 type ArangoproxyLogger struct {
@@ -27,5 +28,6 @@ func (l *ArangoproxyLogger) Printf(s string, args ...any) {
 }
 
 func (l *ArangoproxyLogger) Summary(s string, args ...any) {
+	s = strings.ReplaceAll(s, "\n", "\n<br>")
 	l.summary.Printf(s+"<br>", args...)
 }

--- a/toolchain/arangoproxy/internal/models/logger.go
+++ b/toolchain/arangoproxy/internal/models/logger.go
@@ -28,6 +28,7 @@ func (l *ArangoproxyLogger) Printf(s string, args ...any) {
 }
 
 func (l *ArangoproxyLogger) Summary(s string, args ...any) {
+	s = strings.ReplaceAll(s, "\n\n", "")
 	s = strings.ReplaceAll(s, "\n", "\n<br>")
 	l.summary.Printf(s+"<br>", args...)
 }

--- a/toolchain/arangoproxy/internal/models/logger.go
+++ b/toolchain/arangoproxy/internal/models/logger.go
@@ -28,7 +28,6 @@ func (l *ArangoproxyLogger) Printf(s string, args ...any) {
 }
 
 func (l *ArangoproxyLogger) Summary(s string, args ...any) {
-	s = strings.ReplaceAll(s, "\n\n", "")
 	s = strings.ReplaceAll(s, "\n", "\n<br>")
-	l.summary.Printf(s+"<br>", args...)
+	l.summary.Printf(s, args...)
 }

--- a/toolchain/arangoproxy/internal/service/service.go
+++ b/toolchain/arangoproxy/internal/service/service.go
@@ -33,7 +33,7 @@ func (service CommonService) arangosh(name, code string, repository models.Repos
 
 func (service CommonService) checkArangoshError(exampleFilepath string, arangoshResult map[string]interface{}) {
 	if arangoshResult["err"] != nil {
-		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR </strong></error></li><br>", arangoshResult["version"], arangoshResult["name"])
+		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR %s</strong></error></li><br>", arangoshResult["version"], arangoshResult["name"], exampleFilepath)
 		models.Logger.Summary(arangoshResult["err"].(error).Error())
 	}
 }

--- a/toolchain/arangoproxy/internal/service/service.go
+++ b/toolchain/arangoproxy/internal/service/service.go
@@ -31,8 +31,15 @@ func (service CommonService) arangosh(name, code string, repository models.Repos
 	exampleChannel <- exampleData
 }
 
-func (service CommonService) saveCache(request string, response models.ExampleResponse, cacheChannel chan map[string]interface{}) {
-	if response.Options.SaveCache == "false" || strings.Contains(response.Output, "ERRORD") {
+func (service CommonService) checkArangoshError(exampleFilepath string, arangoshResult map[string]interface{}) {
+	if arangoshResult["err"] != nil {
+		models.Logger.Summary("<li><error code=3><strong>%s</strong>  - %s <strong> ERROR </strong></error></li><br>", arangoshResult["version"], arangoshResult["name"])
+		models.Logger.Summary(arangoshResult["err"].(error).Error())
+	}
+}
+
+func (service CommonService) saveCache(request string, response models.ExampleResponse, cacheChannel chan map[string]interface{}, hasError interface{}) {
+	if response.Options.SaveCache == "false" || hasError != nil {
 		return
 	}
 
@@ -46,7 +53,7 @@ type JSService struct{}
 
 var JSFormatter = format.JSFormatter{}
 
-func (service JSService) Execute(request models.Example, cacheChannel chan map[string]interface{}, exampleChannel chan map[string]interface{}, outputChannel chan string) (res models.ExampleResponse) {
+func (service JSService) Execute(request models.Example, cacheChannel chan map[string]interface{}, exampleChannel chan map[string]interface{}, outputChannel chan map[string]interface{}) (res models.ExampleResponse) {
 	commands := JSFormatter.FormatRequestCode(request.Code)
 
 	repository, err := models.GetRepository(request.Options.Type, request.Options.Version)
@@ -58,10 +65,11 @@ func (service JSService) Execute(request models.Example, cacheChannel chan map[s
 
 	commonService.arangosh(request.Options.Name, commands, repository, exampleChannel)
 
-	cmdOutput := <-outputChannel
-	res = *models.NewExampleResponse(request.Code, cmdOutput, request.Options)
+	arangoshResult := <-outputChannel
+	commonService.checkArangoshError(request.Options.Position, arangoshResult)
+	res = *models.NewExampleResponse(request.Code, arangoshResult["output"].(string), request.Options)
 
-	commonService.saveCache(request.Base64Request, res, cacheChannel)
+	commonService.saveCache(request.Base64Request, res, cacheChannel, arangoshResult["err"])
 
 	return
 }
@@ -70,7 +78,7 @@ type CurlService struct{}
 
 var curlFormatter = format.CurlFormatter{}
 
-func (service CurlService) Execute(request models.Example, cacheChannel chan map[string]interface{}, exampleChannel chan map[string]interface{}, outputChannel chan string) (res models.ExampleResponse, err error) {
+func (service CurlService) Execute(request models.Example, cacheChannel chan map[string]interface{}, exampleChannel chan map[string]interface{}, outputChannel chan map[string]interface{}) (res models.ExampleResponse, err error) {
 	commands := curlFormatter.FormatCommand(request.Code)
 	repository, err := models.GetRepository(request.Options.Type, request.Options.Version)
 	if err != nil {
@@ -81,16 +89,17 @@ func (service CurlService) Execute(request models.Example, cacheChannel chan map
 
 	commonService.arangosh(request.Options.Name, commands, repository, exampleChannel)
 
-	cmdOutput := <-outputChannel
+	arangoshResult := <-outputChannel
+	commonService.checkArangoshError(request.Options.Position, arangoshResult)
 
-	curlRequest, curlOutput, err := curlFormatter.FormatCurlOutput(cmdOutput, string(request.Options.Render))
+	curlRequest, curlOutput, err := curlFormatter.FormatCurlOutput(arangoshResult["output"].(string), string(request.Options.Render))
 	if err != nil {
 		return
 	}
 
 	res = *models.NewExampleResponse(curlRequest, curlOutput, request.Options)
 
-	commonService.saveCache(request.Base64Request, res, cacheChannel)
+	commonService.saveCache(request.Base64Request, res, cacheChannel, arangoshResult["err"])
 
 	return
 }
@@ -99,7 +108,7 @@ type AQLService struct{}
 
 var AQLFormatter = format.AQLFormatter{}
 
-func (service AQLService) Execute(request models.Example, cacheChannel chan map[string]interface{}, exampleChannel chan map[string]interface{}, outputChannel chan string) (res models.AQLResponse) {
+func (service AQLService) Execute(request models.Example, cacheChannel chan map[string]interface{}, exampleChannel chan map[string]interface{}, outputChannel chan map[string]interface{}) (res models.AQLResponse) {
 	commands := AQLFormatter.FormatRequestCode(request.Code, request.Options.BindVars)
 	repository, err := models.GetRepository(request.Options.Type, request.Options.Version)
 	if err != nil {
@@ -116,18 +125,19 @@ func (service AQLService) Execute(request models.Example, cacheChannel chan map[
 
 	commonService.arangosh(request.Options.Name, commands, repository, exampleChannel)
 
-	cmdOutput := <-outputChannel
+	arangoshResult := <-outputChannel
+	commonService.checkArangoshError(request.Options.Position, arangoshResult)
 
 	res.ExampleResponse.Input, res.ExampleResponse.Options = request.Code, request.Options
 
 	if strings.Contains(string(request.Options.Render), "output") {
-		res.ExampleResponse.Output = fmt.Sprintf("%s\n%s", res.Output, cmdOutput)
+		res.ExampleResponse.Output = fmt.Sprintf("%s\n%s", res.Output, arangoshResult["output"].(string))
 	}
 
 	models.FormatResponse(&res.ExampleResponse)
 	res.BindVars = request.Options.BindVars
 
-	commonService.saveCache(request.Base64Request, res.ExampleResponse, cacheChannel)
+	commonService.saveCache(request.Base64Request, res.ExampleResponse, cacheChannel, arangoshResult["err"])
 
 	return
 }

--- a/toolchain/arangoproxy/internal/service/service.go
+++ b/toolchain/arangoproxy/internal/service/service.go
@@ -32,7 +32,7 @@ func (service CommonService) arangosh(name, code string, repository models.Repos
 }
 
 func (service CommonService) saveCache(request string, response models.ExampleResponse, cacheChannel chan map[string]interface{}) {
-	if response.Options.SaveCache == "false" {
+	if response.Options.SaveCache == "false" || strings.Contains(response.Output, "ERRORD") {
 		return
 	}
 
@@ -225,14 +225,11 @@ func (service OpenapiService) ValidateFile(version string, wg *sync.WaitGroup) e
 
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
-			models.Logger.Summary("%s - <strong>Error %d</strong>:", version, exitError.ExitCode())
-			models.Logger.Summary("%s", er.String())
-
-			time.Sleep(time.Second * 2)
-			os.Exit(exitError.ExitCode())
+			models.Logger.Summary("<error code=2>%s - <strong>Error %d</strong>:", version, exitError.ExitCode())
+			models.Logger.Summary("%s</error>", er.String())
 		}
+	} else {
+		models.Logger.Summary("%s &#x2713;", version)
 	}
-
-	models.Logger.Summary("%s &#x2713;", version)
 	return nil
 }

--- a/toolchain/scripts/toolchain.sh
+++ b/toolchain/scripts/toolchain.sh
@@ -589,14 +589,20 @@ function trap_container_exit() {
       terminate=true
     fi
     if [ "$ENV" == "local" ]; then
-      exitStatus=$(cat summary.md  | grep -o '<error code=.' | cut -d '=' -f2)
-      if [ "$exitStatus" != "" ] ; then
+      errors=$(cat summary.md  | grep '<error')
+      if [ "$errors" != "" ] ; then
         docker stop docs_arangoproxy docs_site
-        log "[TERMINATE] Error during content generation, shutting down all containers" >> toolchain.log
         terminate=true
       fi
     fi
   done
+
+  errors=$(cat summary.md  | grep '<error')
+  if [ "$errors" != "" ] ; then
+    docker stop docs_arangoproxy docs_site
+    log "[TERMINATE] Error during content generation:" >> toolchain.log
+    log "[TERMINATE] ""$errors" >> toolchain.log
+  fi
 
   log "[stop_all_containers] A stop signal has been captured. Stopping all containers" >> toolchain.log
   TRAP=1

--- a/toolchain/scripts/toolchain.sh
+++ b/toolchain/scripts/toolchain.sh
@@ -609,7 +609,7 @@ function trap_container_exit() {
   docker stop docs_arangoproxy docs_site
   docker ps -a --filter name=docs_* -q | xargs docker stop | xargs docker rm
   log "[stop_all_containers] Done" >> /home/toolchain.log
-  exitStatus=$(cat summary.md  | grep -o '<error code=.' | cut -d '=' -f2)
+  exitStatus=$(cat summary.md  | grep -o '<error code=.' | cut -d '=' -f2 | head -n 1)
   log "[stop_all_containers] Toolchain Exit Status ""$exitStatus" >> /home/toolchain.log
 
   exit $exitStatus

--- a/toolchain/scripts/toolchain.sh
+++ b/toolchain/scripts/toolchain.sh
@@ -436,8 +436,7 @@ function generate_startup_options() {
       
       if [ $? -ne 0 ]; then
         log "[generate_startup_options] [ERROR] $res"
-        echo "<li><strong>${HELPPROGRAM}</strong>: <strong> ERROR: $res</strong></li>" >> /home/summary.md
-        exit 1
+        echo "<li><error code=4><strong>${HELPPROGRAM}</strong>: <strong> ERROR: $res</strong></error></li>" >> /home/summary.md
       fi
 
       echo $res > ../../site/data/$version/"$HELPPROGRAM".json
@@ -461,8 +460,7 @@ function generate_optimizer_rules() {
 
   if [ $? -ne 0 ]; then
     log "[generate_optimizer_rules] [ERROR] $res"
-    echo "<li><strong>$version</strong>: <strong> ERROR: $res</strong></li>" >> /home/summary.md
-    exit 1
+    echo "<li><error code=5><strong>$version</strong>: <strong> ERROR: $res</strong></error></li>" >> /home/summary.md
   fi
 
   echo $res > ../../site/data/$version/optimizer-rules.json
@@ -489,8 +487,7 @@ function generate_error_codes() {
 
   if [ $? -ne 0 ]; then
     log "[generate_error_codes] [ERROR] $res"
-    echo "<li><strong>$version</strong>: <strong> ERROR: $res</strong></li>" >> /home/summary.md
-    exit 1
+    echo "<li><error code=6><strong>$version</strong>: <strong> ERROR: $res</strong></error></li>" >> /home/summary.md
   fi
 
   echo "<li><strong>$version</strong>: &#x2713;</li>" >> /home/summary.md
@@ -504,7 +501,7 @@ function generate_metrics() {
 
   if [ $version == "" ]; then
     log "[generate_error_codes] ArangoDB Source code not found. Aborting"
-    exit 1
+    echo "<li><error code=7><strong>$version</strong>: <strong> ERROR: ArangoDB Source Not Found</strong><error></li>" >> /home/summary.md
   fi
 
   log "[generate_metrics] Generate Metrics requested"
@@ -513,8 +510,7 @@ function generate_metrics() {
 
   if [ $? -ne 0 ]; then
     log "[generate_metrics] [ERROR] $res"
-    echo "<li><strong>$version</strong>: <strong> ERROR: $res</strong></li>" >> /home/summary.md
-    exit 1
+    echo "<li><error code=7><strong>$version</strong>: <strong> ERROR: $res</strong><error></li>" >> /home/summary.md
   fi
 
   echo "<li><strong>$version</strong>: &#x2713;</li>" >> /home/summary.md
@@ -540,16 +536,14 @@ function generate_oasisctl() {
   res=$(oasisctl generate-docs --link-file-ext .html --replace-underscore-with - --output-dir /tmp/oasisctl)
   if [ $? -ne 0 ]; then
     log "[generate_oasisctl] [ERROR] Error from oasisctl generate-docs: $res"
-    echo "<li><strong>$version</strong>: <strong> ERROR: Error from oasisctl generate-docs: </strong>$res</li>" >> /home/summary.md
-    exit 1
+    echo "<li><error code=8><strong>$version</strong>: <strong> ERROR: Error from oasisctl generate-docs: </strong>$res</error></li>" >> /home/summary.md
   fi
 
   log "[generate_oasisctl] "$PYTHON_EXECUTABLE" generators/oasisctl.py --src /tmp/oasisctl --dst ../../site/content/$version/arangograph/oasisctl/"
   res=$(("$PYTHON_EXECUTABLE" generators/oasisctl.py --src /tmp/oasisctl --dst ../../site/content/$version/arangograph/oasisctl/) 2>&1 )
   if [ $? -ne 0 ]; then
     log "[generate_oasisctl] [ERROR] Error from oasisctl.py: $res"
-    echo "<li><strong>$version</strong>: <strong> ERROR: Error from oasisctl.py: </strong>$res</li>" >> /home/summary.md
-    exit 1
+    echo "<li><error code=8><strong>$version</strong>: <strong> ERROR: Error from oasisctl.py: </strong>$res</error></li>" >> /home/summary.md
   fi
 
   cp /tmp/preserve/oasisctl.md ../../site/content/$version/arangograph/oasisctl/_index.md


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->
This PR brings following features:

- The toolchain won't immediately fail as soon as an example fails validation. 
   Instead, the failing examples will be tracked down into the summary.md. The toolchain will fail with message in post-build.
- The summary.md contains stacktrace, filepath and starting line of failing example.
- Centralized all containers logs into a single toolchain.log file
- Enhanced handling of async exit of any toolchain container.
- A predefined exit status of the toolchain so to understand immediately the macro cause of error (e.g. 2=api-docs, 3=examples, 4=metrics and so on)

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
