### PR TITLE
Simplify navigation generation

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -36,7 +36,7 @@
             {{- safeHTML .Params.head }}
             {{- if $pages }}
               {{ if and (ne .Params.menuTitle "3.10") (ne .Params.menuTitle "3.11") (ne .Params.menuTitle "3.12")}}
-                <li data-nav-id="{{.RelPermalink}}" class="dd-item sect{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label class="closed">
+                <li class="dd-item sect{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label class="closed">
                 </label>
                   <a href="{{.RelPermalink}}" class="toggle sect menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
               {{ end }}
@@ -48,12 +48,12 @@
                 </ul>
               {{- else }}
             {{ if ne .RelPermalink "/hooks/" }}
-            <li data-nav-id="{{.RelPermalink}}" test1 class="dd-item{{if $isActive }} active{{end}}"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle  | markdownify }}</div></a></li>
+            <li class="dd-item{{if $isActive }} active{{end}}"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a></li>
             {{ end }}  
             {{- end }}
           {{- else }}
   
-              <li data-nav-id="{{.RelPermalink}}" test2 class="dd-item{{if $isActive }} active{{end}} leaf"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a></li>
+              <li class="dd-item{{if $isActive }} active{{end}} leaf"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a></li>
           {{- end }}
         {{- end }}
       {{- end }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -36,7 +36,7 @@
             {{- safeHTML .Params.head }}
             {{- if $pages }}
               {{ if and (ne .Params.menuTitle "3.10") (ne .Params.menuTitle "3.11") (ne .Params.menuTitle "3.12")}}
-                <li data-nav-id="{{.RelPermalink}}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label for="section-" class="closed {{.RelPermalink}}" onclick="event.preventDefault();menuToggleClick(event)" >
+                <li data-nav-id="{{.RelPermalink}}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label class="closed" onclick="event.preventDefault();menuToggleClick(event)" >
                 </label>
                   <a href="{{.RelPermalink}}" class="toggle menu-section-entry menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
               {{ end }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -1,59 +1,45 @@
 <div id="sidebar" class="default-animation active">
   <div class="sidenav-container-flex">
     <div class="sidenav-navigation">
-
       <div id="content-wrapper" class="highlightable">
-        
-      
         <ul class="topics{{ if .Site.Params.collapsibleMenu }} collapsible-menu{{ end }}">
           {{- range .Site.Sections.ByWeight }}
-            {{- template "section-tree-nav" dict "sect" . "currentnode" . }}
+            {{/* version folders */}}
+            {{- if ne .Type "hooks" }}
+              <ul class="version-menu {{ .Params.menuTitle }}">{{/* TODO: hide non-stable versions by default? */}}
+                {{- template "section-tree-nav" . }}
+              </ul>
+            {{- end }}
           {{- end }}
         </ul>
         <div class="footermargin footerLangSwitch footerVariantSwitch footerVisitedLinks footerFooter"></div>
-        </div>
       </div>
     </div>
-    <button id="sidebar-toggle-navigation" class="desktop-menu-toggle" onclick="showSidebarHandler();">
-    </button>
   </div>
+  <button id="sidebar-toggle-navigation" class="desktop-menu-toggle" onclick="showSidebarHandler();"></button>
+</div>
 
-      {{- define "section-tree-nav" }}
-        {{- $currentNode := .currentnode }}
-        {{- $currentFileRelPermalink := .currentnode.RelPermalink }}
-  
-        {{- with .sect }}
-          {{- $isSelf := eq .RelPermalink $currentFileRelPermalink }}
-          {{- $isAncestor := and (not $isSelf) (.IsAncestor $currentNode) }}
-          {{- $isActive := $isSelf }}
-          {{- $pages := .Pages }}
-          {{- if .Page.IsHome }}
-            {{- $pages = .Sections }}
-          {{- else if .Page.Sections}}
-            {{- $pages = (.Pages | union .Sections) }}
-          {{- end }}
-          {{- if or .IsSection .IsHome }}
-            {{- safeHTML .Params.head }}
-            {{- if $pages }}
-              {{ if and (ne .Params.menuTitle "3.10") (ne .Params.menuTitle "3.11") (ne .Params.menuTitle "3.12")}}
-                <li class="dd-item sect{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label class="closed">
-                </label>
-                  <a href="{{.RelPermalink}}" class="toggle sect menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
-              {{ end }}
-  
-            <ul class="{{if or (eq .Params.menuTitle "3.10") (eq .Params.menuTitle "3.11") (eq .Params.menuTitle "3.12")}}version-menu {{ .Params.menuTitle }}{{ else }}submenu{{ end }}">
-                  {{- range $pages.ByWeight }}
-                    {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode }}
-                  {{- end }}
-                </ul>
-              {{- else }}
-            {{ if ne .RelPermalink "/hooks/" }}
-            <li class="dd-item{{if $isActive }} active{{end}}"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a></li>
-            {{ end }}  
-            {{- end }}
-          {{- else }}
-  
-              <li class="dd-item{{if $isActive }} active{{end}} leaf"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a></li>
-          {{- end }}
-        {{- end }}
-      {{- end }}
+{{- define "section-tree-nav" }}
+  {{- $pages := .Sections | union .Pages }}
+  {{- range $page := $pages.ByWeight }}
+    {{- if $page.Pages }}
+      {{- /* section (with child pages) */}}
+      <li class="dd-item sect">
+        <label class="closed"></label>{{- /*whitespace control */ -}}
+        <a href="{{ .RelPermalink }}" class="toggle sect menu-link">
+          <div class="menu-title">{{ .Params.menuTitle | markdownify }}</div>
+        </a>
+        <ul class="submenu">
+          {{- template "section-tree-nav" $page }}
+        </ul>
+      </li>
+    {{- else }}
+      {{- /* page (or section without children) */}}
+      <li class="dd-item leaf">
+        <a href="{{ .RelPermalink }}" class="menu-link">
+          <div class="menu-title">{{ .Params.menuTitle | markdownify }}</div>
+        </a>
+      </li>
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -20,7 +20,6 @@
 
       {{- define "section-tree-nav" }}
         {{- $currentNode := .currentnode }}
-        {{ $pageVersion := $currentNode.Page.Scratch.Get "version"  }}
         {{- $currentFileRelPermalink := .currentnode.RelPermalink }}
   
         {{- with .sect }}
@@ -38,13 +37,13 @@
             {{- if $pages }}
               {{ if and (ne .Params.menuTitle "3.10") (ne .Params.menuTitle "3.11") (ne .Params.menuTitle "3.12")}}
                 {{ if eq .Layout "label" }}
-                <li data-nav-id="{{.RelPermalink}}" title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label for="section-" class="closed {{.RelPermalink}}" onclick="event.preventDefault();menuToggleClick(event)" >
+                <li data-nav-id="{{.RelPermalink}}" class="dd-item{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label for="section-" class="closed {{.RelPermalink}}" onclick="event.preventDefault();menuToggleClick(event)" >
                 </label>
                   <a>
                     <div>{{ .Params.menuTitle | markdownify }}</div>
                     </a> 
                 {{ else }}
-                <li data-nav-id="{{.RelPermalink}}" title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label for="section-" class="closed {{.RelPermalink}}" onclick="event.preventDefault();menuToggleClick(event)" >
+                <li data-nav-id="{{.RelPermalink}}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label for="section-" class="closed {{.RelPermalink}}" onclick="event.preventDefault();menuToggleClick(event)" >
                 </label>
                   <a href="{{.RelPermalink}}" class="toggle menu-section-entry menu-link"  ><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
                 {{ end }}
@@ -57,12 +56,12 @@
                 </ul>
               {{- else }}
             {{ if ne .RelPermalink "/hooks/" }}
-            <li data-nav-id="{{.RelPermalink}}" test1 title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item{{if $isActive }} active{{end}}"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle  | markdownify }}</div></a></li>
+            <li data-nav-id="{{.RelPermalink}}" test1 class="dd-item{{if $isActive }} active{{end}}"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle  | markdownify }}</div></a></li>
             {{ end }}  
             {{- end }}
           {{- else }}
   
-              <li data-nav-id="{{.RelPermalink}}" test2 title="{{replace .Title "{{ pageVersion }}" $pageVersion  | markdownify }}" class="dd-item{{if $isActive }} active{{end}} menu-leaf-entry"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle  | markdownify }}</div></a></li>
+              <li data-nav-id="{{.RelPermalink}}" test2 class="dd-item{{if $isActive }} active{{end}} menu-leaf-entry"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle  | markdownify }}</div></a></li>
           {{- end }}
         {{- end }}
       {{- end }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -36,12 +36,12 @@
             {{- safeHTML .Params.head }}
             {{- if $pages }}
               {{ if and (ne .Params.menuTitle "3.10") (ne .Params.menuTitle "3.11") (ne .Params.menuTitle "3.12")}}
-                <li data-nav-id="{{.RelPermalink}}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label class="closed" onclick="event.preventDefault();menuToggleClick(event)" >
+                <li data-nav-id="{{.RelPermalink}}" class="dd-item sect{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label class="closed">
                 </label>
-                  <a href="{{.RelPermalink}}" class="toggle menu-section-entry menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
+                  <a href="{{.RelPermalink}}" class="toggle sect menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
               {{ end }}
   
-            <ul class='{{if or (eq .Params.menuTitle "3.10") (eq .Params.menuTitle "3.11") (eq .Params.menuTitle "3.12")}} version-menu {{ .Params.menuTitle }} {{ else }} submenu {{ end }}'>
+            <ul class="{{if or (eq .Params.menuTitle "3.10") (eq .Params.menuTitle "3.11") (eq .Params.menuTitle "3.12")}}version-menu {{ .Params.menuTitle }}{{ else }}submenu{{ end }}">
                   {{- range $pages.ByWeight }}
                     {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode }}
                   {{- end }}
@@ -53,7 +53,7 @@
             {{- end }}
           {{- else }}
   
-              <li data-nav-id="{{.RelPermalink}}" test2 class="dd-item{{if $isActive }} active{{end}} menu-leaf-entry"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle  | markdownify }}</div></a></li>
+              <li data-nav-id="{{.RelPermalink}}" test2 class="dd-item{{if $isActive }} active{{end}} leaf"><a href="{{.RelPermalink}}" class="menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a></li>
           {{- end }}
         {{- end }}
       {{- end }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -36,17 +36,9 @@
             {{- safeHTML .Params.head }}
             {{- if $pages }}
               {{ if and (ne .Params.menuTitle "3.10") (ne .Params.menuTitle "3.11") (ne .Params.menuTitle "3.12")}}
-                {{ if eq .Layout "label" }}
-                <li data-nav-id="{{.RelPermalink}}" class="dd-item{{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label for="section-" class="closed {{.RelPermalink}}" onclick="event.preventDefault();menuToggleClick(event)" >
-                </label>
-                  <a>
-                    <div>{{ .Params.menuTitle | markdownify }}</div>
-                    </a> 
-                {{ else }}
                 <li data-nav-id="{{.RelPermalink}}" class="dd-item menu-section-entry {{if $isActive }} active{{end}}{{if (or $isSelf $isAncestor) }} parent{{end}}"><label for="section-" class="closed {{.RelPermalink}}" onclick="event.preventDefault();menuToggleClick(event)" >
                 </label>
-                  <a href="{{.RelPermalink}}" class="toggle menu-section-entry menu-link"  ><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
-                {{ end }}
+                  <a href="{{.RelPermalink}}" class="toggle menu-section-entry menu-link"><div class="menu-title">{{ .Params.menuTitle | markdownify }}</div></a>
               {{ end }}
   
             <ul class='{{if or (eq .Params.menuTitle "3.10") (eq .Params.menuTitle "3.11") (eq .Params.menuTitle "3.12")}} version-menu {{ .Params.menuTitle }} {{ else }} submenu {{ end }}'>

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -812,7 +812,7 @@ header .logo {
 }
 
 #sidebar ul li a.toggle,
-#sidebar ul li.menu-leaf-entry a {
+#sidebar ul li.leaf a {
     margin-right: -0.5rem;
     padding-right: 1.5rem;
     border-radius: 8px;
@@ -829,7 +829,7 @@ header .logo {
     line-height: 1rem;
 }
 
-.menu-section-entry > label.closed::before {
+.sect > label.closed::before {
     font-family: "Font Awesome 5 Free";
     content: "\f078";
     display: inline-block;
@@ -841,7 +841,7 @@ header .logo {
     color: var(--gray-300);
 }
 
-.menu-section-entry > label.open::before {
+.sect > label.open::before {
     font-family: "Font Awesome 5 Free";
     content: "\f077";
     display: inline-block;
@@ -853,7 +853,7 @@ header .logo {
     color: var(--gray-300);
 }
 
-.menu-leaf-entry > a {
+.leaf > a {
     align-items: center;
     position: relative;
 }

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -9,12 +9,10 @@ var theme = true;
 
 function toggleMenuItem(event) {
     const listItem = event.target.parentNode;
-    if (listItem.classList.contains("leaf")) 
-        return
+    if (listItem.classList.contains("leaf")) return;
 
-    listItem.childNodes[0].classList.toggle("open");
-    jQuery(listItem.childNodes[2]).slideToggle();
-    console.log(listItem)
+    listItem.querySelector("label").classList.toggle("open");
+    $(listItem.querySelector(".submenu")).slideToggle();
 }
 
 function menuToggleClick(event) {
@@ -402,8 +400,8 @@ function moveTags() {
 
 window.onload = () => {
     var iframe =  document.getElementById('menu-iframe');
-    var iFrameBody= iframe.contentDocument || iframe.contentWindow.document;
-    content= iFrameBody.getElementById('sidebar');
+    var iFrameBody = iframe.contentDocument || iframe.contentWindow.document;
+    content = iFrameBody.getElementById('sidebar');
 
     $("#menu-iframe").replaceWith(content);
 

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -65,8 +65,8 @@ function loadMenu(url) {
     while (current.length > 0 && current.prop("class") != "topics collapsible-menu") {
         if (current.prop("tagName") == "LI") {
             current.addClass("parent");
-            jQuery(current.children()[0]).addClass("open") //Open label arrow
-            jQuery(current.children()[2]).show()
+            current.children("label:first").addClass("open");
+            current.children(".submenu:first").show();
         }
         
         current = current.parent();

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -9,7 +9,7 @@ var theme = true;
 
 function toggleMenuItem(event) {
     const listItem = event.target.parentNode;
-    if (listItem.classList.contains("menu-leaf-entry")) 
+    if (listItem.classList.contains("leaf")) 
         return
 
     listItem.childNodes[0].classList.toggle("open");
@@ -18,6 +18,8 @@ function toggleMenuItem(event) {
 }
 
 function menuToggleClick(event) {
+    if (event.target.tagName !== "LABEL") return;
+    event.preventDefault();
     toggleMenuItem(event);
 }
 
@@ -410,7 +412,7 @@ window.onload = () => {
     renderVersion();
     loadMenu(window.location.href);
     initArticle(window.location.href);
-
+    content.addEventListener("click", menuToggleClick);
 
     var isMobile = window.innerWidth <= 768;
     if (isMobile) {


### PR DESCRIPTION
Cleaner implementation of the nav template with unused data removed.
Everything still seems to look and work the same, but the nav.html file size is down from 728 KB to 420 KB.

Additional savings are possible by not including the baseURL in links but this requires changes to the JavaScript code in multiple places.