### PR TITLE
Add `maxResultsPerGroup` to search

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/search.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/search.html
@@ -12,6 +12,7 @@
     insights: true, // Optional, automatically send insights when user interacts with search results
     container: "#searchbox",
     debug: false, // Set debug to true if you want to inspect the modal,
+    maxResultsPerGroup: 10,
     searchParameters: {
       facetFilters: [`version:${version}`],
     },


### PR DESCRIPTION
### Description

Added `maxResultsPerGroup` with a value of 10 to the search. 

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
