### PR TITLE
DOC-533 | Fix page titles

### DIFF
--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -73,7 +73,7 @@ params:
   disableBreadcrumb: false
   disableNextPrev: false
   disableLandingPageButton: true
-  titleSeparator: "::"
+  titleSeparator: "|"
   themeVariant: [ "relearn-light", "relearn-dark", "learn", "neon", "blue", "green", "red" ]
   disableSeoHiddenPages: true
   additionalContentLanguage: [ "en" ]

--- a/site/themes/arangodb-docs-theme/layouts/partials/head.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/head.html
@@ -3,7 +3,7 @@
 
     {{- partial "meta.html" . }}
     {{- $link := "<link href=\"%s\" rel=\"%s\" type=\"%s\" title=\"%s\">" }}
-    <title>{{ if and .Title (not (eq .Title .Site.Title)) }}{{ .Title }} {{ default "::" .Site.Params.titleSeparator }} {{ end}}{{ .Site.Title }}</title>
+    <title>{{ if and .Title (not (eq .Title .Site.Title)) }}{{ .Title | markdownify | plainify | safeHTML }} {{ default "::" .Site.Params.titleSeparator }} {{ end }}{{ .Site.Title }}</title>
 
     <link href="{{ "/images/favicon.png" | relURL }}" rel="icon" type="image/png">
     {{- partial "javascript.html" . }}

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -86,14 +86,20 @@ function showSidebarHandler() {
 
 var isMobile=false;
 
+function decodeHtmlEntities(text) {
+  var ta = document.createElement("textarea");
+  ta.innerHTML = text;
+  return ta.value;
+}
+
 function replaceArticle(href, newDoc) {
-  var re = new RegExp(/<title>(.*)<\/title>/, 'mg');
+  var re = new RegExp(/<title>(.*?)<\/title>/, "m");
   var match = re.exec(newDoc);
-  if (match) {
-    title = match[1];
-  }
 
   $(".container-main").replaceWith($(".container-main", newDoc));
+  if (match) {
+    document.title = decodeHtmlEntities(match[1]);
+  }
 
   if (matches = href.match(/.*?(#.*)$/)) {
     location.hash = matches[1];


### PR DESCRIPTION
- Page titles can contain some Markdown. Now this gets rendered to HTML to then strip all HTML tags out for a plain title: `The _collection_ object` -> `The collection object`
- On soft navigation, the document.title now gets changed to the new page's title,
  taking into account html entities (`&ldquo;` -> `“` etc.)
- Change separator for titles so that we now get `Title | ArangoDB Documentation` instead of `:: ArangoDB Documentation`

<img width="466" alt="image" src="https://github.com/arangodb/docs-hugo/assets/7819991/ffb2899d-248c-49c3-b501-d18947ea35ab">

<img width="433" alt="image" src="https://github.com/arangodb/docs-hugo/assets/7819991/7afa3014-0f6f-4d3a-babf-6412a61457c3">
