### PR TITLE
Breadcrumb styling

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
@@ -1,23 +1,24 @@
 <nav id="breadcrumbs">
-    <ol class="links" itemscope itemtype="http://schema.org/BreadcrumbList">
-    <meta itemprop="itemListOrder" content="Descending" />
-      {{ range .Ancestors.Reverse }}
-        {{ if not .IsHome }}
-        <li itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
-          <meta itemprop="position" content="{{ .Params.menuTitle }}" />
-          <a itemprop="item" class="link-internal" href="{{ .RelPermalink }}">
-            <span itemprop="name" class="breadcrumb-entry">{{ .Params.menuTitle | markdownify }} > </span>
-          </a>
-        </li>
-        {{ end }}
-      {{- end }}   
-      {{ if not .IsHome }}
-      <li itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
-        <meta itemprop="position" content="{{ .Params.menuTitle }}" />
-        <a itemprop="item" class="link-internal" href="{{ .RelPermalink }}">
-          <span itemprop="name" class="breadcrumb-entry">{{ .Params.menuTitle | markdownify }}</span>
-        </a>
-      </li>
-      {{ end }}
-    </ol>
+  <ol class="links" itemscope itemtype="http://schema.org/BreadcrumbList">
+  <meta itemprop="itemListOrder" content="Descending" />
+  {{ range .Ancestors.Reverse }}
+    {{ if not .IsHome }}
+    <li itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
+      <meta itemprop="position" content="{{ .Params.menuTitle }}" />
+      <a itemprop="item" class="link-internal" href="{{ .RelPermalink }}">
+        <span itemprop="name" class="breadcrumb-entry">{{ .Params.menuTitle | markdownify }}</span>
+      </a>
+      <i class="fas fa-chevron-right fa-fw"></i>
+    </li>
+    {{ end }}
+  {{- end }}   
+  {{ if not .IsHome }}
+  <li itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
+    <meta itemprop="position" content="{{ .Params.menuTitle }}" />
+    <a itemprop="item" class="link-internal" href="{{ .RelPermalink }}">
+      <span itemprop="name" class="breadcrumb-entry">{{ .Params.menuTitle | markdownify }}</span>
+    </a>
+  </li>
+  {{ end }}
+  </ol>
 </nav>

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -915,7 +915,7 @@ header .logo {
     }
 }
 
-/* Badcrumbs row */
+/* Breadcrumbs row */
 #breadcrumbs {
     grid-area: breadcrumbs;
     display: flex;
@@ -953,7 +953,7 @@ header .logo {
 
 
 #breadcrumbs > ol > li {
-    padding: 0px 5px 0px 0px;
+    padding: 0;
     display: inline;
 }
 
@@ -963,8 +963,13 @@ header .logo {
     font-size: var(--TYPOGRAPHY-H4-SIZE);
 }
 
+#breadcrumbs > ol > li > i {
+    margin: 0 5px;
+    color: var(--green-700);
+    font-size: 14px;
+}
 
-/* */
+/* end Breadcrumbs row */
 
 
 /* Table of contents */


### PR DESCRIPTION
Use icon instead of `>` in breadcrumbs and apply styling

As a side effect, this allows us to adjust the Algolia crawler to use the 2nd item from the breadcrumbs as `lvl0` (if available) so that we get nicer result groups instead of the default `Documentation` group.

```js
            lvl0: {
              selectors: "#breadcrumbs li:nth-of-type(2) a",
              defaultValue: "Documentation",
```