### PR TITLE
Add 3.9 and 3.8 to version selector

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/version-selector.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/version-selector.html
@@ -4,5 +4,7 @@
     {{ range $i, $version := $versions }}
         <option value="{{ $version.name }}">{{ $version.name }}</option>
     {{ end }}
+        <option value="3.9">3.9</option>
+        <option value="3.8">3.8</option>
     </select>
 </div>

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -272,6 +272,14 @@ function changeVersion() {
     var versionSelector = document.getElementById("arangodb-version");
     var newVersion  = versionSelector.options[versionSelector.selectedIndex].value;
 
+    if (newVersion === "3.8" || newVersion === "3.9") {
+        var legacyUrl = "https://www.arangodb.com/docs/" + newVersion + "/";
+        var handle = window.open(legacyUrl, "_blank");
+        if (!handle) window.location.href = legacyUrl;
+        versionSelector.value = oldVersion;
+        return;
+    }
+
     try {
         localStorage.setItem('docs-version', newVersion);
         renderVersion()


### PR DESCRIPTION
Selecting either of the legacy version opens the old docs in a new tab. If this is blocked, the address of the current page is changed to the old docs.

The version selector value is reverted to stay in sync with what you actually see. Otherwise, you would click e.g. 3.9, it would open in a new tab, but the new docs would still you show e.g. 3.11 but the selector would be set to 3.9.

Note that there are still ways to get the version selector out of sync, which isn't addressed by this PR.