### PR TITLE
Cleanup 2

### DIFF
--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -3,8 +3,6 @@ languageCode: "en-us"
 title: "ArangoDB Documentation"
 theme: "arangodb-docs-theme"
 timeout: "200000000"
-UglifyURLs: true
-CanonifyURLs: true
 
 module:
   mounts:
@@ -64,4 +62,3 @@ params:
   collapsibleMenu: true
   titleSeparator: "|"
   themeVariant: [ "relearn-light" ]
-  

--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "https://startling-truffle-6032f2.netlify.app"
+baseURL: "https://docs.arangodb.com"
 languageCode: "en-us"
 title: "ArangoDB Documentation"
 theme: "arangodb-docs-theme"
@@ -58,18 +58,10 @@ caches:
 
 params:
   arangoproxyUrl: "http://192.168.129.129:8080"
-  pygmentsUseClassic: false
-  description: "Documentation for ArangoDB"
-  showVisitedLinks: true
-  alwaysopen: false
+  description: >-
+    ArangoDB is a scalable graph database system with native support for other
+    data models and a built-in search engine, for the cloud and on-premises
   collapsibleMenu: true
-  disableBreadcrumb: false
-  disableNextPrev: false
-  disableLandingPageButton: true
   titleSeparator: "|"
   themeVariant: [ "relearn-light" ]
-  disableSeoHiddenPages: true
-  additionalContentLanguage: [ "en" ]
-  custom_css: ["css/*"]
-  swaggerInitialize: "{ \"theme\": \"light\" }"
-  hidden: false
+  

--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -4,6 +4,10 @@ title: "ArangoDB Documentation"
 theme: "arangodb-docs-theme"
 timeout: "200000000"
 
+disableKinds: # Switch off tags and categories
+  - taxonomy
+  - term
+
 module:
   mounts:
     - source: "themes/arangodb-docs-theme/images"

--- a/site/content/3.10/_index.md
+++ b/site/content/3.10/_index.md
@@ -1,10 +1,9 @@
 ---
+title: Recommended Resources
 menuTitle: '3.10'
 weight: 0
 layout: default
 ---
-## Recommended Resources
-
 {{< cards >}}
 
 {{% card title="What is ArangoDB?" link="introduction/about-arangodb/" %}}

--- a/site/content/3.11/_index.md
+++ b/site/content/3.11/_index.md
@@ -1,10 +1,9 @@
 ---
+title: Recommended Resources
 menuTitle: '3.11'
 weight: 0
 layout: default
 ---
-## Recommended Resources
-
 {{< cards >}}
 
 {{% card title="What is ArangoDB?" link="introduction/about-arangodb/" %}}

--- a/site/content/3.12/_index.md
+++ b/site/content/3.12/_index.md
@@ -1,10 +1,9 @@
 ---
+title: Recommended Resources
 menuTitle: '3.12'
 weight: 0
 layout: default
 ---
-## Recommended Resources
-
 {{< cards >}}
 
 {{% card title="What is ArangoDB?" link="introduction/about-arangodb/" %}}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -20,7 +20,7 @@
 </div>
 
 {{- define "section-tree-nav" }}
-  {{- $pages := .Sections | union .Pages }}
+  {{- $pages := .Pages }}
   {{- range $page := $pages.ByWeight }}
     {{- if $page.Pages }}
       {{- /* section (with child pages) */}}

--- a/site/themes/arangodb-docs-theme/layouts/_default/rss.xml
+++ b/site/themes/arangodb-docs-theme/layouts/_default/rss.xml
@@ -24,7 +24,7 @@
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end -}}
     {{- range $pages }}
-	  {{- if and .Permalink .Title (or (ne (.Scratch.Get "relearnIsHiddenStem") true) (ne .Site.Params.disableSeoHiddenPages true) ) }}
+	  {{- if and .Permalink .Title }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>

--- a/site/themes/arangodb-docs-theme/layouts/_default/rss.xml
+++ b/site/themes/arangodb-docs-theme/layouts/_default/rss.xml
@@ -1,9 +1,4 @@
 {{- $pages := .Page.Pages }}
-{{- if .Page.IsHome }}
-  {{- $pages = .Page.Sections }}
-{{- else if .Page.Sections}}
-  {{- $pages = (.Page.Pages | union .Page.Sections) }}
-{{- end }}
 {{- $limit := .Site.Config.Services.RSS.Limit -}}
 {{- if ge $limit 0 -}}
   {{- $pages = $pages | first $limit -}}

--- a/site/themes/arangodb-docs-theme/layouts/_default/sitemap.xml
+++ b/site/themes/arangodb-docs-theme/layouts/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 {{- range .Data.Pages }}
-{{- if and .Title (or (ne (.Scratch.Get "relearnIsHiddenStem") true) (ne .Site.Params.disableSeoHiddenPages true) ) }}
+{{- if .Title }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/deprecated.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/deprecated.html
@@ -8,7 +8,7 @@
     {{ $nonDeprecatedPath := replace .Page.RelPermalink $shortVersion $stableVersion }}
     {{ $stablePage := .Page.GetPage $nonDeprecatedPath }}
     {{ if $stablePage }}
-        {{ $href = $stablePage.Permalink }}
+        {{ $href = $stablePage.RelPermalink }}
     {{ end }}
     <div class="box notices cstyle warning">
         <div class="box-content-container">

--- a/site/themes/arangodb-docs-theme/layouts/partials/deprecated.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/deprecated.html
@@ -1,25 +1,23 @@
-{{- $deprecated := $.Page.Store.Get "deprecated" }}
-{{ $shortVersion := $.Page.Store.Get "versionShort" }}
-{{ $stableVersion := $.Page.Store.Get "stableVersion" }}
+{{- $deprecated := .Page.Store.Get "deprecated" }}
+{{- $shortVersion := .Page.Store.Get "versionShort" }}
+{{- $stableVersion := .Page.Store.Get "stableVersion" }}
 
-
-{{ if $deprecated }}
-    {{ $href := printf "/%s" $shortVersion }}
-    {{ $nonDeprecatedPath := replace .Page.RelPermalink $shortVersion $stableVersion }}
-    {{ $stablePage := .Page.GetPage $nonDeprecatedPath }}
-    {{ if $stablePage }}
-        {{ $href = $stablePage.RelPermalink }}
-    {{ end }}
-    <div class="box notices cstyle warning">
-        <div class="box-content-container">
-            <div class="box-content">
-                <i class="fas fa-exclamation-triangle"></i>
-                <div class="box-text">
-                    <p>ArangoDB v{{ $shortVersion }} reached End of Life (EOL) and is no longer supported.
-
-                    This documentation is outdated. Please see the most recent version here: <a href="{{ $href }}">Latest Docs</a></p>
-                </div>
-            </div>
+{{- if $deprecated }}
+  {{- $href := printf "/%s/" $stableVersion }}
+  {{- $nonDeprecatedPath := replace .Page.File.Path $shortVersion $stableVersion }}
+  {{- $stablePage := .Page.GetPage $nonDeprecatedPath }}
+  {{- if $stablePage }}
+    {{- $href = $stablePage.RelPermalink }}
+  {{- end }}
+  <div class="box notices cstyle warning">
+    <div class="box-content-container">
+      <div class="box-content">
+        <i class="fas fa-exclamation-triangle"></i>
+        <div class="box-text">
+          <p>ArangoDB v{{ $shortVersion }} reached End of Life (EOL) and is no longer supported.</p>
+          <p>This documentation is outdated. Please see the most recent <a href="{{ $href }}">{{ $stableVersion }} version</a>.</p>
         </div>
+      </div>
     </div>
-{{ end }}
+  </div>
+{{- end }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/meta.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/meta.html
@@ -5,7 +5,7 @@
     {{- $gen := hugo.Generator }}
     {{- $gen = replaceRE "\\s*/>$" ">" $gen }}
     {{ $gen | safeHTML }}
-    {{- if not (and .Title (or (ne (.Scratch.Get "relearnIsHiddenStem") true) (ne .Site.Params.disableSeoHiddenPages true) ) ) }}
+    {{- if not .Title }}
     <meta itemprop="description" name="description" content="ArangoDB is a scalable graph database system with native support for other data models and a built-in search engine, for the cloud and on-premises">
     <meta property="og:url" content="https://docs.arangodb.com/">
     <meta property="og:title" content="Introduction to ArangoDB's Technical Documentation and Ecosystem | ArangoDB Documentation">

--- a/site/themes/arangodb-docs-theme/layouts/partials/meta.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/meta.html
@@ -1,36 +1,33 @@
-
-    <meta charset="utf-8">
-    {{- $c:=""}}{{/* to avoid that user swiping to the left leaves a gap on the right side, we set minimum-scale, even if not advised to */}}
-    <meta name="viewport" content="height=device-height, width=device-width, initial-scale=1.0, minimum-scale=1.0">
-    {{- $gen := hugo.Generator }}
-    {{- $gen = replaceRE "\\s*/>$" ">" $gen }}
-    {{ $gen | safeHTML }}
-    {{- if not .Title }}
-    <meta itemprop="description" name="description" content="ArangoDB is a scalable graph database system with native support for other data models and a built-in search engine, for the cloud and on-premises">
-    <meta property="og:url" content="https://docs.arangodb.com/">
-    <meta property="og:title" content="Introduction to ArangoDB's Technical Documentation and Ecosystem | ArangoDB Documentation">
-    <meta property="og:type" content="website">
-    <meta property="og:description" content="ArangoDB is a scalable graph database system with native support for other data models and a built-in search engine, for the cloud and on-premises">
-    {{- end }}
-    <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}">
-    {{- with .Site.Params.author }}
-    <meta name="author" content="{{ . }}">
-    {{- end }}
-    {{- $versionShort := .Page.Store.Get "versionShort" }}
-    {{- with $versionShort }}
-    <meta name="docsearch:version" content="{{ . }}">
-    {{- end }}
-    {{- if .Page.IsHome }}
-      {{- $shortVersions := slice }}
-      {{- $versions := index site.Data "versions" }}
-      {{- range $version := $versions }}
-        {{- $shortVersions = $shortVersions | append $version.name }}
-      {{- end }}
-      <meta name="docsearch:version" content="{{ delimit $shortVersions "," }}">
-    {{- end }}
-    {{- if or (eq .Type "hooks") (.IsHome) }}
-      {{- $redirectPath := printf "/%s" (index (where (index site.Data "versions") "alias" "stable") 0).name }}
-      <script>
-        window.location.href = "{{ $redirectPath }}/";
-      </script>
-    {{- end }}
+<meta charset="utf-8">
+{{- /* to avoid that user swiping to the left leaves a gap on the right side, we set minimum-scale, even if not advised to */}}
+<meta name="viewport" content="height=device-height, width=device-width, initial-scale=1.0, minimum-scale=1.0">
+{{- $gen := hugo.Generator }}
+{{- $gen = replaceRE "\\s*/>$" ">" $gen }}
+{{ $gen | safeHTML }}
+{{- $pageDescription := .Description | default .Site.Params.description | markdownify | plainify }}
+<meta itemprop="description" property="description" content="{{ $pageDescription }}">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:title" content="{{ .Title | default .Site.Title | markdownify | plainify }}">
+<meta property="og:type" content="website">
+<meta property="og:description" content="{{ $pageDescription }}">
+{{- with .Site.Params.author }}
+<meta name="author" content="{{ . }}">
+{{- end }}
+{{- $versionShort := .Page.Store.Get "versionShort" }}
+{{- with $versionShort }}
+<meta name="docsearch:version" content="{{ . }}">
+{{- end }}
+{{- if .Page.IsHome }}
+  {{- $shortVersions := slice }}
+  {{- $versions := index site.Data "versions" }}
+  {{- range $version := $versions }}
+    {{- $shortVersions = $shortVersions | append $version.name }}
+  {{- end }}
+  <meta name="docsearch:version" content="{{ delimit $shortVersions "," }}">
+{{- end }}
+{{- if or (eq .Type "hooks") (.IsHome) }}
+  {{- $redirectPath := printf "/%s" (index (where (index site.Data "versions") "alias" "stable") 0).name }}
+  <script>
+    window.location.href = "{{ $redirectPath }}/";
+  </script>
+{{- end }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/nested-article.hugo
+++ b/site/themes/arangodb-docs-theme/layouts/partials/nested-article.hugo
@@ -50,11 +50,6 @@
     {{- $isAncestor := and (not $isSelf) (.IsAncestor $currentNode) }}
     {{- $isActive = or $isSelf $isActive }}
     {{- $pages := .Pages }}
-    {{- if .Page.IsHome }}
-      {{- $pages = .Sections }}
-    {{- else if .Page.Sections}}
-      {{- $pages = (.Pages | union .Sections) }}
-    {{- end }}
     {{- $relearnIsHiddenFrom := index ($currentNode.Scratch.Get "relearnIsHiddenFrom") .RelPermalink }}
     {{- $hidden := and $relearnIsHiddenFrom (not $.showhidden) (not $isSelf) (not $isAncestor) }}
     {{- if $hidden }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/base-image.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/base-image.html
@@ -16,12 +16,12 @@
 
         <img {{ with $image }}
                 {{ if eq .MediaType.SubType "svg" }} 
-                    src="{{ .Permalink }}"
+                    src="{{ .RelPermalink }}"
                 {{- else }}
                     {{ if eq $size "" }}
-                        src="{{ .Permalink }}" 
+                        src="{{ .RelPermalink }}" 
                     {{- else }}
-                        src="{{ (.Resize (printf "%dx" $width)).Permalink }}"
+                        src="{{ (.Resize (printf "%dx" $width)).RelPermalink }}"
                     {{ end }}
                     {{ with $class }}
                         class="{{.}}"

--- a/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/card.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/card.html
@@ -8,7 +8,7 @@ $content := .Inner }}
   {{ $destinationPage = $context.Page.GetPage $link -}}
 {{ end }}
 
-<a href="{{ $destinationPage.Permalink }}" class="link-internal">
+<a href="{{ $destinationPage.RelPermalink }}" class="link-internal">
   <div class="card">
     <div class="card-head">
       {{ with $image }}<img

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -56,8 +56,6 @@ function closeAllEntries() {
 }
 
 function loadMenu(url) {
-    url = url.replace(/#.*$/, "");
-
     closeAllEntries();
     var current = $('.dd-item > a[href="' + url + '"]').parent();
     
@@ -137,7 +135,7 @@ function loadPage(target) {
   var href = target;
   getCurrentVersion(href);
   renderVersion();
-  loadMenu(href);
+  loadMenu(new URL(href).pathname);
   $.get({
     url: href,
     success: function(newDoc) {
@@ -422,7 +420,7 @@ window.onload = () => {
     getCurrentVersion(window.location.href);
     menuEntryClickListener();
     renderVersion();
-    loadMenu(window.location.href);
+    loadMenu(window.location.pathname);
     initArticle(window.location.href);
     content.addEventListener("click", menuToggleClick);
 


### PR DESCRIPTION
### Description

- Remove unused Hugo / Relearn config options and parameters
- Properly implement meta tags
- Omit baseURL in links (also images; reduces nav.html size)
-  Fix deprecated version partial for pages
-  Move version root headline to title
- Switch off the currently unused pages for tags and categories

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
