### PR TITLE
fix: search version faceting

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/search.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/search.html
@@ -5,16 +5,21 @@
 <script type="text/javascript">
   // get version from localstorage
   var version = localStorage.getItem("docs-version");
-  docsearch({
-    appId: "OK3ZBQ5982",
-    apiKey: "500c85ccecb335d507fe4449aed12e1d",
-    indexName: "arangodbdocs",
-    insights: true, // Optional, automatically send insights when user interacts with search results
-    container: "#searchbox",
-    debug: false, // Set debug to true if you want to inspect the modal,
-    maxResultsPerGroup: 10,
-    searchParameters: {
-      facetFilters: [`version:${version}`],
-    },
-  });
+  var url = new URL(window.location.href);
+  var versionFromUrl = url.pathname.split("/")[1];
+  window.setupDocSearch = function (facetVersion) {
+    docsearch({
+      appId: "OK3ZBQ5982",
+      apiKey: "500c85ccecb335d507fe4449aed12e1d",
+      indexName: "arangodbdocs",
+      insights: true, // Optional, automatically send insights when user interacts with search results
+      container: "#searchbox",
+      debug: false, // Set debug to true if you want to inspect the modal,
+      maxResultsPerGroup: 10,
+      searchParameters: {
+        facetFilters: [`version:${facetVersion}`],
+      },
+    });
+  };
+  window.setupDocSearch(versionFromUrl || version);
 </script>

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -295,13 +295,15 @@ function changeVersion() {
         return;
     }
 
-    try {
+    // try {
         localStorage.setItem('docs-version', newVersion);
-        renderVersion()
-        console.log(newVersion)
-    } catch(exception) {
-        changeVersion();
-    }
+        renderVersion();
+        window.setupDocSearch(newVersion);
+        console.log(newVersion);
+    // } catch(exception) {
+    //   console.log({exception})
+    //     changeVersion();
+    // }
 
     var newUrl = window.location.href.replace(oldVersion, newVersion)
     updateHistory("", newUrl);

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -295,15 +295,15 @@ function changeVersion() {
         return;
     }
 
-    // try {
+    try {
         localStorage.setItem('docs-version', newVersion);
         renderVersion();
         window.setupDocSearch(newVersion);
         console.log(newVersion);
-    // } catch(exception) {
-    //   console.log({exception})
-    //     changeVersion();
-    // }
+    } catch(exception) {
+      console.log({exception})
+        changeVersion();
+    }
 
     var newUrl = window.location.href.replace(oldVersion, newVersion)
     updateHistory("", newUrl);


### PR DESCRIPTION
### Description

1. Initial localStorage version was not being set properly. Switched to using URL as a source of truth on initilization
2. On switching version, we need to re-initialize the search (as the page doesn’t reload). To fix, moved docsearch creation into a function & called that on switching






#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
