### PR TITLE
ArangoGraph: Add new default port `443`

### DIFF
--- a/site/content/3.10/arangograph/deployments/_index.md
+++ b/site/content/3.10/arangograph/deployments/_index.md
@@ -211,8 +211,6 @@ disabling this feature in the following situations:
 - You need to give individuals access to a database's UI without giving them
   any access to ArangoGraph. Note, however, that it's possible to only give an
   ArangoGraph user database UI access, without other ArangoGraph permissions.
-- For some reason, you require driver access via `8529` port and you are unable
-  to use the designated `18529` driver port.
 
 Before getting started, make sure you are signed into ArangoGraph as a user
 with one of the following permissions in your project:
@@ -226,8 +224,7 @@ organization. See how to create a
 [role binding](../security-and-access-control/_index.md#how-to-view-edit-or-remove-role-bindings-of-a-policy).
 
 {{< warning >}}
-This feature is available on `8529` port only. Make sure your connecting drivers
-are using the `18529` port to avoid breaking changes.
+This feature is available on `8529` and `443` ports only.
 {{< /warning >}}
 
 ## How to edit a deployment

--- a/site/content/3.10/arangograph/deployments/_index.md
+++ b/site/content/3.10/arangograph/deployments/_index.md
@@ -224,7 +224,7 @@ organization. See how to create a
 [role binding](../security-and-access-control/_index.md#how-to-view-edit-or-remove-role-bindings-of-a-policy).
 
 {{< warning >}}
-This feature is available on `8529` and `443` ports only.
+This feature is available on `443` port only.
 {{< /warning >}}
 
 ## How to edit a deployment

--- a/site/content/3.10/arangograph/security-and-access-control/x-509-certificates.md
+++ b/site/content/3.10/arangograph/security-and-access-control/x-509-certificates.md
@@ -65,7 +65,7 @@ TLS connection.
 The default ports (`8529` and `443`) always serve the well-known certificate
 and have the [auto login to database UI](../deployments/_index.md#auto-login-to-database-ui)
 feature enabled by default.
-{{< info >}}
+{{< /info >}}
 
 ### Well-known X.509 certificates
 

--- a/site/content/3.10/arangograph/security-and-access-control/x-509-certificates.md
+++ b/site/content/3.10/arangograph/security-and-access-control/x-509-certificates.md
@@ -62,16 +62,16 @@ The distinction between these port numbers is in the certificate used for the
 TLS connection.
 
 {{< info >}}
-The default ports (`8529` and `443`) always serve the well-known certificate
-and have the [auto login to database UI](../deployments/_index.md#auto-login-to-database-ui)
-feature enabled by default.
+The default ports (`8529` and `443`) always serve the well-known certificate.
+The [auto login to database UI](../deployments/_index.md#auto-login-to-database-ui)
+feature is only available on the `443` port and is enabled by default.
 {{< /info >}}
 
 ### Well-known X.509 certificates
 
 **Well-known X.509 certificates** created by
 [Let's Encrypt](https://letsencrypt.org/) are used on the
-default ports, i.e. `8529` or `443`.
+default ports, `8529` and `443`.
 
 This type of certificate has a lifetime of 5 years and is rotated automatically.
 It is recommended to use well-known certificates, as this eases access of a

--- a/site/content/3.10/arangograph/security-and-access-control/x-509-certificates.md
+++ b/site/content/3.10/arangograph/security-and-access-control/x-509-certificates.md
@@ -46,26 +46,32 @@ browser does not trust the digital certificate.
 
 ## X.509 certificates in ArangoGraph
 
-Each ArangoGraph deployment is accessible on two different port numbers:
-- default port `8529`
+Each ArangoGraph deployment is accessible on different port numbers:
+- default port `8529`, `443`
 - high port `18529`
 
-Each ArangoGraph Notebook is accessible on two different port numbers:
-- default port `8840`
+Each ArangoGraph Notebook is accessible on different port numbers:
+- default port `8840`, `443`
 - high port `18840`
 
-Metrics are accessible on two different port numbers:
-- default port `8829`
+Metrics are accessible on different port numbers:
+- default port `8829`, `443`
 - high port `18829`
 
 The distinction between these port numbers is in the certificate used for the
 TLS connection.
 
+{{< info >}}
+The default ports (`8529` and `443`) always serve the well-known certificate
+and have the [auto login to database UI](../deployments/_index.md#auto-login-to-database-ui)
+feature enabled by default.
+{{< info >}}
+
 ### Well-known X.509 certificates
 
 **Well-known X.509 certificates** created by
 [Let's Encrypt](https://letsencrypt.org/) are used on the
-default ports, i.e. `8529`.
+default ports, i.e. `8529` or `443`.
 
 This type of certificate has a lifetime of 5 years and is rotated automatically.
 It is recommended to use well-known certificates, as this eases access of a

--- a/site/content/3.11/arangograph/deployments/_index.md
+++ b/site/content/3.11/arangograph/deployments/_index.md
@@ -211,8 +211,6 @@ disabling this feature in the following situations:
 - You need to give individuals access to a database's UI without giving them
   any access to ArangoGraph. Note, however, that it's possible to only give an
   ArangoGraph user database UI access, without other ArangoGraph permissions.
-- For some reason, you require driver access via `8529` port and you are unable
-  to use the designated `18529` driver port.
 
 Before getting started, make sure you are signed into ArangoGraph as a user
 with one of the following permissions in your project:
@@ -226,8 +224,7 @@ organization. See how to create a
 [role binding](../security-and-access-control/_index.md#how-to-view-edit-or-remove-role-bindings-of-a-policy).
 
 {{< warning >}}
-This feature is available on `8529` port only. Make sure your connecting drivers
-are using the `18529` port to avoid breaking changes.
+This feature is available on `443` port only.
 {{< /warning >}}
 
 ## How to edit a deployment

--- a/site/content/3.11/arangograph/security-and-access-control/x-509-certificates.md
+++ b/site/content/3.11/arangograph/security-and-access-control/x-509-certificates.md
@@ -46,26 +46,32 @@ browser does not trust the digital certificate.
 
 ## X.509 certificates in ArangoGraph
 
-Each ArangoGraph deployment is accessible on two different port numbers:
-- default port `8529`
+Each ArangoGraph deployment is accessible on different port numbers:
+- default port `8529`, `443`
 - high port `18529`
 
-Each ArangoGraph Notebook is accessible on two different port numbers:
-- default port `8840`
+Each ArangoGraph Notebook is accessible on different port numbers:
+- default port `8840`, `443`
 - high port `18840`
 
-Metrics are accessible on two different port numbers:
-- default port `8829`
+Metrics are accessible on different port numbers:
+- default port `8829`, `443`
 - high port `18829`
 
 The distinction between these port numbers is in the certificate used for the
 TLS connection.
 
+{{< info >}}
+The default ports (`8529` and `443`) always serve the well-known certificate.
+The [auto login to database UI](../deployments/_index.md#auto-login-to-database-ui)
+feature is only available on the `443` port and is enabled by default.
+{{< /info >}}
+
 ### Well-known X.509 certificates
 
 **Well-known X.509 certificates** created by
 [Let's Encrypt](https://letsencrypt.org/) are used on the
-default ports, i.e. `8529`.
+default ports, `8529` and `443`.
 
 This type of certificate has a lifetime of 5 years and is rotated automatically.
 It is recommended to use well-known certificates, as this eases access of a

--- a/site/content/3.12/arangograph/deployments/_index.md
+++ b/site/content/3.12/arangograph/deployments/_index.md
@@ -211,8 +211,6 @@ disabling this feature in the following situations:
 - You need to give individuals access to a database's UI without giving them
   any access to ArangoGraph. Note, however, that it's possible to only give an
   ArangoGraph user database UI access, without other ArangoGraph permissions.
-- For some reason, you require driver access via `8529` port and you are unable
-  to use the designated `18529` driver port.
 
 Before getting started, make sure you are signed into ArangoGraph as a user
 with one of the following permissions in your project:
@@ -226,8 +224,7 @@ organization. See how to create a
 [role binding](../security-and-access-control/_index.md#how-to-view-edit-or-remove-role-bindings-of-a-policy).
 
 {{< warning >}}
-This feature is available on `8529` port only. Make sure your connecting drivers
-are using the `18529` port to avoid breaking changes.
+This feature is available on `443` port only.
 {{< /warning >}}
 
 ## How to edit a deployment

--- a/site/content/3.12/arangograph/security-and-access-control/x-509-certificates.md
+++ b/site/content/3.12/arangograph/security-and-access-control/x-509-certificates.md
@@ -46,26 +46,32 @@ browser does not trust the digital certificate.
 
 ## X.509 certificates in ArangoGraph
 
-Each ArangoGraph deployment is accessible on two different port numbers:
-- default port `8529`
+Each ArangoGraph deployment is accessible on different port numbers:
+- default port `8529`, `443`
 - high port `18529`
 
-Each ArangoGraph Notebook is accessible on two different port numbers:
-- default port `8840`
+Each ArangoGraph Notebook is accessible on different port numbers:
+- default port `8840`, `443`
 - high port `18840`
 
-Metrics are accessible on two different port numbers:
-- default port `8829`
+Metrics are accessible on different port numbers:
+- default port `8829`, `443`
 - high port `18829`
 
 The distinction between these port numbers is in the certificate used for the
 TLS connection.
 
+{{< info >}}
+The default ports (`8529` and `443`) always serve the well-known certificate.
+The [auto login to database UI](../deployments/_index.md#auto-login-to-database-ui)
+feature is only available on the `443` port and is enabled by default.
+{{< /info >}}
+
 ### Well-known X.509 certificates
 
 **Well-known X.509 certificates** created by
 [Let's Encrypt](https://letsencrypt.org/) are used on the
-default ports, i.e. `8529`.
+default ports, `8529` and `443`.
 
 This type of certificate has a lifetime of 5 years and is rotated automatically.
 It is recommended to use well-known certificates, as this eases access of a


### PR DESCRIPTION
### Description

Add new default port `443` to ArangoGraph docs. Needs to be applied to 3.11 and 3.12.
