### PR TITLE
Fix logic error in startup option rendering

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/program-options.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/program-options.md
@@ -58,7 +58,7 @@
 
 {{ $option.description }}
 
-{{ if and (eq $option.requiresValue true ) (ne $option.category "command" )}}
+{{ if and (ne $option.requiresValue true ) (ne $option.category "command" )}}
 This option can be specified without a value to enable it.
 {{ end }}
 


### PR DESCRIPTION
### Description

A startup option can be enabled without value if requiresValue != true

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
