### PR TITLE
Add emphasis that uploaded backups are necessary for cloning

### DIFF
--- a/site/content/3.10/arangograph/backups.md
+++ b/site/content/3.10/arangograph/backups.md
@@ -136,6 +136,8 @@ During restore, the deployment is temporarily not available.
 ## How to clone deployments using backups
 
 {{< info >}}
+**Uploaded backups are required for cloning**
+
 The cloned deployment will have the exact same features as the previous
 deployment including node size, model, and cloud provider. The region
 can stay the same or you can select a different one.


### PR DESCRIPTION
In the "Uploading backups" section there is mention that Uploaded backups are required for cloning. This caveat should be repeated and emphasized in the "How to clone" section

### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
