### PR TITLE
Move info about database context to HTTP API description

### DIFF
--- a/site/content/3.10/concepts/data-structure/databases.md
+++ b/site/content/3.10/concepts/data-structure/databases.md
@@ -21,15 +21,8 @@ database named `_system`. This database cannot be dropped and provides special
 operations for creating, dropping, and enumerating databases.
 
 You can create additional databases and give them unique names to access them
-later. Database management operations cannot be initiated from out of user-defined
-databases. You need to use the `_system` database as context.
-
-When ArangoDB is accessed via its HTTP REST API, the database name is read from
-the first part of the request URI path (e.g. `/_db/myDB/...`). If the request
-URI does not contain a database name, it defaults to `/_db/_system`.
-If a database name is provided in the request URI, the name must be properly URL-encoded, and,
-if it contains UTF-8 characters, these must be NFC-normalized. Any non-NFC-normalized
-database names are rejected by the server.
+later. You need to be in the `_system` database for executing database management
+operations. They cannot be initiated while in a user-defined database.
 
 ## Database names
 

--- a/site/content/3.10/develop/http/databases.md
+++ b/site/content/3.10/develop/http/databases.md
@@ -22,8 +22,12 @@ All database management operations can only be accessed via the default
 ## Addresses of databases
 
 Any operation triggered via ArangoDB's RESTful HTTP API is executed in the
-context of exactly one database. To explicitly specify the database in a request,
-the request URI must contain the database name before the actual path:
+context of exactly one database. The database name is read from the first part
+of the request URI path (e.g. `/_db/mydb/...`). If the request URI does not
+contain a database name, it defaults to `/_db/_system`.
+
+To explicitly specify the database in a request, the request URI must contain
+the database name at the beginning of the path:
 
 ```
 http://localhost:8529/_db/mydb/...
@@ -39,6 +43,11 @@ http://localhost:8529/_db/mydb/_api/document/test/12345
 http://localhost:8529/_db/mydb/myapp/get
 ```
 
+{{< info >}}
+Database management operations like listing, creating, and dropping databases
+can only be executed with the `_system` database as the context.
+{{< /info >}}
+ 
 Special characters in database names must be properly URL-encoded, e.g.
 `a + b = c` needs to be encoded as `a%20%2B%20b%20%3D%20c`:
 

--- a/site/content/3.11/concepts/data-structure/databases.md
+++ b/site/content/3.11/concepts/data-structure/databases.md
@@ -21,15 +21,8 @@ database named `_system`. This database cannot be dropped and provides special
 operations for creating, dropping, and enumerating databases.
 
 You can create additional databases and give them unique names to access them
-later. Database management operations cannot be initiated from out of user-defined
-databases. You need to use the `_system` database as context.
-
-When ArangoDB is accessed via its HTTP REST API, the database name is read from
-the first part of the request URI path (e.g. `/_db/myDB/...`). If the request
-URI does not contain a database name, it defaults to `/_db/_system`.
-If a database name is provided in the request URI, the name must be properly URL-encoded, and,
-if it contains UTF-8 characters, these must be NFC-normalized. Any non-NFC-normalized
-database names are rejected by the server.
+later. You need to be in the `_system` database for executing database management
+operations. They cannot be initiated while in a user-defined database.
 
 ## Database names
 

--- a/site/content/3.11/develop/http/databases.md
+++ b/site/content/3.11/develop/http/databases.md
@@ -22,8 +22,12 @@ All database management operations can only be accessed via the default
 ## Addresses of databases
 
 Any operation triggered via ArangoDB's RESTful HTTP API is executed in the
-context of exactly one database. To explicitly specify the database in a request,
-the request URI must contain the database name before the actual path:
+context of exactly one database. The database name is read from the first part
+of the request URI path (e.g. `/_db/mydb/...`). If the request URI does not
+contain a database name, it defaults to `/_db/_system`.
+
+To explicitly specify the database in a request, the request URI must contain
+the database name at the beginning of the path:
 
 ```
 http://localhost:8529/_db/mydb/...
@@ -39,6 +43,11 @@ http://localhost:8529/_db/mydb/_api/document/test/12345
 http://localhost:8529/_db/mydb/myapp/get
 ```
 
+{{< info >}}
+Database management operations like listing, creating, and dropping databases
+can only be executed with the `_system` database as the context.
+{{< /info >}}
+ 
 Special characters in database names must be properly URL-encoded, e.g.
 `a + b = c` needs to be encoded as `a%20%2B%20b%20%3D%20c`:
 

--- a/site/content/3.12/concepts/data-structure/databases.md
+++ b/site/content/3.12/concepts/data-structure/databases.md
@@ -21,15 +21,8 @@ database named `_system`. This database cannot be dropped and provides special
 operations for creating, dropping, and enumerating databases.
 
 You can create additional databases and give them unique names to access them
-later. Database management operations cannot be initiated from out of user-defined
-databases. You need to use the `_system` database as context.
-
-When ArangoDB is accessed via its HTTP REST API, the database name is read from
-the first part of the request URI path (e.g. `/_db/myDB/...`). If the request
-URI does not contain a database name, it defaults to `/_db/_system`.
-If a database name is provided in the request URI, the name must be properly URL-encoded, and,
-if it contains UTF-8 characters, these must be NFC-normalized. Any non-NFC-normalized
-database names are rejected by the server.
+later. You need to be in the `_system` database for executing database management
+operations. They cannot be initiated while in a user-defined database.
 
 ## Database names
 

--- a/site/content/3.12/develop/http/databases.md
+++ b/site/content/3.12/develop/http/databases.md
@@ -22,8 +22,12 @@ All database management operations can only be accessed via the default
 ## Addresses of databases
 
 Any operation triggered via ArangoDB's RESTful HTTP API is executed in the
-context of exactly one database. To explicitly specify the database in a request,
-the request URI must contain the database name before the actual path:
+context of exactly one database. The database name is read from the first part
+of the request URI path (e.g. `/_db/mydb/...`). If the request URI does not
+contain a database name, it defaults to `/_db/_system`.
+
+To explicitly specify the database in a request, the request URI must contain
+the database name at the beginning of the path:
 
 ```
 http://localhost:8529/_db/mydb/...
@@ -39,6 +43,11 @@ http://localhost:8529/_db/mydb/_api/document/test/12345
 http://localhost:8529/_db/mydb/myapp/get
 ```
 
+{{< info >}}
+Database management operations like listing, creating, and dropping databases
+can only be executed with the `_system` database as the context.
+{{< /info >}}
+ 
 Special characters in database names must be properly URL-encoded, e.g.
 `a + b = c` needs to be encoded as `a%20%2B%20b%20%3D%20c`:
 


### PR DESCRIPTION
### Description

It's more appropriate to talk about URL-requirements of the API in the API docs instead of the general explanation about databases.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
