### PR TITLE
Prepend URL with site origin when copying headline anchor link

### DIFF
--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -436,9 +436,10 @@ function goToHomepage(event){
 }
 
 function copyURI(evt) {
-    navigator.clipboard.writeText(evt.target.closest("a").getAttribute('href')).then(() => {
-    }, () => {
-      console.log("clipboard copy failed")
+    navigator.clipboard.writeText(
+      window.location.origin + evt.target.closest("a").getAttribute('href')
+    ).then(() => {}, () => {
+      console.log("clipboard copy failed");
     });
 }
 


### PR DESCRIPTION
### Description

Since the removal of the canonical URL option, headline links only contain the path. Therefore, we need to prepend the origin for a full URL.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
