### PR TITLE
[DOC-586] Fix goToTop logic

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/back-to-top.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/back-to-top.html
@@ -1,1 +1,1 @@
-<button class="back-to-top hidden" onclick="goToTop()" href="#"><i class="fa fa-arrow-up"></i></button>
+<button class="back-to-top hidden" onclick="goToTop(event)" href="#"><i class="fa fa-arrow-up"></i></button>

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -424,10 +424,15 @@ window.addEventListener("scroll", () => {
 });
 
 
-const goToTop = () => {
+const goToTop = (event) => {
+    if (event != undefined)       // Comes from the back-to-top button
+      window.scrollTo({top: 0});
+
     if (window.location.hash.length == 0)
         window.scrollTo({top: 0});
 };
+
+
 
 function goToHomepage(event){
     event.preventDefault();


### PR DESCRIPTION
Add a logic to the goToTop() function to check whether it comes from back-to-top button or just from a new page loading.

If it comes from the button, scroll to top without looking for any condition.
If comes from page loading, scroll to top only if the URL doesn't contain fragments

### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
