### PR TITLE
Release notes: more cache metrics

### DIFF
--- a/site/content/3.10/release-notes/version-3.10/whats-new-in-3-10.md
+++ b/site/content/3.10/release-notes/version-3.10/whats-new-in-3-10.md
@@ -1406,6 +1406,30 @@ The caching subsystem now provides the following 3 additional metrics:
   so they can be recycled quickly. The overall amount of inactive tables is
   limited, so not much memory will be used here.
 
+### Observability of in-memory cache subsystem
+
+<small>Introduced in: v3.10.11</small>
+
+The following metrics have been added to improve the observability of in-memory
+cache subsystem:
+- `rocksdb_cache_free_memory_tasks_total`: Total number of free memory tasks
+  that were scheduled by the in-memory edge cache subsystem. This metric will
+  be increased whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see this metric
+  rising when the cache subsystem hits its global memory budget.
+- `rocksdb_cache_free_memory_tasks_duration_total`: Total amount of time spent
+  inside the free memory tasks of the in-memory cache subsystem. Free memory
+  tasks are scheduled by the cache subsystem to free up memory in existing cache
+  hash tables.
+- `rocksdb_cache_migrate_tasks_total`: Total number of migrate tasks that were
+  scheduled by the in-memory edge cache subsystem. This metric will be increased 
+  whenever the cache subsystem schedules a task to migrate an existing cache hash
+  table to a bigger or smaller size.
+- `rocksdb_cache_migrate_tasks_duration_total`: Total amount of time spent inside
+  the migrate tasks of the in-memory cache subsystem. Migrate tasks are scheduled
+  by the cache subsystem to migrate existing cache hash tables to a bigger or
+  smaller table.
+
 ### Replication improvements
 
 For synchronous replication of document operations in the cluster, the follower

--- a/site/content/3.11/release-notes/version-3.10/whats-new-in-3-10.md
+++ b/site/content/3.11/release-notes/version-3.10/whats-new-in-3-10.md
@@ -1406,6 +1406,30 @@ The caching subsystem now provides the following 3 additional metrics:
   so they can be recycled quickly. The overall amount of inactive tables is
   limited, so not much memory will be used here.
 
+### Observability of in-memory cache subsystem
+
+<small>Introduced in: v3.10.11</small>
+
+The following metrics have been added to improve the observability of in-memory
+cache subsystem:
+- `rocksdb_cache_free_memory_tasks_total`: Total number of free memory tasks
+  that were scheduled by the in-memory edge cache subsystem. This metric will
+  be increased whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see this metric
+  rising when the cache subsystem hits its global memory budget.
+- `rocksdb_cache_free_memory_tasks_duration_total`: Total amount of time spent
+  inside the free memory tasks of the in-memory cache subsystem. Free memory
+  tasks are scheduled by the cache subsystem to free up memory in existing cache
+  hash tables.
+- `rocksdb_cache_migrate_tasks_total`: Total number of migrate tasks that were
+  scheduled by the in-memory edge cache subsystem. This metric will be increased 
+  whenever the cache subsystem schedules a task to migrate an existing cache hash
+  table to a bigger or smaller size.
+- `rocksdb_cache_migrate_tasks_duration_total`: Total amount of time spent inside
+  the migrate tasks of the in-memory cache subsystem. Migrate tasks are scheduled
+  by the cache subsystem to migrate existing cache hash tables to a bigger or
+  smaller table.  
+
 ### Replication improvements
 
 For synchronous replication of document operations in the cluster, the follower

--- a/site/content/3.11/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1217,6 +1217,30 @@ The following metrics have been added:
 | `rocksdb_cache_edge_empty_inserts_total` | Total number of insertions into the in-memory edge cache for non-connected edges. |
 | `rocksdb_cache_edge_inserts_total` | Total number of insertions into the in-memory edge cache. |
 
+### Observability of in-memory cache subsystem
+
+<small>Introduced in: v3.10.11, v.3.11.4</small>
+
+The following metrics have been added to improve the observability of in-memory
+cache subsystem:
+- `rocksdb_cache_free_memory_tasks_total`: Total number of free memory tasks
+  that were scheduled by the in-memory edge cache subsystem. This metric will
+  be increased whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see this metric
+  rising when the cache subsystem hits its global memory budget.
+- `rocksdb_cache_free_memory_tasks_duration_total`: Total amount of time spent
+  inside the free memory tasks of the in-memory cache subsystem. Free memory
+  tasks are scheduled by the cache subsystem to free up memory in existing cache
+  hash tables.
+- `rocksdb_cache_migrate_tasks_total`: Total number of migrate tasks that were
+  scheduled by the in-memory edge cache subsystem. This metric will be increased 
+  whenever the cache subsystem schedules a task to migrate an existing cache hash
+  table to a bigger or smaller size.
+- `rocksdb_cache_migrate_tasks_duration_total`: Total amount of time spent inside
+  the migrate tasks of the in-memory cache subsystem. Migrate tasks are scheduled
+  by the cache subsystem to migrate existing cache hash tables to a bigger or
+  smaller table.
+
 ## Client tools
 
 ### arangodump

--- a/site/content/3.12/release-notes/version-3.10/whats-new-in-3-10.md
+++ b/site/content/3.12/release-notes/version-3.10/whats-new-in-3-10.md
@@ -1406,6 +1406,30 @@ The caching subsystem now provides the following 3 additional metrics:
   so they can be recycled quickly. The overall amount of inactive tables is
   limited, so not much memory will be used here.
 
+### Observability of in-memory cache subsystem
+
+<small>Introduced in: v3.10.11</small>
+
+The following metrics have been added to improve the observability of in-memory
+cache subsystem:
+- `rocksdb_cache_free_memory_tasks_total`: Total number of free memory tasks
+  that were scheduled by the in-memory edge cache subsystem. This metric will
+  be increased whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see this metric
+  rising when the cache subsystem hits its global memory budget.
+- `rocksdb_cache_free_memory_tasks_duration_total`: Total amount of time spent
+  inside the free memory tasks of the in-memory cache subsystem. Free memory
+  tasks are scheduled by the cache subsystem to free up memory in existing cache
+  hash tables.
+- `rocksdb_cache_migrate_tasks_total`: Total number of migrate tasks that were
+  scheduled by the in-memory edge cache subsystem. This metric will be increased 
+  whenever the cache subsystem schedules a task to migrate an existing cache hash
+  table to a bigger or smaller size.
+- `rocksdb_cache_migrate_tasks_duration_total`: Total amount of time spent inside
+  the migrate tasks of the in-memory cache subsystem. Migrate tasks are scheduled
+  by the cache subsystem to migrate existing cache hash tables to a bigger or
+  smaller table.
+
 ### Replication improvements
 
 For synchronous replication of document operations in the cluster, the follower

--- a/site/content/3.12/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/3.12/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1217,6 +1217,30 @@ The following metrics have been added:
 | `rocksdb_cache_edge_empty_inserts_total` | Total number of insertions into the in-memory edge cache for non-connected edges. |
 | `rocksdb_cache_edge_inserts_total` | Total number of insertions into the in-memory edge cache. |
 
+### Observability of in-memory cache subsystem
+
+<small>Introduced in: v3.10.11, v.3.11.4</small>
+
+The following metrics have been added to improve the observability of in-memory
+cache subsystem:
+- `rocksdb_cache_free_memory_tasks_total`: Total number of free memory tasks
+  that were scheduled by the in-memory edge cache subsystem. This metric will
+  be increased whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see this metric
+  rising when the cache subsystem hits its global memory budget.
+- `rocksdb_cache_free_memory_tasks_duration_total`: Total amount of time spent
+  inside the free memory tasks of the in-memory cache subsystem. Free memory
+  tasks are scheduled by the cache subsystem to free up memory in existing cache
+  hash tables.
+- `rocksdb_cache_migrate_tasks_total`: Total number of migrate tasks that were
+  scheduled by the in-memory edge cache subsystem. This metric will be increased 
+  whenever the cache subsystem schedules a task to migrate an existing cache hash
+  table to a bigger or smaller size.
+- `rocksdb_cache_migrate_tasks_duration_total`: Total amount of time spent inside
+  the migrate tasks of the in-memory cache subsystem. Migrate tasks are scheduled
+  by the cache subsystem to migrate existing cache hash tables to a bigger or
+  smaller table.
+
 ## Client tools
 
 ### arangodump

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -137,6 +137,30 @@ The following metrics have been added:
 | `rocksdb_cache_edge_empty_inserts_total` | Total number of insertions into the in-memory edge cache for non-connected edges. |
 | `rocksdb_cache_edge_inserts_total` | Total number of insertions into the in-memory edge cache. |
 
+### Observability of in-memory cache subsystem
+
+<small>Introduced in: v3.10.11, v.3.11.4, v.3.12.0</small>
+
+The following metrics have been added to improve the observability of in-memory
+cache subsystem:
+- `rocksdb_cache_free_memory_tasks_total`: Total number of free memory tasks
+  that were scheduled by the in-memory edge cache subsystem. This metric will
+  be increased whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see this metric
+  rising when the cache subsystem hits its global memory budget.
+- `rocksdb_cache_free_memory_tasks_duration_total`: Total amount of time spent
+  inside the free memory tasks of the in-memory cache subsystem. Free memory
+  tasks are scheduled by the cache subsystem to free up memory in existing cache
+  hash tables.
+- `rocksdb_cache_migrate_tasks_total`: Total number of migrate tasks that were
+  scheduled by the in-memory edge cache subsystem. This metric will be increased 
+  whenever the cache subsystem schedules a task to migrate an existing cache hash
+  table to a bigger or smaller size.
+- `rocksdb_cache_migrate_tasks_duration_total`: Total amount of time spent inside
+  the migrate tasks of the in-memory cache subsystem. Migrate tasks are scheduled
+  by the cache subsystem to migrate existing cache hash tables to a bigger or
+  smaller table.
+
 ### RocksDB .sst file partitioning (experimental)
 
 The following experimental startup options for RockDB .sst file partitioning


### PR DESCRIPTION
### Description

Added release notes for metrics that improve observability of the in-memory cache subsystem. 

Relates to https://github.com/arangodb/arangodb/pull/19841 and corresponding backports.

Generated content via https://github.com/arangodb/docs-hugo/pull/248. 


#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
