### PR TITLE
No logJsonLResponse

### DIFF
--- a/site/content/3.10/develop/http/replication/replication-logger.md
+++ b/site/content/3.10/develop/http/replication/replication-logger.md
@@ -299,7 +299,7 @@ var response = logCurlRequest('GET', url);
 
 assert(response.code === 200);
 
-logJsonLResponse(response);
+logJsonResponse(response);
 ```
 
 ```curl

--- a/site/content/3.10/develop/http/replication/write-ahead-log.md
+++ b/site/content/3.10/develop/http/replication/write-ahead-log.md
@@ -361,7 +361,7 @@ var response = logCurlRequest('GET', url);
 
 assert(response.code === 200);
 
-logJsonLResponse(response);
+logJsonResponse(response);
 ```
 
 ```curl

--- a/site/content/3.11/develop/http/replication/replication-logger.md
+++ b/site/content/3.11/develop/http/replication/replication-logger.md
@@ -299,7 +299,7 @@ var response = logCurlRequest('GET', url);
 
 assert(response.code === 200);
 
-logJsonLResponse(response);
+logJsonResponse(response);
 ```
 
 ```curl

--- a/site/content/3.11/develop/http/replication/write-ahead-log.md
+++ b/site/content/3.11/develop/http/replication/write-ahead-log.md
@@ -361,7 +361,7 @@ var response = logCurlRequest('GET', url);
 
 assert(response.code === 200);
 
-logJsonLResponse(response);
+logJsonResponse(response);
 ```
 
 ```curl

--- a/site/content/3.12/develop/http/replication/replication-logger.md
+++ b/site/content/3.12/develop/http/replication/replication-logger.md
@@ -299,7 +299,7 @@ var response = logCurlRequest('GET', url);
 
 assert(response.code === 200);
 
-logJsonLResponse(response);
+logJsonResponse(response);
 ```
 
 ```curl

--- a/site/content/3.12/develop/http/replication/write-ahead-log.md
+++ b/site/content/3.12/develop/http/replication/write-ahead-log.md
@@ -361,7 +361,7 @@ var response = logCurlRequest('GET', url);
 
 assert(response.code === 200);
 
-logJsonLResponse(response);
+logJsonResponse(response);
 ```
 
 ```curl

--- a/toolchain/arangoproxy/internal/utils/common.js
+++ b/toolchain/arangoproxy/internal/utils/common.js
@@ -252,14 +252,6 @@ var curlRequest = function () {
 var logJsonResponseRaw = internal.appendJsonResponse(rawAppender, rawAppender);
 var logJsonResponse = internal.appendJsonResponse(rawAppender, jsonAppender);
 
-var logJsonLResponseRaw = internal.appendJsonLResponse(rawAppender, jsonLAppender);
-var logJsonLResponse = function (response) {
-  var r = logJsonLResponseRaw.apply(logJsonLResponseRaw, [response]);
-  print("RESP");
-  print(output);
-  print("ENDRESP");
-  output = "";
-}
 
 var logHtmlResponse = internal.appendRawResponse(rawAppender, htmlAppender);
 var logRawResponseRaw = internal.appendRawResponse(rawAppender, rawAppender);


### PR DESCRIPTION
### Description

From https://arangodb.slack.com/archives/C0NQHDJ59/p1696764828510009

logJsonLResponse added html to the response output. I think this is a leftover from old toolchain as using logJsonResponse would return the clean response with no added html.

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: arangodb/enterprise-preview:3.10-nightly
- 3.11: arangodb/enterprise-preview:3.11-nightly
- 3.12: arangodb/enterprise-preview:devel-nightly
