### PR TITLE
documentation about `warnings` attribute change

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -89,6 +89,14 @@ for details.
 The `GET /_api/query/rules` endpoint now includes a `description` attribute for
 every optimizer rule that briefly explains what it does.
 
+#### AQL Query Parse API
+
+The `POST /_api/query/parse` endpoint for parsing AQL queries now unconditionally
+returns the `warnings` attribute, even if no warnings were produced while parsing
+the query. In that case, `warnings` will contain an empty array.
+In previous versions, no `warnings` attribute was returned when parsing a query
+produced no warnings.
+
 ### Endpoints moved
 
 


### PR DESCRIPTION
### Description

Docs PR for https://github.com/arangodb/arangodb/pull/19932

#### Upstream PRs

https://github.com/arangodb/arangodb/pull/19932

- 3.10: not required
- 3.11: not required
- 3.12: https://github.com/arangodb/arangodb/pull/19932
