### PR TITLE
`--database.extended-names` enabled by default

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -14,6 +14,8 @@ integrations for ArangoDB 3.12.
 
 ### Behavior changes
 
+#### HTTP headers
+
 The following long-deprecated features have been removed from ArangoDB's HTTP
 server:
 
@@ -33,6 +35,12 @@ server:
   `--http.hide-product-header`.
   The functionality has now been removed and setting the startup option does
   nothing.
+
+#### `--database.extended-names` enabled by default
+
+The `--database.extended-names` startup option is now enabled by default.
+The names of databases, collections, Views, and indexes may contain Unicode
+characters using the default settings.
 
 #### Collection API
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -172,7 +172,24 @@ the JavaScript graph modules.
 
 ## Startup options
 
+### `--database.extended-names` enabled by default
 
+The `--database.extended-names` startup option is now enabled by default.
+This allows you to use Unicode characters inside database names, collection names,
+view names and index names by default, unless you explicitly turn off the
+functionality.
+
+Note that once a server in your deployment has been started with the flag set to
+`true`, it stores this setting permanently. Switching the startup option back to
+`false` raises a warning about the option change at startup, but it is not
+blockig the startup.
+
+Existing databases, collections, views and indexes with extended names can still
+be used even with the option set back to `false`, but no new database objects
+with extended names can be created with the option disabled. This state is only
+meant to facilitate downgrading or reverting the option change. When the option
+is set to `false`, all database objects with extended names that were created
+in the meantime should be removed manually.
 
 ## Client tools
 

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -125,6 +125,25 @@ attempt to create an additional database fails with error
 if other databases are dropped first. The default value for this option is
 unlimited, so an arbitrary amount of databases can be created.
 
+### `--database.extended-names` enabled by default
+
+The `--database.extended-names` startup option is now enabled by default.
+This allows you to use Unicode characters inside database names, collection names,
+view names and index names by default, unless you explicitly turn off the
+functionality.
+
+Note that once a server in your deployment has been started with the flag set to
+`true`, it stores this setting permanently. Switching the startup option back to
+`false` raises a warning about the option change at startup, but it is not
+blockig the startup.
+
+Existing databases, collections, views and indexes with extended names can still
+be used even with the option set back to `false`, but no new database objects
+with extended names can be created with the option disabled. This state is only
+meant to facilitate downgrading or reverting the option change. When the option
+is set to `false`, all database objects with extended names that were created
+in the meantime should be removed manually.
+
 ## Miscellaneous changes
 
 ### In-memory edge cache startup options and metrics


### PR DESCRIPTION
### Description

Added release notes.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12: https://github.com/arangodb/arangodb/pull/19928
