### PR TITLE
[DOC-605] Use golang latest image in docs docker images

### DIFF
--- a/toolchain/docker/Dockerfile
+++ b/toolchain/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILDARCH
 RUN echo ${BUILDARCH}
 ENV ARCH=${BUILDARCH}
 
-COPY --from=golang:1.19-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:alpine /usr/local/go/ /usr/local/go/
  
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -26,7 +26,7 @@ ARG BUILDARCH
 RUN echo ${BUILDARCH}
 ENV ARCH=${BUILDARCH}
 
-COPY --from=golang:1.19-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:alpine /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN apk add --update --no-cache git curl bash


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: arangodb/enterprise-preview:3.10-nightly
- 3.11: arangodb/enterprise-preview:3.11-nightly
- 3.12: arangodb/enterprise-preview:devel-nightly
