### PR TITLE
Enable Forked Repo PR on CircleCI

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -372,7 +372,7 @@ jobs:
           name: Clone docs repo
           command: |
             git clone git@github.com:arangodb/docs-hugo.git
-            cd docs-hugo
+            cd /home/circleci/project/docs-hugo
             git fetch && git checkout $CIRCLE_SHA1
 
 
@@ -383,7 +383,7 @@ jobs:
             export HUGO_URL=<< parameters.url >>
             export HUGO_ENV=frontend
 
-            cd toolchain/docker/amd64
+            cd /home/circleci/project/docs-hugo/toolchain/docker/amd64
             docker compose -f docker-compose.plain-build.yml up --abort-on-container-exit
       - upload-summary:
           summary-name: "plain-build-summary"

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -371,7 +371,10 @@ jobs:
       - run: 
           name: Clone docs repo
           command: |
-            git clone --depth 1 git@github.com:arangodb/docs-hugo.git --branch $CIRCLE_BRANCH
+            git clone git@github.com:arangodb/docs-hugo.git
+            cd docs-hugo
+            git fetch && git checkout $CIRCLE_SHA1
+
 
       - run:
           name: Build site
@@ -380,7 +383,7 @@ jobs:
             export HUGO_URL=<< parameters.url >>
             export HUGO_ENV=frontend
 
-            cd docs-hugo/toolchain/docker/amd64
+            cd toolchain/docker/amd64
             docker compose -f docker-compose.plain-build.yml up --abort-on-container-exit
       - upload-summary:
           summary-name: "plain-build-summary"

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -373,7 +373,7 @@ jobs:
           command: |
             git clone git@github.com:arangodb/docs-hugo.git
             cd /home/circleci/project/docs-hugo
-            git fetch $CIRCLE_BRANCH:$CIRCLE_SHA1 && git checkout $CIRCLE_SHA1
+            git fetch origin $CIRCLE_BRANCH:$CIRCLE_SHA1 && git checkout $CIRCLE_SHA1
 
 
       - run:

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -373,7 +373,7 @@ jobs:
           command: |
             git clone git@github.com:arangodb/docs-hugo.git
             cd /home/circleci/project/docs-hugo
-            git fetch && git checkout $CIRCLE_SHA1
+            git fetch $CIRCLE_BRANCH:$CIRCLE_SHA1 && git checkout $CIRCLE_SHA1
 
 
       - run:


### PR DESCRIPTION
### Description

This PR changes the git clone step in the plain-build CircleCI Workflow.
Insted of just cloning the target branch, will clone the target branch and locally tag it as a new branch in a detached head state.
This allows to be able to run the plain-build on PRs coming from forks too as they are in a **pull/{NUMBER}/head**.
Without this PR the forked PRs would not be able to build

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
