### PR TITLE
Fix linking to anchors

### DIFF
--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -161,7 +161,7 @@ function loadPage(target) {
     xhr: function() { return xhr; },
     url: href,
     success: function(newDoc) {
-      if (xhr.responseURL && href !== xhr.responseURL) {
+      if (xhr.responseURL && href.replace(/#.*/, "") !== xhr.responseURL) {
         updateHistory(xhr.responseURL.replace(version, getVersionByURL()));
         return;
       }


### PR DESCRIPTION
### Description

Remove anchor from target URL before comparing to responseURL

This check determines whether Netlify responded with a redirect but it had false-positives for URLs with fragment identifier

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
