### PR TITLE
Compare version name against `.Page.Type` to avoid false matches with Release Notes

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/version.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/version.html
@@ -1,33 +1,28 @@
-{{ $pagePath := .page }}
-{{ $versions := index site.Data "versions" }}
-{{ range $i, $version := $versions }}
-    {{ if strings.Contains $pagePath $version.name }}
-        {{ $pagePath.Page.Store.Set "version" $version.version }}
-        {{ $pagePath.Page.Store.Set "versionShort" $version.name }}
-        {{ $pagePath.Page.Store.Set "alias" $version.alias }}
-        {{ $pagePath.Page.Store.Set "deprecated" $version.deprecated }}
-
-        {{ template "checkVersionIsInDevelopment" dict "page" $pagePath "pageVersion" $version.name "versions" $versions }}
-    {{ end }}
-{{ end }}
+{{- $page := .page }}
+{{- $versions := index site.Data "versions" }}
+{{- range $i, $version := $versions }}
+  {{- if eq $page.Type $version.name }}
+    {{- $page.Store.Set "version" $version.version }}
+    {{- $page.Store.Set "versionShort" $version.name }}
+    {{- $page.Store.Set "alias" $version.alias }}
+    {{- $page.Store.Set "deprecated" $version.deprecated }}
+    {{- template "checkVersionIsInDevelopment" dict "page" $page "pageVersion" $version.name "versions" $versions }}
+  {{- end }}
+{{- end }}
 
 {{- define "checkVersionIsInDevelopment" }}
-{{ $page := .page }}
-{{ $pageVersion := .pageVersion }}
-{{ $versions := index (where .versions "alias" "stable") 0 }}
-{{ $page.Page.Store.Set "stableVersion" $versions.name }}
-
-
-    {{ $stableVersion := split $versions.name "." }}
-    {{ $currentVersion := split $pageVersion "." }}
-
-    {{ range $j, $elem := $stableVersion }}
-        {{ $intStable := int $elem }}
-        {{ $currentVersionElement := index $currentVersion $j }}
-        {{ $intCurrent := int $currentVersionElement }}
-        {{ if gt $intCurrent $intStable }}
-            {{ $page.Page.Store.Set "underDevelopment" true }}
-
-        {{ end }}
-    {{ end }}
-{{ end }}
+  {{- $page := .page }}
+  {{- $pageVersion := .pageVersion }}
+  {{- $versions := index (where .versions "alias" "stable") 0 }}
+  {{- $page.Store.Set "stableVersion" $versions.name }}
+  {{- $stableVersion := split $versions.name "." }}
+  {{- $currentVersion := split $pageVersion "." }}
+  {{- range $j, $elem := $stableVersion }}
+    {{- $intStable := int $elem }}
+    {{- $currentVersionElement := index $currentVersion $j }}
+    {{- $intCurrent := int $currentVersionElement }}
+    {{- if gt $intCurrent $intStable }}
+      {{- $page.Store.Set "underDevelopment" true }}
+    {{- end }}
+  {{- end }}
+{{- end -}}


### PR DESCRIPTION
### Description

For example, https://docs.arangodb.com/devel/release-notes/version-3.11/ incorrectly reports "ArangoDB v3.11 is under development ..."

The version matching used the stringified Page object which is like `Page(/the/path)` and in case of the Release Notes, we have `3.11` in the path after the `3.12/` version folder, which made the template logic pick 3.11 instead of the correct version.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12: arangodb/enterprise-preview:devel-nightly
