### PR TITLE
Improve Document API

### DIFF
--- a/site/content/3.10/concepts/data-structure/documents/_index.md
+++ b/site/content/3.10/concepts/data-structure/documents/_index.md
@@ -60,15 +60,17 @@ Example document:
 All documents contain special attributes at the top-level that start with an 
 underscore, known as **system attributes**:
 
-- The **document identifier** is stored as a string in the `_id` attribute.
 - The **document key** is stored as a string in the `_key` attribute.
+- The **document identifier** is stored as a string in the `_id` attribute.
 - The **document revision** is stored as a string in the `_rev` attribute.
 
 You can specify a value for the `_key` attribute when creating a document.
+The `_id` attribute is automatically set based on the collection and `_key`.
 The `_id` and `_key` values are immutable once the document has been created.
 The `_rev` value is maintained by ArangoDB automatically.
 
 Edge documents in edge collections have two additional system attributes:
+
 - The document identifier of the source vertex stored in the `_from` attribute.
 - The document identifier of the target vertex stored in the `_to` attribute.
 
@@ -79,6 +81,9 @@ you should avoid using own attribute names starting with an underscore.
 
 Each document has a unique **document key** (or _primary key_) which identifies
 it within its collection.
+
+To distinguish between documents from multiple collections, see
+[Document identifiers](#document-identifiers).
 
 A document key uniquely identifies a document in the collection it is
 stored in. It can and should be used by clients when specific documents
@@ -156,6 +161,10 @@ forward slash (`/`), like `collection-name/document-key`.
 
 See [Collection names](../collections.md#collection-names) and
 [Document keys](#document-keys) for information about the allowed characters.
+
+When working with documents from multiple collections, you can see what
+collections they are from by looking at the `_id` attribute values and tell
+documents from different collections but the same keys apart.
 
 ### Document revisions
 

--- a/site/content/3.10/develop/http-api/documents.md
+++ b/site/content/3.10/develop/http-api/documents.md
@@ -82,9 +82,9 @@ paths:
       description: |
         Returns the document identified by the collection name and document key.
         The returned document contains three special attributes:
-        - `_id` containing the document identifier
-        - `_key` containing key which uniquely identifies a document in a given collection
-        - `_rev` containing the revision
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
       parameters:
         - name: collection
           in: path
@@ -331,23 +331,24 @@ paths:
       operationId: createDocument
       description: |
         Creates a new document from the document given in the body, unless there
-        is already a document with the `_key` given. If no `_key` is given, a new
-        unique `_key` is generated automatically.
+        is already a document with the `_key` given. If no `_key` is given, a
+        new unique `_key` is generated automatically. The `_id` is automatically
+        set in both cases, derived from the collection name and `_key`.
 
-        Possibly given `_id` and `_rev` attributes in the body are always ignored,
-        the URL part or the query parameter collection respectively counts.
+        {{</* info */>}}
+        An `_id` or `_rev` attribute specified in the body is ignored.
+        {{</* /info */>}}
 
         If the document was created successfully, then the `Location` header
         contains the path to the newly created document. The `ETag` header field
         contains the revision of the document. Both are only set in the single
         document case.
 
-        If `silent` is not set to `true`, the body of the response contains a
+        Unless `silent` is set to `true`, the body of the response contains a
         JSON object with the following attributes:
-
-          - `_id` contains the document identifier of the newly created document
-          - `_key` contains the document key
-          - `_rev` contains the document revision
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the collection parameter `waitForSync` is `false`, then the call
         returns as soon as the document has been accepted. It does not wait
@@ -691,8 +692,8 @@ paths:
         Replaces the specified document with the one in the body, provided there is
         such a document and no precondition is violated.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         If the `If-Match` header is specified and the revision of the
         document in the database is unequal to the given revision, the
@@ -726,12 +727,12 @@ paths:
         applied. The `waitForSync` query parameter cannot be used to disable
         synchronization for collections that have a default `waitForSync` value
         of `true`.
-
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the updated document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the new document revision.
+        
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -944,8 +945,8 @@ paths:
         yet exist, and overwritten in the existing document if they do exist
         there.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         Setting an attribute value to `null` in the patch document causes a
         value of `null` to be saved for the attribute by default.
@@ -982,12 +983,12 @@ paths:
         applied. The `waitForSync` query parameter cannot be used to disable
         synchronization for collections that have a default `waitForSync` value
         of `true`.
-
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the updated document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the new document revision.
+        
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -1217,11 +1218,11 @@ paths:
     delete:
       operationId: deleteDocument
       description: |
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the removed document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the document revision.
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the `waitForSync` parameter is not specified or set to `false`,
         then the collection's default `waitForSync` behavior is applied.
@@ -1411,11 +1412,11 @@ especially in a cluster deployment.
 ArangoDB continues to process the remaining operations should an error
 occur during the processing of one operation. Errors are returned _inline_ in
 the response body as an error document (see below for more details).
-Additionally, the `X-Arango-Error-Codes` header contains a map of the
-error codes that occurred together with their multiplicities, like
-`1205:10,1210:17` which means that in 10 cases the error 1205
-(illegal document handle) and in 17 cases the error 1210
-(unique constraint violated) has happened.
+Additionally, the `X-Arango-Error-Codes` header is set. It contains a
+map of the error codes and how often each kind of error occurred. For
+example, `1200:17,1205:10` means that in 17 cases the error 1200
+("revision conflict") has happened, and in 10 cases the error 1205
+("illegal document handle").
 
 Generally, the bulk operations expect an input array and the result body
 contains a JSON array of the same length.
@@ -1428,6 +1429,13 @@ paths:
     put:
       operationId: getDocuments
       description: |
+        {{</* warning */>}}
+        The endpoint for getting multiple documents is the same as for replacing
+        multiple documents but with an additional query parameter:
+        `PUT /_api/document/{collection}?onlyget=true`. This is because a lot of
+        software does not support payload bodies in `GET` requests.
+        {{</* /warning */>}}
+
         Returns the documents identified by their `_key` in the body objects.
         The body of the request _must_ contain a JSON array of either
         strings (the `_key` values to lookup) or search documents.
@@ -1441,9 +1449,10 @@ paths:
         are treated as hints to improve performance. Should the shard keys
         values be incorrect ArangoDB may answer with a *not found* error.
 
-        The returned array of documents contain three special attributes: `_id` containing the document
-        identifier, `_key` containing key which uniquely identifies a document
-        in a given collection and `_rev` containing the revision.
+        The returned array of documents contain three special attributes: 
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
       parameters:
         - name: collection
           in: path
@@ -1553,7 +1562,8 @@ paths:
       description: |
         Creates new documents from the documents given in the body, unless there
         is already a document with the `_key` given. If no `_key` is given, a new
-        unique `_key` is generated automatically.
+        unique `_key` is generated automatically. The `_id` is automatically
+        set in both cases, derived from the collection name and `_key`.
 
         The result body contains a JSON array of the
         same length as the input array, and each entry contains the result
@@ -1561,15 +1571,15 @@ paths:
         the entry is a document with attributes `error` set to `true` and
         errorCode set to the error code that has happened.
 
-        Possibly given `_id` and `_rev` attributes in the body are always ignored,
-        the URL part or the query parameter collection respectively counts.
+        {{</* info */>}}
+        Any `_id` or `_rev` attribute specified in the body is ignored.
+        {{</* /info */>}}
 
-        If `silent` is not set to `true`, the body of the response contains an
+        Unless `silent` is set to `true`, the body of the response contains an
         array of JSON objects with the following attributes:
-
-          - `_id` contains the document identifier of the newly created document
-          - `_key` contains the document key
-          - `_rev` contains the document revision
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the collection parameter `waitForSync` is `false`, then the call
         returns as soon as the documents have been accepted. It does not wait
@@ -1590,12 +1600,11 @@ paths:
         generated document, the complete new document is returned under
         the `new` attribute in the result.
 
-        Should an error have occurred with some of the documents
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1205:10,1210:17` which means that in 10
-        cases the error 1205 "illegal document handle" and in 17 cases the
-        error 1210 "unique constraint violated" has happened.
+        Should an error have occurred with some of the documents,
+        the `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       parameters:
         - name: collection
           in: path
@@ -1824,8 +1833,8 @@ paths:
         ones in the body, the replaced documents are specified by the `_key`
         attributes in the body documents.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         If `ignoreRevs` is `false` and there is a `_rev` attribute in a
         document in the body and its value does not match the revision of
@@ -1850,11 +1859,13 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the replaced documents. In each entry, the attribute
-        `_id` contains the known `document-id` of each updated document,
-        `_key` contains the key which uniquely identifies a document in a
-        given collection, and the attribute `_rev` contains the new document
-        revision. In case of an error or violated precondition, an error
+        revision of the replaced documents. In each element has the following
+        attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
+
+        In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
 
@@ -1867,12 +1878,11 @@ paths:
         the `new` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 201 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 201 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -1884,6 +1894,7 @@ paths:
                 documents:
                   description: |
                     A JSON representation of an array of documents.
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection
@@ -1983,9 +1994,9 @@ paths:
         not yet exist, and overwritten in the existing documents if they do
         exist there.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
-
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
+        
         Setting an attribute value to `null` in the patch documents causes a
         value of `null` to be saved for the attribute by default.
 
@@ -2012,11 +2023,13 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the updated documents. In each entry, the attribute
-        `_id` contains the known *document ID* of each updated document,
-        `_key` contains the key which uniquely identifies a document in a
-        given collection, and the attribute `_rev` contains the new document
-        revision. In case of an error or violated precondition, an error
+        revision of the updated documents. Each element has the following
+        attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
+
+        In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
 
@@ -2029,12 +2042,11 @@ paths:
         the `new` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 201 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 201 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -2045,7 +2057,8 @@ paths:
               properties:
                 documents:
                   description: |
-                    A JSON representation of an array of document updates as objects.
+                    A JSON representation of an array of document updates as objects. 
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection
@@ -2171,12 +2184,12 @@ paths:
         The body of the response is an array of the same length as the input
         array. For each input selector, the output contains a JSON object
         with the information about the outcome of the operation. If no error
-        occurred, an object is built in which the attribute `_id` contains
-        the known *document ID* of the removed document, `_key` contains
-        the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the document revision. In case of
-        an error, an object with the attribute `error` set to `true` and
-        `errorCode` set to the error code is built.
+        occurred, then such an object has the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
+        In case of an error, the object has the `error` attribute set to `true`
+        and `errorCode` set to the error code.
 
         If the `waitForSync` parameter is not specified or set to `false`,
         then the collection's default `waitForSync` behavior is applied.
@@ -2189,12 +2202,11 @@ paths:
         is returned under the `old` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 200 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 200 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -2205,7 +2217,8 @@ paths:
               properties:
                 documents:
                   description: |
-                    A JSON array of strings or documents.
+                    A JSON representation of an array of document updates as objects. 
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection

--- a/site/content/3.11/concepts/data-structure/documents/_index.md
+++ b/site/content/3.11/concepts/data-structure/documents/_index.md
@@ -60,15 +60,17 @@ Example document:
 All documents contain special attributes at the top-level that start with an 
 underscore, known as **system attributes**:
 
-- The **document identifier** is stored as a string in the `_id` attribute.
 - The **document key** is stored as a string in the `_key` attribute.
+- The **document identifier** is stored as a string in the `_id` attribute.
 - The **document revision** is stored as a string in the `_rev` attribute.
 
 You can specify a value for the `_key` attribute when creating a document.
+The `_id` attribute is automatically set based on the collection and `_key`.
 The `_id` and `_key` values are immutable once the document has been created.
 The `_rev` value is maintained by ArangoDB automatically.
 
 Edge documents in edge collections have two additional system attributes:
+
 - The document identifier of the source vertex stored in the `_from` attribute.
 - The document identifier of the target vertex stored in the `_to` attribute.
 
@@ -79,6 +81,9 @@ you should avoid using own attribute names starting with an underscore.
 
 Each document has a unique **document key** (or _primary key_) which identifies
 it within its collection.
+
+To distinguish between documents from multiple collections, see
+[Document identifiers](#document-identifiers).
 
 A document key uniquely identifies a document in the collection it is
 stored in. It can and should be used by clients when specific documents
@@ -156,6 +161,10 @@ forward slash (`/`), like `collection-name/document-key`.
 
 See [Collection names](../collections.md#collection-names) and
 [Document keys](#document-keys) for information about the allowed characters.
+
+When working with documents from multiple collections, you can see what
+collections they are from by looking at the `_id` attribute values and tell
+documents from different collections but the same keys apart.
 
 ### Document revisions
 

--- a/site/content/3.11/develop/http-api/documents.md
+++ b/site/content/3.11/develop/http-api/documents.md
@@ -82,9 +82,9 @@ paths:
       description: |
         Returns the document identified by the collection name and document key.
         The returned document contains three special attributes:
-        - `_id` containing the document identifier
-        - `_key` containing key which uniquely identifies a document in a given collection
-        - `_rev` containing the revision
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
       parameters:
         - name: collection
           in: path
@@ -331,23 +331,24 @@ paths:
       operationId: createDocument
       description: |
         Creates a new document from the document given in the body, unless there
-        is already a document with the `_key` given. If no `_key` is given, a new
-        unique `_key` is generated automatically.
+        is already a document with the `_key` given. If no `_key` is given, a
+        new unique `_key` is generated automatically. The `_id` is automatically
+        set in both cases, derived from the collection name and `_key`.
 
-        Possibly given `_id` and `_rev` attributes in the body are always ignored,
-        the URL part or the query parameter collection respectively counts.
+        {{</* info */>}}
+        An `_id` or `_rev` attribute specified in the body is ignored.
+        {{</* /info */>}}
 
         If the document was created successfully, then the `Location` header
         contains the path to the newly created document. The `ETag` header field
         contains the revision of the document. Both are only set in the single
         document case.
 
-        If `silent` is not set to `true`, the body of the response contains a
+        Unless `silent` is set to `true`, the body of the response contains a
         JSON object with the following attributes:
-
-          - `_id` contains the document identifier of the newly created document
-          - `_key` contains the document key
-          - `_rev` contains the document revision
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the collection parameter `waitForSync` is `false`, then the call
         returns as soon as the document has been accepted. It does not wait
@@ -700,8 +701,8 @@ paths:
         Replaces the specified document with the one in the body, provided there is
         such a document and no precondition is violated.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         If the `If-Match` header is specified and the revision of the
         document in the database is unequal to the given revision, the
@@ -735,12 +736,12 @@ paths:
         applied. The `waitForSync` query parameter cannot be used to disable
         synchronization for collections that have a default `waitForSync` value
         of `true`.
-
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the updated document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the new document revision.
+        
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -964,8 +965,8 @@ paths:
         yet exist, and overwritten in the existing document if they do exist
         there.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         Setting an attribute value to `null` in the patch document causes a
         value of `null` to be saved for the attribute by default.
@@ -1002,12 +1003,12 @@ paths:
         applied. The `waitForSync` query parameter cannot be used to disable
         synchronization for collections that have a default `waitForSync` value
         of `true`.
-
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the updated document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the new document revision.
+        
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -1248,11 +1249,11 @@ paths:
     delete:
       operationId: deleteDocument
       description: |
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the removed document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the document revision.
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the `waitForSync` parameter is not specified or set to `false`,
         then the collection's default `waitForSync` behavior is applied.
@@ -1461,11 +1462,11 @@ especially in a cluster deployment.
 ArangoDB continues to process the remaining operations should an error
 occur during the processing of one operation. Errors are returned _inline_ in
 the response body as an error document (see below for more details).
-Additionally, the `X-Arango-Error-Codes` header contains a map of the
-error codes that occurred together with their multiplicities, like
-`1205:10,1210:17` which means that in 10 cases the error 1205
-(illegal document handle) and in 17 cases the error 1210
-(unique constraint violated) has happened.
+Additionally, the `X-Arango-Error-Codes` header is set. It contains a
+map of the error codes and how often each kind of error occurred. For
+example, `1200:17,1205:10` means that in 17 cases the error 1200
+("revision conflict") has happened, and in 10 cases the error 1205
+("illegal document handle").
 
 Generally, the bulk operations expect an input array and the result body
 contains a JSON array of the same length.
@@ -1478,6 +1479,13 @@ paths:
     put:
       operationId: getDocuments
       description: |
+        {{</* warning */>}}
+        The endpoint for getting multiple documents is the same as for replacing
+        multiple documents but with an additional query parameter:
+        `PUT /_api/document/{collection}?onlyget=true`. This is because a lot of
+        software does not support payload bodies in `GET` requests.
+        {{</* /warning */>}}
+
         Returns the documents identified by their `_key` in the body objects.
         The body of the request _must_ contain a JSON array of either
         strings (the `_key` values to lookup) or search documents.
@@ -1491,9 +1499,10 @@ paths:
         are treated as hints to improve performance. Should the shard keys
         values be incorrect ArangoDB may answer with a *not found* error.
 
-        The returned array of documents contain three special attributes: `_id` containing the document
-        identifier, `_key` containing key which uniquely identifies a document
-        in a given collection and `_rev` containing the revision.
+        The returned array of documents contain three special attributes: 
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
       parameters:
         - name: collection
           in: path
@@ -1603,7 +1612,8 @@ paths:
       description: |
         Creates new documents from the documents given in the body, unless there
         is already a document with the `_key` given. If no `_key` is given, a new
-        unique `_key` is generated automatically.
+        unique `_key` is generated automatically. The `_id` is automatically
+        set in both cases, derived from the collection name and `_key`.
 
         The result body contains a JSON array of the
         same length as the input array, and each entry contains the result
@@ -1611,15 +1621,15 @@ paths:
         the entry is a document with attributes `error` set to `true` and
         errorCode set to the error code that has happened.
 
-        Possibly given `_id` and `_rev` attributes in the body are always ignored,
-        the URL part or the query parameter collection respectively counts.
+        {{</* info */>}}
+        Any `_id` or `_rev` attribute specified in the body is ignored.
+        {{</* /info */>}}
 
-        If `silent` is not set to `true`, the body of the response contains an
+        Unless `silent` is set to `true`, the body of the response contains an
         array of JSON objects with the following attributes:
-
-          - `_id` contains the document identifier of the newly created document
-          - `_key` contains the document key
-          - `_rev` contains the document revision
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the collection parameter `waitForSync` is `false`, then the call
         returns as soon as the documents have been accepted. It does not wait
@@ -1640,12 +1650,11 @@ paths:
         generated document, the complete new document is returned under
         the `new` attribute in the result.
 
-        Should an error have occurred with some of the documents
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1205:10,1210:17` which means that in 10
-        cases the error 1205 "illegal document handle" and in 17 cases the
-        error 1210 "unique constraint violated" has happened.
+        Should an error have occurred with some of the documents,
+        the `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       parameters:
         - name: collection
           in: path
@@ -1886,8 +1895,8 @@ paths:
         ones in the body, the replaced documents are specified by the `_key`
         attributes in the body documents.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         If `ignoreRevs` is `false` and there is a `_rev` attribute in a
         document in the body and its value does not match the revision of
@@ -1912,11 +1921,13 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the replaced documents. In each entry, the attribute
-        `_id` contains the known `document-id` of each updated document,
-        `_key` contains the key which uniquely identifies a document in a
-        given collection, and the attribute `_rev` contains the new document
-        revision. In case of an error or violated precondition, an error
+        revision of the replaced documents. In each element has the following
+        attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
+
+        In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
 
@@ -1929,12 +1940,11 @@ paths:
         the `new` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 201 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 201 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -1946,6 +1956,7 @@ paths:
                 documents:
                   description: |
                     A JSON representation of an array of documents.
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection
@@ -2057,9 +2068,9 @@ paths:
         not yet exist, and overwritten in the existing documents if they do
         exist there.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
-
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
+        
         Setting an attribute value to `null` in the patch documents causes a
         value of `null` to be saved for the attribute by default.
 
@@ -2086,11 +2097,13 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the updated documents. In each entry, the attribute
-        `_id` contains the known *document ID* of each updated document,
-        `_key` contains the key which uniquely identifies a document in a
-        given collection, and the attribute `_rev` contains the new document
-        revision. In case of an error or violated precondition, an error
+        revision of the updated documents. Each element has the following
+        attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
+
+        In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
 
@@ -2103,12 +2116,11 @@ paths:
         the `new` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 201 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 201 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -2119,7 +2131,8 @@ paths:
               properties:
                 documents:
                   description: |
-                    A JSON representation of an array of document updates as objects.
+                    A JSON representation of an array of document updates as objects. 
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection
@@ -2257,12 +2270,12 @@ paths:
         The body of the response is an array of the same length as the input
         array. For each input selector, the output contains a JSON object
         with the information about the outcome of the operation. If no error
-        occurred, an object is built in which the attribute `_id` contains
-        the known *document ID* of the removed document, `_key` contains
-        the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the document revision. In case of
-        an error, an object with the attribute `error` set to `true` and
-        `errorCode` set to the error code is built.
+        occurred, then such an object has the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
+        In case of an error, the object has the `error` attribute set to `true`
+        and `errorCode` set to the error code.
 
         If the `waitForSync` parameter is not specified or set to `false`,
         then the collection's default `waitForSync` behavior is applied.
@@ -2275,12 +2288,11 @@ paths:
         is returned under the `old` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 200 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 200 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -2291,7 +2303,8 @@ paths:
               properties:
                 documents:
                   description: |
-                    A JSON array of strings or documents.
+                    A JSON representation of an array of document updates as objects. 
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection

--- a/site/content/3.12/concepts/data-structure/documents/_index.md
+++ b/site/content/3.12/concepts/data-structure/documents/_index.md
@@ -60,15 +60,17 @@ Example document:
 All documents contain special attributes at the top-level that start with an 
 underscore, known as **system attributes**:
 
-- The **document identifier** is stored as a string in the `_id` attribute.
 - The **document key** is stored as a string in the `_key` attribute.
+- The **document identifier** is stored as a string in the `_id` attribute.
 - The **document revision** is stored as a string in the `_rev` attribute.
 
 You can specify a value for the `_key` attribute when creating a document.
+The `_id` attribute is automatically set based on the collection and `_key`.
 The `_id` and `_key` values are immutable once the document has been created.
 The `_rev` value is maintained by ArangoDB automatically.
 
 Edge documents in edge collections have two additional system attributes:
+
 - The document identifier of the source vertex stored in the `_from` attribute.
 - The document identifier of the target vertex stored in the `_to` attribute.
 
@@ -79,6 +81,9 @@ you should avoid using own attribute names starting with an underscore.
 
 Each document has a unique **document key** (or _primary key_) which identifies
 it within its collection.
+
+To distinguish between documents from multiple collections, see
+[Document identifiers](#document-identifiers).
 
 A document key uniquely identifies a document in the collection it is
 stored in. It can and should be used by clients when specific documents
@@ -156,6 +161,10 @@ forward slash (`/`), like `collection-name/document-key`.
 
 See [Collection names](../collections.md#collection-names) and
 [Document keys](#document-keys) for information about the allowed characters.
+
+When working with documents from multiple collections, you can see what
+collections they are from by looking at the `_id` attribute values and tell
+documents from different collections but the same keys apart.
 
 ### Document revisions
 

--- a/site/content/3.12/develop/http-api/documents.md
+++ b/site/content/3.12/develop/http-api/documents.md
@@ -2048,6 +2048,10 @@ paths:
 
         The value of the `_key` attribute as well as attributes
         used as sharding keys may not be changed.
+        
+        {{< warning >}}
+        Possibly given `_id` attribute in the body are always ignored.
+        {{< /warning >}}
 
         Setting an attribute value to `null` in the patch documents causes a
         value of `null` to be saved for the attribute by default.
@@ -2109,7 +2113,8 @@ paths:
               properties:
                 documents:
                   description: |
-                    A JSON representation of an array of document updates as objects.
+                    A JSON representation of an array of document updates as objects. 
+                    Each entry has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection
@@ -2282,7 +2287,8 @@ paths:
               properties:
                 documents:
                   description: |
-                    A JSON array of strings or documents.
+                    A JSON representation of an array of document updates as objects. 
+                    Each entry has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection

--- a/site/content/3.12/develop/http-api/documents.md
+++ b/site/content/3.12/develop/http-api/documents.md
@@ -82,8 +82,9 @@ paths:
       description: |
         Returns the document identified by the collection name and document key.
         The returned document contains three special attributes:
-        - `_id` containing the document identifier
-        - `_key` containing key which uniquely identifies a document in a given collection
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
         - `_rev` containing the revision
       parameters:
         - name: collection
@@ -334,19 +335,20 @@ paths:
         is already a document with the `_key` given. If no `_key` is given, a new
         unique `_key` is generated automatically.
 
+        {{< warning >}}
         Possibly given `_id` and `_rev` attributes in the body are always ignored,
         the URL part or the query parameter collection respectively counts.
+        {{< /warning >}}
 
         If the document was created successfully, then the `Location` header
         contains the path to the newly created document. The `ETag` header field
         contains the revision of the document. Both are only set in the single
         document case.
 
-        If `silent` is not set to `true`, the body of the response contains a
-        JSON object with the following attributes:
-
-          - `_id` contains the document identifier of the newly created document
-          - `_key` contains the document key
+        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
+          - `_id` contains the document identifier build with the following pattern: `collection-name/_key`. 
+            It is useful for identifying documents in a result that combines data from multiple collections.
+          - `_key` contains key which uniquely identifies a document in a **given** collection
           - `_rev` contains the document revision
 
         If the collection parameter `waitForSync` is `false`, then the call
@@ -485,7 +487,9 @@ paths:
               properties:
                 document:
                   description: |
-                    A JSON representation of a single document.
+                    A JSON representation of a single document. If the `_key` attribute is not empty, then it will be 
+                    used as the document identifier. If the `_key` attribute is empty or missing, then the server will 
+                    auto-generate a unique document identifier.
                   type: object
       responses:
         '201':
@@ -725,12 +729,12 @@ paths:
         applied. The `waitForSync` query parameter cannot be used to disable
         synchronization for collections that have a default `waitForSync` value
         of `true`.
-
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the updated document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the new document revision.
+        
+        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -752,7 +756,7 @@ paths:
               properties:
                 document:
                   description: |
-                    A JSON representation of a single document.
+                    A JSON representation of a single document. It has to contain a `_key` attribute.
                   type: object
       parameters:
         - name: collection
@@ -992,12 +996,12 @@ paths:
         applied. The `waitForSync` query parameter cannot be used to disable
         synchronization for collections that have a default `waitForSync` value
         of `true`.
-
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the updated document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the new document revision.
+        
+        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -1238,11 +1242,11 @@ paths:
     delete:
       operationId: deleteDocument
       description: |
-        If `silent` is not set to `true`, the body of the response contains a JSON
-        object with the information about the identifier and the revision. The attribute
-        `_id` contains the known *document ID* of the removed document, `_key`
-        contains the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the document revision.
+        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
 
         If the `waitForSync` parameter is not specified or set to `false`,
         then the collection's default `waitForSync` behavior is applied.
@@ -1481,9 +1485,11 @@ paths:
         are treated as hints to improve performance. Should the shard keys
         values be incorrect ArangoDB may answer with a *not found* error.
 
-        The returned array of documents contain three special attributes: `_id` containing the document
-        identifier, `_key` containing key which uniquely identifies a document
-        in a given collection and `_rev` containing the revision.
+        The returned array of documents contain three special attributes: 
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
       parameters:
         - name: collection
           in: path
@@ -1601,15 +1607,17 @@ paths:
         the entry is a document with attributes `error` set to `true` and
         errorCode set to the error code that has happened.
 
+        {{< warning >}}
         Possibly given `_id` and `_rev` attributes in the body are always ignored,
         the URL part or the query parameter collection respectively counts.
+        {{< /warning >}}
 
         If `silent` is not set to `true`, the body of the response contains an
         array of JSON objects with the following attributes:
-
-          - `_id` contains the document identifier of the newly created document
-          - `_key` contains the document key
-          - `_rev` contains the document revision
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
 
         If the collection parameter `waitForSync` is `false`, then the call
         returns as soon as the documents have been accepted. It does not wait
@@ -1892,11 +1900,12 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the replaced documents. In each entry, the attribute
-        `_id` contains the known `document-id` of each updated document,
-        `_key` contains the key which uniquely identifies a document in a
-        given collection, and the attribute `_rev` contains the new document
-        revision. In case of an error or violated precondition, an error
+        revision of the replaced documents. In each entry there are following attributes:
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
+        In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
 
@@ -2066,11 +2075,12 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the updated documents. In each entry, the attribute
-        `_id` contains the known *document ID* of each updated document,
-        `_key` contains the key which uniquely identifies a document in a
-        given collection, and the attribute `_rev` contains the new document
-        revision. In case of an error or violated precondition, an error
+        revision of the updated documents. In each entry there are following attributes:
+        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
+        In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
 
@@ -2237,11 +2247,12 @@ paths:
         The body of the response is an array of the same length as the input
         array. For each input selector, the output contains a JSON object
         with the information about the outcome of the operation. If no error
-        occurred, an object is built in which the attribute `_id` contains
-        the known *document ID* of the removed document, `_key` contains
-        the key which uniquely identifies a document in a given collection,
-        and the attribute `_rev` contains the document revision. In case of
-        an error, an object with the attribute `error` set to `true` and
+        occurred, an object is built from the following attributes:
+        - `_id` containing the removed document identifier build with the following pattern: `collection-name/_key`. 
+          It is useful for identifying documents in a result that combines data from multiple collections.
+        - `_key` containing key which uniquely identifies a document in a **given** collection
+        - `_rev` containing the revision.
+        In case of an error, an object with the attribute `error` set to `true` and
         `errorCode` set to the error code is built.
 
         If the `waitForSync` parameter is not specified or set to `false`,

--- a/site/content/3.12/develop/http-api/documents.md
+++ b/site/content/3.12/develop/http-api/documents.md
@@ -82,10 +82,9 @@ paths:
       description: |
         Returns the document identified by the collection name and document key.
         The returned document contains three special attributes:
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
       parameters:
         - name: collection
           in: path
@@ -332,24 +331,24 @@ paths:
       operationId: createDocument
       description: |
         Creates a new document from the document given in the body, unless there
-        is already a document with the `_key` given. If no `_key` is given, a new
-        unique `_key` is generated automatically.
+        is already a document with the `_key` given. If no `_key` is given, a
+        new unique `_key` is generated automatically. The `_id` is automatically
+        set in both cases, derived from the collection name and `_key`.
 
-        {{< warning >}}
-        Possibly given `_id` and `_rev` attributes in the body are always ignored,
-        the URL part or the query parameter collection respectively counts.
-        {{< /warning >}}
+        {{</* info */>}}
+        An `_id` or `_rev` attribute specified in the body is ignored.
+        {{</* /info */>}}
 
         If the document was created successfully, then the `Location` header
         contains the path to the newly created document. The `ETag` header field
         contains the revision of the document. Both are only set in the single
         document case.
 
-        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
-          - `_id` contains the document identifier build with the following pattern: `collection-name/_key`. 
-            It is useful for identifying documents in a result that combines data from multiple collections.
-          - `_key` contains key which uniquely identifies a document in a **given** collection
-          - `_rev` contains the document revision
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the collection parameter `waitForSync` is `false`, then the call
         returns as soon as the document has been accepted. It does not wait
@@ -487,9 +486,7 @@ paths:
               properties:
                 document:
                   description: |
-                    A JSON representation of a single document. If the `_key` attribute is not empty, then it will be 
-                    used as the document identifier. If the `_key` attribute is empty or missing, then the server will 
-                    auto-generate a unique document identifier.
+                    A JSON representation of a single document.
                   type: object
       responses:
         '201':
@@ -694,8 +691,8 @@ paths:
         Replaces the specified document with the one in the body, provided there is
         such a document and no precondition is violated.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         If the `If-Match` header is specified and the revision of the
         document in the database is unequal to the given revision, the
@@ -730,11 +727,11 @@ paths:
         synchronization for collections that have a default `waitForSync` value
         of `true`.
         
-        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -756,7 +753,7 @@ paths:
               properties:
                 document:
                   description: |
-                    A JSON representation of a single document. It has to contain a `_key` attribute.
+                    A JSON representation of a single document.
                   type: object
       parameters:
         - name: collection
@@ -958,8 +955,8 @@ paths:
         yet exist, and overwritten in the existing document if they do exist
         there.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         Setting an attribute value to `null` in the patch document causes a
         value of `null` to be saved for the attribute by default.
@@ -997,11 +994,11 @@ paths:
         synchronization for collections that have a default `waitForSync` value
         of `true`.
         
-        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
 
         If the query parameter `returnOld` is `true`, then
         the complete previous revision of the document
@@ -1242,11 +1239,11 @@ paths:
     delete:
       operationId: deleteDocument
       description: |
-        If `silent` is not set to `true`, the body of the response contains a JSON object with the following attributes:
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
+        Unless `silent` is set to `true`, the body of the response contains a
+        JSON object with the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the `waitForSync` parameter is not specified or set to `false`,
         then the collection's default `waitForSync` behavior is applied.
@@ -1455,11 +1452,11 @@ especially in a cluster deployment.
 ArangoDB continues to process the remaining operations should an error
 occur during the processing of one operation. Errors are returned _inline_ in
 the response body as an error document (see below for more details).
-Additionally, the `X-Arango-Error-Codes` header contains a map of the
-error codes that occurred together with their multiplicities, like
-`1205:10,1210:17` which means that in 10 cases the error 1205
-(illegal document handle) and in 17 cases the error 1210
-(unique constraint violated) has happened.
+Additionally, the `X-Arango-Error-Codes` header is set. It contains a
+map of the error codes and how often each kind of error occurred. For
+example, `1200:17,1205:10` means that in 17 cases the error 1200
+("revision conflict") has happened, and in 10 cases the error 1205
+("illegal document handle").
 
 Generally, the bulk operations expect an input array and the result body
 contains a JSON array of the same length.
@@ -1472,6 +1469,13 @@ paths:
     put:
       operationId: getDocuments
       description: |
+        {{</* warning */>}}
+        The endpoint for getting multiple documents is the same as for replacing
+        multiple documents but with an additional query parameter:
+        `PUT /_api/document/{collection}?onlyget=true`. This is because a lot of
+        software does not support payload bodies in `GET` requests.
+        {{</* /warning */>}}
+
         Returns the documents identified by their `_key` in the body objects.
         The body of the request _must_ contain a JSON array of either
         strings (the `_key` values to lookup) or search documents.
@@ -1486,10 +1490,9 @@ paths:
         values be incorrect ArangoDB may answer with a *not found* error.
 
         The returned array of documents contain three special attributes: 
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
       parameters:
         - name: collection
           in: path
@@ -1599,7 +1602,8 @@ paths:
       description: |
         Creates new documents from the documents given in the body, unless there
         is already a document with the `_key` given. If no `_key` is given, a new
-        unique `_key` is generated automatically.
+        unique `_key` is generated automatically. The `_id` is automatically
+        set in both cases, derived from the collection name and `_key`.
 
         The result body contains a JSON array of the
         same length as the input array, and each entry contains the result
@@ -1607,17 +1611,15 @@ paths:
         the entry is a document with attributes `error` set to `true` and
         errorCode set to the error code that has happened.
 
-        {{< warning >}}
-        Possibly given `_id` and `_rev` attributes in the body are always ignored,
-        the URL part or the query parameter collection respectively counts.
-        {{< /warning >}}
+        {{</* info */>}}
+        Any `_id` or `_rev` attribute specified in the body is ignored.
+        {{</* /info */>}}
 
-        If `silent` is not set to `true`, the body of the response contains an
+        Unless `silent` is set to `true`, the body of the response contains an
         array of JSON objects with the following attributes:
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
 
         If the collection parameter `waitForSync` is `false`, then the call
         returns as soon as the documents have been accepted. It does not wait
@@ -1638,12 +1640,11 @@ paths:
         generated document, the complete new document is returned under
         the `new` attribute in the result.
 
-        Should an error have occurred with some of the documents
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1205:10,1210:17` which means that in 10
-        cases the error 1205 "illegal document handle" and in 17 cases the
-        error 1210 "unique constraint violated" has happened.
+        Should an error have occurred with some of the documents,
+        the `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       parameters:
         - name: collection
           in: path
@@ -1874,8 +1875,8 @@ paths:
         ones in the body, the replaced documents are specified by the `_key`
         attributes in the body documents.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
 
         If `ignoreRevs` is `false` and there is a `_rev` attribute in a
         document in the body and its value does not match the revision of
@@ -1900,11 +1901,12 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the replaced documents. In each entry there are following attributes:
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
+        revision of the replaced documents. In each element has the following
+        attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
+
         In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
@@ -1918,12 +1920,11 @@ paths:
         the `new` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 201 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 201 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -1935,6 +1936,7 @@ paths:
                 documents:
                   description: |
                     A JSON representation of an array of documents.
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection
@@ -2046,13 +2048,9 @@ paths:
         not yet exist, and overwritten in the existing documents if they do
         exist there.
 
-        The value of the `_key` attribute as well as attributes
-        used as sharding keys may not be changed.
+        The values of the `_key`, `_id`, and `_rev` system attributes as well as
+        attributes used as sharding keys cannot be changed.
         
-        {{< warning >}}
-        Possibly given `_id` attribute in the body are always ignored.
-        {{< /warning >}}
-
         Setting an attribute value to `null` in the patch documents causes a
         value of `null` to be saved for the attribute by default.
 
@@ -2079,11 +2077,12 @@ paths:
 
         The body of the response contains a JSON array of the same length
         as the input array with the information about the identifier and the
-        revision of the updated documents. In each entry there are following attributes:
-        - `_id` containing the document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
+        revision of the updated documents. Each element has the following
+        attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the new document revision.
+
         In case of an error or violated precondition, an error
         object with the attribute `error` set to `true` and the attribute
         `errorCode` set to the error code is built.
@@ -2097,12 +2096,11 @@ paths:
         the `new` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 201 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 201 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -2114,7 +2112,7 @@ paths:
                 documents:
                   description: |
                     A JSON representation of an array of document updates as objects. 
-                    Each entry has to contain a `_key` attribute.
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection
@@ -2252,13 +2250,12 @@ paths:
         The body of the response is an array of the same length as the input
         array. For each input selector, the output contains a JSON object
         with the information about the outcome of the operation. If no error
-        occurred, an object is built from the following attributes:
-        - `_id` containing the removed document identifier build with the following pattern: `collection-name/_key`. 
-          It is useful for identifying documents in a result that combines data from multiple collections.
-        - `_key` containing key which uniquely identifies a document in a **given** collection
-        - `_rev` containing the revision.
-        In case of an error, an object with the attribute `error` set to `true` and
-        `errorCode` set to the error code is built.
+        occurred, then such an object has the following attributes:
+        - `_id`, containing the document identifier with the format `<collection-name>/<document-key>`.
+        - `_key`, containing the document key that uniquely identifies a document within the collection.
+        - `_rev`, containing the document revision.
+        In case of an error, the object has the `error` attribute set to `true`
+        and `errorCode` set to the error code.
 
         If the `waitForSync` parameter is not specified or set to `false`,
         then the collection's default `waitForSync` behavior is applied.
@@ -2271,12 +2268,11 @@ paths:
         is returned under the `old` attribute in the result.
 
         Note that if any precondition is violated or an error occurred with
-        some of the documents, the return code is still 200 or 202, but
-        the additional HTTP header `X-Arango-Error-Codes` is set, which
-        contains a map of the error codes that occurred together with their
-        multiplicities, as in: `1200:17,1205:10` which means that in 17
-        cases the error 1200 "revision conflict" and in 10 cases the error
-        1205 "illegal document handle" has happened.
+        some of the documents, the return code is still 200 or 202, but the
+        `X-Arango-Error-Codes` HTTP header is set. It contains a map of the
+        error codes and how often each kind of error occurred. For example,
+        `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
+        has happened, and in 10 cases the error 1205 ("illegal document handle").
       requestBody:
         content:
           application/json:
@@ -2288,7 +2284,7 @@ paths:
                 documents:
                   description: |
                     A JSON representation of an array of document updates as objects. 
-                    Each entry has to contain a `_key` attribute.
+                    Each element has to contain a `_key` attribute.
                   type: json
       parameters:
         - name: collection


### PR DESCRIPTION
### Description

Document API was unclear for the `_id` and `_key` fields use cases

