### PR TITLE
DOC-621 | Warn about mixing user-specified and auto-generated keys for a collection with 2+ shards

### DIFF
--- a/site/content/3.10/concepts/data-structure/documents/_index.md
+++ b/site/content/3.10/concepts/data-structure/documents/_index.md
@@ -98,6 +98,13 @@ collections with the `keyOptions` attribute. Using `keyOptions`, it is possible
 to disallow user-specified keys completely, or to force a specific regime for
 auto-generating the `_key` values.
 
+{{< warning >}}
+You should not use both user-specified and automatically generated document keys
+in the same collection in cluster deployments for collections with more than a
+single shard. Mixing the two can lead to conflicts because Coordinators that
+auto-generate keys in this case are not aware of all keys which are already used.
+{{< /warning >}}
+
 #### User-specified keys
 
 If you allow user-specified keys, you can pick the key values as required,

--- a/site/content/3.10/develop/http-api/collections.md
+++ b/site/content/3.10/develop/http-api/collections.md
@@ -236,6 +236,13 @@ paths:
                           `false`, then the key generator is solely responsible for
                           generating keys and an error is raised if you supply own key values in the
                           `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
                         type: boolean
                       increment:
                         description: |
@@ -1081,6 +1088,14 @@ paths:
                         `_key` attribute of documents. If set to `false`, then the key generator
                         is solely be responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
+
+
+                        {{</* warning */>}}
+                        You should not use both user-specified and automatically generated document keys
+                        in the same collection in cluster deployments for collections with more than a
+                        single shard. Mixing the two can lead to conflicts because Coordinators that
+                        auto-generate keys in this case are not aware of all keys which are already used.
+                        {{</* /warning */>}}
                       type: boolean
                     increment:
                       description: |
@@ -1350,6 +1365,13 @@ paths:
                           `false`, then the key generator is solely responsible for
                           generating keys and an error is raised if you supply own key values in the
                           `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
                         type: boolean
                       increment:
                         description: |

--- a/site/content/3.10/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.10/develop/javascript-api/@arangodb/collection-object.md
@@ -201,6 +201,13 @@ Returns an object containing all collection properties.
     `false`, then the key generator is solely responsible for
     generating keys and an error is raised if you supply own key values in the
     `_key` attribute of documents.
+
+    {{< warning >}}
+    You should not use both user-specified and automatically generated document keys
+    in the same collection in cluster deployments for collections with more than a
+    single shard. Mixing the two can lead to conflicts because Coordinators that
+    auto-generate keys in this case are not aware of all keys which are already used.
+    {{< /warning >}}
   - `increment` (number): The increment value for the `autoincrement` key generator.
     Not used for other key generator types.
   - `offset` (number): The initial offset value for the `autoincrement` key generator.

--- a/site/content/3.10/develop/javascript-api/@arangodb/db-object.md
+++ b/site/content/3.10/develop/javascript-api/@arangodb/db-object.md
@@ -265,6 +265,13 @@ error is thrown. For information about the naming constraints for collections, s
     `false`, then the key generator is solely responsible for generating keys and
     an error is raised if you supply own key values in the `_key` attribute
     of documents.
+
+    {{< warning >}}
+    You should not use both user-specified and automatically generated document keys
+    in the same collection in cluster deployments for collections with more than a
+    single shard. Mixing the two can lead to conflicts because Coordinators that
+    auto-generate keys in this case are not aware of all keys which are already used.
+    {{< /warning >}}
   - `increment`: The increment value for the `autoincrement` key generator.
     Not used for other key generator types.
   - `offset`: The initial offset value for the `autoincrement` key generator.

--- a/site/content/3.11/concepts/data-structure/documents/_index.md
+++ b/site/content/3.11/concepts/data-structure/documents/_index.md
@@ -98,6 +98,13 @@ collections with the `keyOptions` attribute. Using `keyOptions`, it is possible
 to disallow user-specified keys completely, or to force a specific regime for
 auto-generating the `_key` values.
 
+{{< warning >}}
+You should not use both user-specified and automatically generated document keys
+in the same collection in cluster deployments for collections with more than a
+single shard. Mixing the two can lead to conflicts because Coordinators that
+auto-generate keys in this case are not aware of all keys which are already used.
+{{< /warning >}}
+
 #### User-specified keys
 
 If you allow user-specified keys, you can pick the key values as required,

--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -236,6 +236,13 @@ paths:
                           `false`, then the key generator is solely responsible for
                           generating keys and an error is raised if you supply own key values in the
                           `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
                         type: boolean
                       increment:
                         description: |
@@ -1081,6 +1088,14 @@ paths:
                         `_key` attribute of documents. If set to `false`, then the key generator
                         is solely be responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
+
+
+                        {{</* warning */>}}
+                        You should not use both user-specified and automatically generated document keys
+                        in the same collection in cluster deployments for collections with more than a
+                        single shard. Mixing the two can lead to conflicts because Coordinators that
+                        auto-generate keys in this case are not aware of all keys which are already used.
+                        {{</* /warning */>}}
                       type: boolean
                     increment:
                       description: |
@@ -1350,6 +1365,13 @@ paths:
                           `false`, then the key generator is solely responsible for
                           generating keys and an error is raised if you supply own key values in the
                           `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
                         type: boolean
                       increment:
                         description: |

--- a/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
@@ -201,6 +201,13 @@ Returns an object containing all collection properties.
     `false`, then the key generator is solely responsible for
     generating keys and an error is raised if you supply own key values in the
     `_key` attribute of documents.
+
+    {{< warning >}}
+    You should not use both user-specified and automatically generated document keys
+    in the same collection in cluster deployments for collections with more than a
+    single shard. Mixing the two can lead to conflicts because Coordinators that
+    auto-generate keys in this case are not aware of all keys which are already used.
+    {{< /warning >}}
   - `increment` (number): The increment value for the `autoincrement` key generator.
     Not used for other key generator types.
   - `offset` (number): The initial offset value for the `autoincrement` key generator.

--- a/site/content/3.11/develop/javascript-api/@arangodb/db-object.md
+++ b/site/content/3.11/develop/javascript-api/@arangodb/db-object.md
@@ -265,6 +265,13 @@ error is thrown. For information about the naming constraints for collections, s
     `false`, then the key generator is solely responsible for generating keys and
     an error is raised if you supply own key values in the `_key` attribute
     of documents.
+
+    {{< warning >}}
+    You should not use both user-specified and automatically generated document keys
+    in the same collection in cluster deployments for collections with more than a
+    single shard. Mixing the two can lead to conflicts because Coordinators that
+    auto-generate keys in this case are not aware of all keys which are already used.
+    {{< /warning >}}
   - `increment`: The increment value for the `autoincrement` key generator.
     Not used for other key generator types.
   - `offset`: The initial offset value for the `autoincrement` key generator.

--- a/site/content/3.12/concepts/data-structure/documents/_index.md
+++ b/site/content/3.12/concepts/data-structure/documents/_index.md
@@ -98,6 +98,13 @@ collections with the `keyOptions` attribute. Using `keyOptions`, it is possible
 to disallow user-specified keys completely, or to force a specific regime for
 auto-generating the `_key` values.
 
+{{< warning >}}
+You should not use both user-specified and automatically generated document keys
+in the same collection in cluster deployments for collections with more than a
+single shard. Mixing the two can lead to conflicts because Coordinators that
+auto-generate keys in this case are not aware of all keys which are already used.
+{{< /warning >}}
+
 #### User-specified keys
 
 If you allow user-specified keys, you can pick the key values as required,

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -236,6 +236,13 @@ paths:
                           `false`, then the key generator is solely responsible for
                           generating keys and an error is raised if you supply own key values in the
                           `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
                         type: boolean
                       increment:
                         description: |
@@ -1081,6 +1088,14 @@ paths:
                         `_key` attribute of documents. If set to `false`, then the key generator
                         is solely be responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
+
+
+                        {{</* warning */>}}
+                        You should not use both user-specified and automatically generated document keys
+                        in the same collection in cluster deployments for collections with more than a
+                        single shard. Mixing the two can lead to conflicts because Coordinators that
+                        auto-generate keys in this case are not aware of all keys which are already used.
+                        {{</* /warning */>}}
                       type: boolean
                     increment:
                       description: |
@@ -1350,6 +1365,13 @@ paths:
                           `false`, then the key generator is solely responsible for
                           generating keys and an error is raised if you supply own key values in the
                           `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
                         type: boolean
                       increment:
                         description: |

--- a/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
@@ -201,6 +201,13 @@ Returns an object containing all collection properties.
     `false`, then the key generator is solely responsible for
     generating keys and an error is raised if you supply own key values in the
     `_key` attribute of documents.
+
+    {{< warning >}}
+    You should not use both user-specified and automatically generated document keys
+    in the same collection in cluster deployments for collections with more than a
+    single shard. Mixing the two can lead to conflicts because Coordinators that
+    auto-generate keys in this case are not aware of all keys which are already used.
+    {{< /warning >}}
   - `increment` (number): The increment value for the `autoincrement` key generator.
     Not used for other key generator types.
   - `offset` (number): The initial offset value for the `autoincrement` key generator.

--- a/site/content/3.12/develop/javascript-api/@arangodb/db-object.md
+++ b/site/content/3.12/develop/javascript-api/@arangodb/db-object.md
@@ -265,6 +265,13 @@ error is thrown. For information about the naming constraints for collections, s
     `false`, then the key generator is solely responsible for generating keys and
     an error is raised if you supply own key values in the `_key` attribute
     of documents.
+
+    {{< warning >}}
+    You should not use both user-specified and automatically generated document keys
+    in the same collection in cluster deployments for collections with more than a
+    single shard. Mixing the two can lead to conflicts because Coordinators that
+    auto-generate keys in this case are not aware of all keys which are already used.
+    {{< /warning >}}
   - `increment`: The increment value for the `autoincrement` key generator.
     Not used for other key generator types.
   - `offset`: The initial offset value for the `autoincrement` key generator.


### PR DESCRIPTION
### Description

~To be applied to 3.10 and 3.11 after review~

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
