### PR TITLE
Toolchain: Wait for cluster and single server until they are ready

### DIFF
--- a/toolchain/scripts/toolchain.sh
+++ b/toolchain/scripts/toolchain.sh
@@ -364,13 +364,20 @@ function process_server() {
 
 ### Check status of ArangoDB instance until it is up and running
 function wait_for_arangodb_ready() {
+  attemps=1
   res=$(docker exec -it $1 wget -q -S -O - http://localhost:8529/_api/version 2>&1 | grep -m 1 HTTP/ | awk '{print $2}')
   if [ "$res" = "200" ]; then
     log "Server is ready: $1"
   else
     log "Server not ready: $1  $res"
-    sleep 2s
-    wait_for_arangodb_ready $1
+    let attemps++
+    if [ "$attemps" -gt 30 ]; then
+      log "Giving up waiting on server."
+      exit 1
+    else
+      sleep 2s
+      wait_for_arangodb_ready $1
+    fi
   fi
 }
 

--- a/toolchain/scripts/toolchain.sh
+++ b/toolchain/scripts/toolchain.sh
@@ -364,19 +364,19 @@ function process_server() {
 
 ### Check status of ArangoDB instance until it is up and running
 function wait_for_arangodb_ready() {
-  attemps=1
+  attempts="${2:-1}"
   res=$(docker exec -it $1 wget -q -S -O - http://localhost:8529/_api/version 2>&1 | grep -m 1 HTTP/ | awk '{print $2}')
   if [ "$res" = "200" ]; then
     log "Server is ready: $1"
   else
     log "Server not ready: $1  $res"
-    let attemps++
-    if [ "$attemps" -gt 30 ]; then
+    let attempts++
+    if [ "$attempts" -gt 30 ]; then
       log "Giving up waiting on server."
       exit 1
     else
       sleep 2s
-      wait_for_arangodb_ready $1
+      wait_for_arangodb_ready $1 $attempts
     fi
   fi
 }


### PR DESCRIPTION
### Description

Fix the following CircleCI error in scheduled workflow:

```
toolchain  | [arangodb/enterprise-preview:3.10-nightly 3.10] [run_arangodb_container] Run cluster server
toolchain  | 7976000485ac10583752d694c8ab2a2633d9d83e78689c581291883b7dedd3dc
...
toolchain  | Error response from daemon: Container 7976000485ac10583752d694c8ab2a2633d9d83e78689c581291883b7dedd3dc is not running
toolchain  | [arangodb/enterprise-preview:3.10-nightly 3.10] [generate_optimizer_rules] [ERROR] 
toolchain  | [arangodb/enterprise-preview:3.10-nightly 3.10] [generate_optimizer_rules] Done
```

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: arangodb/enterprise-preview:3.10-nightly
- 3.11: arangodb/enterprise-preview:3.11-nightly
- 3.12: arangodb/enterprise-preview:devel-nightly
