### PR TITLE
Check whether docsearch is defined before calling it

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/search.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/search.html
@@ -4,6 +4,7 @@
 
 <script type="text/javascript">
   window.setupDocSearch = function (facetVersion) {
+    if (!window.docsearch) return;
     docsearch({
       appId: "OK3ZBQ5982",
       apiKey: "500c85ccecb335d507fe4449aed12e1d",


### PR DESCRIPTION
### Description

Prevents the docs from remaining hidden because of an error in theme.js as the result of e.g. the browser blocking the load of the docsearch script

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
