### PR TITLE
Changes related to the storage engine

### DIFF
--- a/site/content/3.12/aql/data-queries.md
+++ b/site/content/3.12/aql/data-queries.md
@@ -541,12 +541,12 @@ On a single server, data modification operations are executed transactionally.
 If a data modification operation fails, any changes made by it are rolled 
 back automatically as if they never happened. 
 
-If the RocksDB engine is used and intermediate commits are enabled, a query may 
-execute intermediate transaction commits in case the running transaction (AQL
-query) hits the specified size thresholds. In this case, the query's operations 
-carried out so far are committed and not rolled back in case of a later abort/rollback. 
-That behavior can be controlled by adjusting the intermediate commit settings for 
-the RocksDB engine. 
+A query may execute intermediate transaction commits in case the running
+transaction (AQL query) hits the specified size thresholds. In this case, the
+query's operations carried out so far are committed and not rolled back in case
+of a later abort/rollback. This behavior can be controlled by adjusting the
+intermediate commit settings for the RocksDB engine. See
+[Known limitations for AQL queries](fundamentals/limitations.md#storage-engine-properties).
 
 In a cluster, AQL data modification queries are not executed transactionally.
 Additionally, AQL queries with `UPDATE`, `REPLACE`, `UPSERT`, or `REMOVE`

--- a/site/content/3.12/aql/fundamentals/limitations.md
+++ b/site/content/3.12/aql/fundamentals/limitations.md
@@ -7,6 +7,8 @@ description: >-
   they operate on, as well as design limitations to be aware of
 archetype: default
 ---
+## Complexity limitations
+
 The following hard-coded limitations exist for AQL queries:
 
 - An AQL query cannot use more than _1000_ result registers.
@@ -37,7 +39,9 @@ of different collections. Please also consider that large queries (in terms of
 intermediate result size or final result size) can use considerable amounts of
 memory and may hit the configurable memory limits for AQL queries.
 
-The following other limitations are known for AQL queries:
+## Design limitations
+
+The following design limitations are known for AQL queries:
 
 - Subqueries that are used inside expressions are pulled out of these
   expressions and executed beforehand. That means that subqueries do not
@@ -52,3 +56,50 @@ The following other limitations are known for AQL queries:
   [`WITH` statement](../high-level-operations/with.md). To make the `WITH` statement
   required in single server as well (e.g. for testing a migration to cluster),
   please start the server with the option `--query.require-with`.
+
+## Storage engine properties
+
+{{< info >}}
+The following restrictions and limitations do not apply to JavaScript Transactions
+and Stream Transactions, including AQL queries that run inside such transactions.
+Their intended use case is for smaller transactions with full transactional
+guarantees. So the following only applies to standalone AQL queries.
+{{< /info >}}
+
+Data of ongoing transactions is stored in RAM. Transactions that get too big
+(in terms of number of operations involved or the total size of data created or
+modified by the transaction) are committed automatically. Effectively, this
+means that big user transactions are split into multiple smaller RocksDB
+transactions that are committed individually. The entire user transaction does
+not necessarily have ACID properties in this case.
+
+The following startup options can be used to control the RAM usage and automatic
+intermediate commits for the RocksDB engine:
+
+- `--rocksdb.max-transaction-size`
+
+  Transaction size limit (in bytes). Transactions store all keys and values in
+  RAM, so large transactions run the risk of causing out-of-memory situations.
+  This setting allows you to ensure that does not happen by limiting the size of
+  any individual transaction. Transactions whose operations would consume more
+  RAM than this threshold value will abort automatically with error 32 ("resource
+  limit exceeded").
+
+- `--rocksdb.intermediate-commit-size`
+
+  If the size of all operations in a transaction reaches this threshold, the transaction
+  is committed automatically and a new transaction is started. The value is specified in bytes.
+
+- `--rocksdb.intermediate-commit-count`
+
+  If the number of operations in a transaction reaches this value, the transaction is
+  committed automatically and a new transaction is started.
+
+The above values can also be adjusted per query, for example, by setting the
+following attributes in the call to `db._query()` in the JavaScript API:
+
+- `maxTransactionSize`: transaction size limit in bytes
+- `intermediateCommitSize`: maximum total size of operations after which an intermediate
+  commit is performed automatically
+- `intermediateCommitCount`: maximum number of operations after which an intermediate
+  commit is performed automatically

--- a/site/content/3.12/aql/high-level-operations/insert.md
+++ b/site/content/3.12/aql/high-level-operations/insert.md
@@ -205,12 +205,12 @@ FOR i IN 1..100
 On a single server, an insert operation is executed transactionally in an
 all-or-nothing fashion.
 
-If the RocksDB engine is used and intermediate commits are enabled, a query may
-execute intermediate transaction commits in case the running transaction (AQL
-query) hits the specified size thresholds. In this case, the query's operations
-carried out so far will be committed and not rolled back in case of a later
-abort/rollback. That behavior can be controlled by adjusting the intermediate
-commit settings for the RocksDB engine.
+A query may execute intermediate transaction commits in case the running
+transaction (AQL query) hits the specified size thresholds. In this case, the
+query's operations carried out so far are committed and not rolled back in case
+of a later abort/rollback. This behavior can be controlled by adjusting the
+intermediate commit settings for the RocksDB engine. See
+[Known limitations for AQL queries](../fundamentals/limitations.md#storage-engine-properties).
 
 For sharded collections, the entire query and/or insert operation may not be
 transactional, especially if it involves different shards and/or DB-Servers.

--- a/site/content/3.12/aql/high-level-operations/remove.md
+++ b/site/content/3.12/aql/high-level-operations/remove.md
@@ -175,12 +175,12 @@ FOR u IN users
 On a single server, the document removal is executed transactionally in an
 all-or-nothing fashion.
 
-If the RocksDB engine is used and intermediate commits are enabled, a query may
-execute intermediate transaction commits in case the running transaction (AQL
-query) hits the specified size thresholds. In this case, the query's operations
-carried out so far will be committed and not rolled back in case of a later
-abort/rollback. That behavior can be controlled by adjusting the intermediate
-commit settings for the RocksDB engine. 
+A query may execute intermediate transaction commits in case the running
+transaction (AQL query) hits the specified size thresholds. In this case, the
+query's operations carried out so far are committed and not rolled back in case
+of a later abort/rollback. This behavior can be controlled by adjusting the
+intermediate commit settings for the RocksDB engine. See
+[Known limitations for AQL queries](../fundamentals/limitations.md#storage-engine-properties).
 
 For sharded collections, the entire query and/or remove operation may not be
 transactional, especially if it involves different shards and/or DB-Servers.

--- a/site/content/3.12/aql/high-level-operations/replace.md
+++ b/site/content/3.12/aql/high-level-operations/replace.md
@@ -296,12 +296,12 @@ FOR u IN users
 On a single server, replace operations are executed transactionally in an
 all-or-nothing fashion.
 
-If the RocksDB engine is used and intermediate commits are enabled, a query may
-execute intermediate transaction commits in case the running transaction (AQL
-query) hits the specified size thresholds. In this case, the query's operations
-carried out so far are committed and not rolled back in case of a later
-abort/rollback. That behavior can be controlled by adjusting the intermediate
-commit settings for the RocksDB engine. 
+A query may execute intermediate transaction commits in case the running
+transaction (AQL query) hits the specified size thresholds. In this case, the
+query's operations carried out so far are committed and not rolled back in case
+of a later abort/rollback. This behavior can be controlled by adjusting the
+intermediate commit settings for the RocksDB engine. See
+[Known limitations for AQL queries](../fundamentals/limitations.md#storage-engine-properties).
 
 For sharded collections, the entire query and/or replace operation may not be
 transactional, especially if it involves different shards and/or DB-Servers.

--- a/site/content/3.12/aql/high-level-operations/update.md
+++ b/site/content/3.12/aql/high-level-operations/update.md
@@ -419,12 +419,12 @@ FOR u IN users
 On a single server, updates are executed transactionally in an all-or-nothing
 fashion.
 
-If the RocksDB engine is used and intermediate commits are enabled, a query may
-execute intermediate transaction commits in case the running transaction (AQL
-query) hits the specified size thresholds. In this case, the query's operations
-carried out so far are committed and not rolled back in case of a later
-abort/rollback. That behavior can be controlled by adjusting the intermediate
-commit settings for the RocksDB engine.
+A query may execute intermediate transaction commits in case the running
+transaction (AQL query) hits the specified size thresholds. In this case, the
+query's operations carried out so far are committed and not rolled back in case
+of a later abort/rollback. This behavior can be controlled by adjusting the
+intermediate commit settings for the RocksDB engine. See
+[Known limitations for AQL queries](../fundamentals/limitations.md#storage-engine-properties).
 
 For sharded collections, the entire query and/or update operation may not be
 transactional, especially if it involves different shards and/or DB-Servers.

--- a/site/content/3.12/aql/high-level-operations/with.md
+++ b/site/content/3.12/aql/high-level-operations/with.md
@@ -40,9 +40,9 @@ at the very start of the query.
 
 ## Usage
 
-With RocksDB as storage engine, the `WITH` operation is only required if you
-use a cluster deployment and only for AQL queries that dynamically read from
-vertex collections as part of graph traversals.
+The `WITH` operation is only required if you use a cluster deployment and only
+for AQL queries that dynamically read from vertex collections as part of
+graph traversals.
 
 You can enable the `--query.require-with` startup option to make single server
 instances require `WITH` declarations like cluster deployments to ease development,

--- a/site/content/3.12/deploy/architecture/storage-engine.md
+++ b/site/content/3.12/deploy/architecture/storage-engine.md
@@ -39,30 +39,21 @@ the same time, a write conflict is raised. It is possible to exclusively lock
 collections when executing AQL. This avoids write conflicts, but also inhibits
 concurrent writes.
 
-ArangoDB uses RocksDB's transactions to implement the ArangoDB transaction
-handling. Therefore, the same restrictions apply for ArangoDB transactions when
-using the RocksDB engine.
+ArangoDB uses RocksDB transactions to implement the transaction handling for
+standalone AQL queries (outside of JavaScript Transactions and Stream Transactions).
 
-RocksDB imposes a limit on the transaction size. It is optimized to
-handle small transactions very efficiently, but is effectively limiting
-the total size of transactions. If you have an operation that modifies a lot of
-documents, it is necessary to commit data in-between. This is done automatically
-for AQL by default. Transactions that get too big (in terms of number of
-operations involved or the total size of data modified by the transaction)
+RocksDB imposes a limit on the transaction size. It is optimized to handle small
+transactions very efficiently, but is effectively limiting the total size of
+transactions. If you have an AQL query that modifies a lot of documents, it is
+necessary to commit data in-between. Transactions that get too big (in terms of
+number of operations involved or the total size of data modified by the transaction)
 are committed automatically. Effectively, this means that big user transactions
 are split into multiple smaller RocksDB transactions that are committed individually.
 The entire user transaction does not necessarily have ACID properties in this case.
 
-The threshold values for transaction sizes can be configured globally using the
-startup options
-
-- [`--rocksdb.intermediate-commit-size`](../../components/arangodb-server/options.md#--rocksdbintermediate-commit-size)
-
-- [`--rocksdb.intermediate-commit-count`](../../components/arangodb-server/options.md#--rocksdbintermediate-commit-count)
-
-- [`--rocksdb.max-transaction-size`](../../components/arangodb-server/options.md#--rocksdbmax-transaction-size)
-
-It is also possible to override these thresholds per transaction.
+The threshold values for transaction sizes can be configured globally as well as
+overridden per transaction. See
+[Known limitations for AQL queries](../../aql/fundamentals/limitations.md#storage-engine-properties).
 
 ### Write-ahead log
 

--- a/site/content/3.12/deploy/oneshard.md
+++ b/site/content/3.12/deploy/oneshard.md
@@ -276,10 +276,13 @@ on the leader shards in a cluster, a few things need to be considered:
 - The collection option `writeConcern: 2` makes sure that a transaction is only
   successful if at least one follower shard is in sync with the leader shard,
   for a total of two shard replicas.
-- The RocksDB engine supports intermediate commits for larger document
-  operations, potentially breaking the atomicity of transactions. To prevent
+- The RocksDB storage engine uses intermediate commits for larger document
+  operations carried out by standalone AQL queries
+  (outside of JavaScript Transactions and Stream Transactions).
+  This potentially breaks the atomicity of transactions. To prevent
   this for individual queries you can increase `intermediateCommitSize`
   (default 512 MB) and `intermediateCommitCount` accordingly as query option.
+  Also see [Known limitations for AQL queries](../aql/fundamentals/limitations.md#storage-engine-properties).
 
 ### Limitations
 

--- a/site/content/3.12/develop/http-api/administration.md
+++ b/site/content/3.12/develop/http-api/administration.md
@@ -253,7 +253,7 @@ paths:
 ```curl
 ---
 description: |-
-  Return the active storage engine with the RocksDB storage engine in use:
+  Return the active storage engine:
 name: RestEngine
 ---
 var response = logCurlRequest('GET', '/_api/engine');

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -1064,8 +1064,8 @@ paths:
                           inserts.
 
                         - The `padded` key generator generates keys of a fixed length (16 bytes) in
-                          ascending lexicographical sort order. This is ideal for usage with the _RocksDB_
-                          engine, which will slightly benefit keys that are inserted in lexicographically
+                          ascending lexicographical sort order. This is ideal for the RocksDB storage engine,
+                          which will slightly benefit keys that are inserted in lexicographically
                           ascending order. The key generator can be used in a single-server or cluster.
                           The sequence of generated keys is not guaranteed to be gap-free.
 

--- a/site/content/3.12/develop/http-api/replication/replication-dump.md
+++ b/site/content/3.12/develop/http-api/replication/replication-dump.md
@@ -144,7 +144,7 @@ paths:
 ## Batch
 
 The *batch* method will create a snapshot of the current state that then can be
-dumped. A batchId is required when using the dump API with RocksDB.
+dumped.
 
 ### Create a new dump batch
 

--- a/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
@@ -544,8 +544,8 @@ db.five.all().limit(2).toArray();
 
 Returns a random document from the collection or `null` if none exists.
 
-**Note**: this method is expensive when using the RocksDB storage engine.
-<!-- TODO: only pseudo-random and there is an optimization for a single doc -->
+**Note**: This is generally an expensive operation for the RocksDB storage engine
+but ArangoDB uses an optimization for retrieving a single pseudo-random document.
 
 ### `collection.byExample(example)`
 

--- a/site/content/3.12/develop/javascript-api/@arangodb/db-object.md
+++ b/site/content/3.12/develop/javascript-api/@arangodb/db-object.md
@@ -243,8 +243,8 @@ error is thrown. For information about the naming constraints for collections, s
       is generated on every document insert attempt, not just for successful
       inserts.
     - The `padded` key generator generates keys of a fixed length (16 bytes) in
-      ascending lexicographical sort order. This is ideal for usage with the _RocksDB_
-      engine, which slightly benefits keys that are inserted in lexicographically
+      ascending lexicographical sort order. This is ideal for the RocksDB storage engine,
+      which slightly benefits keys that are inserted in lexicographically
       ascending order. The key generator can be used in a single-server or cluster.
       The sequence of generated keys is not guaranteed to be gap-free.
     - The `uuid` key generator generates universally unique 128 bit keys, which 

--- a/site/content/3.12/develop/operational-factors.md
+++ b/site/content/3.12/develop/operational-factors.md
@@ -304,8 +304,9 @@ of the RocksDB storage engine.
 - Consider a maximum size of 50-75 kB _per document_ as a good rule of thumb.
   This allows you to maintain steady write throughput even under very high load.
 - Transactions are held in-memory before they are committed.
-  This means that transactions have to be split if they become too big, see the
-  [limitations section](transactions/limitations.md#rocksdb-storage-engine).
+  This means that certain transactions have to be split if they become too big.
+  See [Known limitations for AQL queries](../aql/fundamentals/limitations.md#storage-engine-properties)
+  for details.
 
 ### Improving Update Query Performance
 

--- a/site/content/3.12/develop/transactions/limitations.md
+++ b/site/content/3.12/develop/transactions/limitations.md
@@ -125,52 +125,14 @@ time when the transaction begins *on that DB-Server*.
 It is guaranteed that successfully committed transactions are persistent. Using
 replication and / or *waitForSync* increases the durability (Just as with the single-server).
 
-## RocksDB storage engine
+## Size and time limits
 
-{{< info >}}
-The following restrictions and limitations do not apply to JavaScript
-transactions, since their intended use case is for smaller transactions
-with full transactional guarantees. So the following only applies
-to AQL queries and transactions created through the document API (i.e. batch operations).
-{{< /info >}}
+### Intermediate commits
 
-Data of ongoing transactions is stored in RAM. Transactions that get too big 
-(in terms of number of operations involved or the total size of data created or
-modified by the transaction) will be committed automatically. Effectively this 
-means that big user transactions are split into multiple smaller RocksDB 
-transactions that are committed individually. The entire user transaction will 
-not necessarily have ACID properties in this case.
- 
-The following global options can be used to control the RAM usage and automatic 
-intermediate commits for the RocksDB engine: 
-
-`--rocksdb.max-transaction-size`
-
-Transaction size limit (in bytes). Transactions store all keys and values in
-RAM, so large transactions run the risk of causing out-of-memory situations.
-This setting allows you to ensure that does not happen by limiting the size of
-any individual transaction. Transactions whose operations would consume more
-RAM than this threshold value will abort automatically with error 32 ("resource
-limit exceeded").
-
-`--rocksdb.intermediate-commit-size`
-
-If the size of all operations in a transaction reaches this threshold, the transaction 
-is committed automatically and a new transaction is started. The value is specified in bytes.
-  
-`--rocksdb.intermediate-commit-count`
-
-If the number of operations in a transaction reaches this value, the transaction is 
-committed automatically and a new transaction is started.
-
-The above values can also be adjusted per query, by setting the following
-attributes in the call to *db._query()*:
-
-- *maxTransactionSize*: transaction size limit in bytes
-- *intermediateCommitSize*: maximum total size of operations after which an intermediate
-  commit is performed automatically
-- *intermediateCommitCount*: maximum number of operations after which an intermediate
-  commit is performed automatically
+[Intermediate commits](../../aql/fundamentals/limitations.md#storage-engine-properties)
+that would automatically split and commit parts of big transactions are **disabled**
+for JavaScript Transactions and Stream Transactions in the RocksDB storage engine,
+including AQL queries that run inside of such transactions.
 
 ### Limits for Stream transactions
 

--- a/site/content/3.12/develop/transactions/locking-and-isolation.md
+++ b/site/content/3.12/develop/transactions/locking-and-isolation.md
@@ -34,7 +34,7 @@ concurrent transactions.
 
 ## Storage engine
 
-The *RocksDB* engine does not lock any collections participating in a transaction
+The RocksDB storage engine does not lock any collections participating in a transaction
 for read. Read operations can run in parallel to other read or write operations on the
 same collections.
 
@@ -232,7 +232,7 @@ In case this is not possible because collections are added dynamically inside th
 transaction, deadlocks may occur and the deadlock detection may kick in and abort
 the transaction. 
 
-The *RocksDB* engine uses document-level locks and therefore will not have a deadlock
+The RocksDB storage engine uses document-level locks and therefore will not have a deadlock
 problem on collection level. If two concurrent transactions however modify the same
 documents or index entries, the RocksDB engine will signal a write-write conflict
 and abort one of the transactions with error 1200 ("conflict") automatically.

--- a/site/content/3.12/index-and-search/indexing/basics.md
+++ b/site/content/3.12/index-and-search/indexing/basics.md
@@ -42,8 +42,8 @@ Creating new indexes is by default done under an exclusive collection lock. The 
 available while the index is being created. This "foreground" index creation can be undesirable, 
 if you have to perform it on a live system without a dedicated maintenance window.
 
-For potentially long running index creation operations the _RocksDB_ storage-engine also supports 
-creating indexes in "background". The collection remains (mostly) available during the index creation, 
+For potentially long running index creation operations, creating indexes in the
+"background" is supported. The collection remains (mostly) available during the index creation,
 see the section [Creating Indexes in Background](#creating-indexes-in-background) for more information.
 
 ## Primary Index

--- a/site/content/3.12/operations/security/encryption-at-rest.md
+++ b/site/content/3.12/operations/security/encryption-at-rest.md
@@ -46,7 +46,6 @@ The encryption feature has the following limitations:
   data you will need to take a backup first, then enable encryption and
   start your server on an empty data-directory, and finally restore your
   backup.
-- The Encryption feature requires the RocksDB storage engine.
 
 ## Encryption keys
 
@@ -76,16 +75,12 @@ to the server.
 Make sure to pass this option the very first time you start your database.
 You cannot encrypt a database that already exists.
 
-Note: You also have to activate the RocksDB storage engine.
-
 ### Encryption key stored in file
 
 Pass the following option to `arangod`:
 
 ```
-$ arangod \
-    --rocksdb.encryption-keyfile=/mytmpfs/mySecretKey \
-    --server.storage-engine=rocksdb
+$ arangod --rocksdb.encryption-keyfile=/mytmpfs/mySecretKey ...
 ```
 The file `/mytmpfs/mySecretKey` must contain the encryption key. This
 file must be secured, so that only `arangod` can access it. You should
@@ -98,9 +93,7 @@ creating an in-memory file-system under `/mytmpfs`.
 Pass the following option to `arangod`:
 
 ```
-$ arangod \
-    --rocksdb.encryption-key-generator=path-to-my-generator \
-    --server.storage-engine=rocksdb
+$ arangod --rocksdb.encryption-key-generator=path-to-my-generator ...
 ```
 
 The program `path-to-my-generator` output the encryption on standard
@@ -143,8 +136,7 @@ To enable smooth rollout of new keys you can use the new option
 _arangod_ will then store the master key encrypted with the provided secrets.
 
 ```
-$ arangod \
-    --rocksdb.encryption-keyfolder=/mytmpfs/mySecrets
+$ arangod --rocksdb.encryption-keyfolder=/mytmpfs/mySecrets ...
 ```
 
 To start an arangod instance only one of the secrets needs to be correct, 

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/program-options.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/program-options.md
@@ -71,9 +71,9 @@ This is a command, no value needs to be specified. The process terminates after 
 {{ with $option.default }}
   {{ if ne $option.category "command"}}
     {{ if $option.dynamic }}
-Default: _dynamic_ (e.g. `{{ . }}`)
+Default: _dynamic_ (e.g. `{{ string . }}`)
     {{ else }}{{/* if $option.type is a vector, don't print e.g. [info info] as that is not how it would be set by users */}}
-Default: `{{ index (slice | append .) 0 }}`
+Default: `{{ string (index (slice | append .) 0) }}`
     {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
### Description

TODO: Apply to 3.10 and 3.11 after initial review

- Remove unnecessary mentions of RocksDB
- `collection.any()` presumably uses an optimization for retrieving a single document
- Intermediate commits only apply to standalone AQL queries (rework and reorganize the affected content)
- Prevent Hugo from rendering startup option default numbers in scientific notation, esp. RocksDB values

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
