### PR TITLE
Update ArangoRDF doc page

### DIFF
--- a/site/content/3.10/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.10/data-science/adapters/arangordf-adapter/_index.md
@@ -33,6 +33,7 @@ Watch this
 [lunch & learn session](https://www.arangodb.com/resources/lunch-sessions/graph-beyond-lunch-break-2-11-arangordf/) to get an
 introduction on ArangoRDF - an RDF adapter developed with the community
 as a first step at bringing RDF graphs into ArangoDB.
+- Note: Since the recording of this session, ArangoRDF has been overhauled and extended. Package usage has changed, so please refer to the [Quickstart](#quickstart) section below for the latest specification.
 
 The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
 is available on Github. Check it out!
@@ -53,55 +54,66 @@ Check also the
 [interactive tutorial](https://colab.research.google.com/github/ArangoDB-Community/ArangoRDF/blob/main/examples/ArangoRDF.ipynb).
 
 ```py
+from rdflib import Graph
 from arango import ArangoClient
 from arango_rdf import ArangoRDF
 
-db = ArangoClient(hosts="http://localhost:8529").db(
-    "rdf", username="root", password="openSesame"
+db = ArangoClient(hosts="http://localhost:8529").db("_system_", username="root", password="")
+
+adbrdf = ArangoRDF(db)
+
+g = Graph()
+g.parse("https://raw.githubusercontent.com/stardog-union/stardog-tutorials/master/music/beatles.ttl")
+
+###################
+# RDF to ArangoDB #
+###################
+
+# 1.1: RDF-Topology Preserving Transformation (RPT)
+adbrdf.rdf_to_arangodb_by_rpt("Beatles", g, overwrite_graph=True)
+
+# 1.2: Property Graph Transformation (PGT) 
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, overwrite_graph=True)
+
+g = adbrdf.load_meta_ontology(g)
+
+# 1.3: RPT w/ Graph Contextualization
+adbrdf.rdf_to_arangodb_by_rpt("Beatles", g, contextualize_graph=True, overwrite_graph=True)
+
+# 1.4: PGT w/ Graph Contextualization
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, contextualize_graph=True, overwrite_graph=True)
+
+# 1.5: PGT w/ ArangoDB Document-to-Collection Mapping Exposed
+adb_mapping = adbrdf.build_adb_mapping_for_pgt(g)
+print(adb_mapping.serialize())
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, adb_mapping, contextualize_graph=True, overwrite_graph=True)
+
+###################
+# ArangoDB to RDF #
+###################
+
+# Start from scratch!
+g = Graph()
+g.parse("https://raw.githubusercontent.com/stardog-union/stardog-tutorials/master/music/beatles.ttl")
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, overwrite_graph=True)
+
+# 2.1: Via Graph Name
+g2, adb_mapping_2 = adbrdf.arangodb_graph_to_rdf("Beatles", Graph())
+
+# 2.2: Via Collection Names
+g3, adb_mapping_3 = adbrdf.arangodb_collections_to_rdf(
+    "Beatles",
+    Graph(),
+    v_cols={"Album", "Band", "Class", "Property", "SoloArtist", "Song"},
+    e_cols={"artist", "member", "track", "type", "writer"},
 )
 
-# Clean up existing data and collections
-if db.has_graph("default_graph"):
-    db.delete_graph("default_graph", drop_collections=True, ignore_missing=True)
+print(len(g2), len(adb_mapping_2))
+print(len(g3), len(adb_mapping_3))
 
-# Initializes default_graph and sets RDF graph identifier (ArangoDB sub_graph)
-# Optional: sub_graph (stores graph name as the 'graph' attribute on all edges in Statement collection)
-# Optional: default_graph (name of ArangoDB Named Graph, defaults to 'default_graph',
-#           is root graph that contains all collections/relations)
-adb_rdf = ArangoRDF(db, sub_graph="http://data.sfgov.org/ontology") 
-config = {"normalize_literals": False}  # default: False
-
-# RDF Import
-adb_rdf.init_rdf_collections(bnode="Blank")
-
-# Start with importing the ontology
-adb_graph = adb_rdf.import_rdf("./examples/data/airport-ontology.owl", format="xml", config=config, save_config=True)
-
-# Next, let's import the actual graph data
-adb_graph = adb_rdf.import_rdf(f"./examples/data/sfo-aircraft-partial.ttl", format="ttl", config=config, save_config=True)
-
-
-# RDF Export
-# WARNING:
-# Exports ALL collections of the database,
-# currently does not account for default_graph or sub_graph
-# Results may vary, minifying may occur
-rdf_graph = adb_rdf.export_rdf(f"./examples/data/rdfExport.xml", format="xml")
-
-# Drop graph and ALL documents and collections to test import from exported data
-if db.has_graph("default_graph"):
-    db.delete_graph("default_graph", drop_collections=True, ignore_missing=True)
-
-# Re-initialize our RDF Graph
-# Initializes default_graph and sets RDF graph identifier (ArangoDB sub_graph)
-adb_rdf = ArangoRDF(db, sub_graph="http://data.sfgov.org/ontology")
-
-adb_rdf.init_rdf_collections(bnode="Blank")
-
-config = adb_rdf.get_config_by_latest() # gets the last config saved
-# config = adb_rdf.get_config_by_key_value('graph', 'music')
-# config = adb_rdf.get_config_by_key_value('AnyKeySuppliedInConfig', 'SomeValue')
-
-# Re-import Exported data
-adb_graph = adb_rdf.import_rdf(f"./examples/data/rdfExport.xml", format="xml", config=config)
+print('--------------------')
+print(g2.serialize())
+print('--------------------')
+print(adb_mapping_2.serialize())
+print('--------------------')
 ```

--- a/site/content/3.10/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.10/data-science/adapters/arangordf-adapter/_index.md
@@ -29,12 +29,6 @@ Check the resources below to get started:
 
 ## Resources
 
-Watch this
-[lunch & learn session](https://www.arangodb.com/resources/lunch-sessions/graph-beyond-lunch-break-2-11-arangordf/) to get an
-introduction on ArangoRDF - an RDF adapter developed with the community
-as a first step at bringing RDF graphs into ArangoDB.
-- Note: Since the recording of this session, ArangoRDF has been overhauled and extended. Package usage has changed, so please refer to the [Quickstart](#quickstart) section below for the latest specification.
-
 The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
 is available on Github. Check it out!
 

--- a/site/content/3.10/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.10/data-science/adapters/arangordf-adapter/_index.md
@@ -21,16 +21,14 @@ the named link between two resources, represented by the graph nodes. This graph
 view is the easiest possible mental model for RDF and is often used in
 easy-to-understand visual explanations.
 
-Check the resources below to get started:
+## Resources
 
+- [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF),
+  available on GitHub
 - [RDF Primer](https://www.w3.org/TR/rdf11-concepts/)
 - [RDFLib (Python)](https://pypi.org/project/rdflib/)
 - [Example for Modeling RDF as ArangoDB Graphs](mapping-rdf-to-graphs.md)
 
-## Resources
-
-The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
-is available on Github. Check it out!
 
 ## Installation
 

--- a/site/content/3.11/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.11/data-science/adapters/arangordf-adapter/_index.md
@@ -21,16 +21,13 @@ the named link between two resources, represented by the graph nodes. This graph
 view is the easiest possible mental model for RDF and is often used in
 easy-to-understand visual explanations.
 
-Check the resources below to get started:
+## Resources
 
+- [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF),
+  available on GitHub
 - [RDF Primer](https://www.w3.org/TR/rdf11-concepts/)
 - [RDFLib (Python)](https://pypi.org/project/rdflib/)
 - [Example for Modeling RDF as ArangoDB Graphs](mapping-rdf-to-graphs.md)
-
-## Resources
-
-The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
-is available on Github. Check it out!
 
 ## Installation
 

--- a/site/content/3.11/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.11/data-science/adapters/arangordf-adapter/_index.md
@@ -33,6 +33,7 @@ Watch this
 [lunch & learn session](https://www.arangodb.com/resources/lunch-sessions/graph-beyond-lunch-break-2-11-arangordf/) to get an
 introduction on ArangoRDF - an RDF adapter developed with the community
 as a first step at bringing RDF graphs into ArangoDB.
+- Note: Since the recording of this session, ArangoRDF has been overhauled and extended. Package usage has changed, so please refer to the [Quickstart](#quickstart) section below for the latest specification.
 
 The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
 is available on Github. Check it out!
@@ -53,55 +54,66 @@ Check also the
 [interactive tutorial](https://colab.research.google.com/github/ArangoDB-Community/ArangoRDF/blob/main/examples/ArangoRDF.ipynb).
 
 ```py
+from rdflib import Graph
 from arango import ArangoClient
 from arango_rdf import ArangoRDF
 
-db = ArangoClient(hosts="http://localhost:8529").db(
-    "rdf", username="root", password="openSesame"
+db = ArangoClient(hosts="http://localhost:8529").db("_system_", username="root", password="")
+
+adbrdf = ArangoRDF(db)
+
+g = Graph()
+g.parse("https://raw.githubusercontent.com/stardog-union/stardog-tutorials/master/music/beatles.ttl")
+
+###################
+# RDF to ArangoDB #
+###################
+
+# 1.1: RDF-Topology Preserving Transformation (RPT)
+adbrdf.rdf_to_arangodb_by_rpt("Beatles", g, overwrite_graph=True)
+
+# 1.2: Property Graph Transformation (PGT) 
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, overwrite_graph=True)
+
+g = adbrdf.load_meta_ontology(g)
+
+# 1.3: RPT w/ Graph Contextualization
+adbrdf.rdf_to_arangodb_by_rpt("Beatles", g, contextualize_graph=True, overwrite_graph=True)
+
+# 1.4: PGT w/ Graph Contextualization
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, contextualize_graph=True, overwrite_graph=True)
+
+# 1.5: PGT w/ ArangoDB Document-to-Collection Mapping Exposed
+adb_mapping = adbrdf.build_adb_mapping_for_pgt(g)
+print(adb_mapping.serialize())
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, adb_mapping, contextualize_graph=True, overwrite_graph=True)
+
+###################
+# ArangoDB to RDF #
+###################
+
+# Start from scratch!
+g = Graph()
+g.parse("https://raw.githubusercontent.com/stardog-union/stardog-tutorials/master/music/beatles.ttl")
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, overwrite_graph=True)
+
+# 2.1: Via Graph Name
+g2, adb_mapping_2 = adbrdf.arangodb_graph_to_rdf("Beatles", Graph())
+
+# 2.2: Via Collection Names
+g3, adb_mapping_3 = adbrdf.arangodb_collections_to_rdf(
+    "Beatles",
+    Graph(),
+    v_cols={"Album", "Band", "Class", "Property", "SoloArtist", "Song"},
+    e_cols={"artist", "member", "track", "type", "writer"},
 )
 
-# Clean up existing data and collections
-if db.has_graph("default_graph"):
-    db.delete_graph("default_graph", drop_collections=True, ignore_missing=True)
+print(len(g2), len(adb_mapping_2))
+print(len(g3), len(adb_mapping_3))
 
-# Initializes default_graph and sets RDF graph identifier (ArangoDB sub_graph)
-# Optional: sub_graph (stores graph name as the 'graph' attribute on all edges in Statement collection)
-# Optional: default_graph (name of ArangoDB Named Graph, defaults to 'default_graph',
-#           is root graph that contains all collections/relations)
-adb_rdf = ArangoRDF(db, sub_graph="http://data.sfgov.org/ontology") 
-config = {"normalize_literals": False}  # default: False
-
-# RDF Import
-adb_rdf.init_rdf_collections(bnode="Blank")
-
-# Start with importing the ontology
-adb_graph = adb_rdf.import_rdf("./examples/data/airport-ontology.owl", format="xml", config=config, save_config=True)
-
-# Next, let's import the actual graph data
-adb_graph = adb_rdf.import_rdf(f"./examples/data/sfo-aircraft-partial.ttl", format="ttl", config=config, save_config=True)
-
-
-# RDF Export
-# WARNING:
-# Exports ALL collections of the database,
-# currently does not account for default_graph or sub_graph
-# Results may vary, minifying may occur
-rdf_graph = adb_rdf.export_rdf(f"./examples/data/rdfExport.xml", format="xml")
-
-# Drop graph and ALL documents and collections to test import from exported data
-if db.has_graph("default_graph"):
-    db.delete_graph("default_graph", drop_collections=True, ignore_missing=True)
-
-# Re-initialize our RDF Graph
-# Initializes default_graph and sets RDF graph identifier (ArangoDB sub_graph)
-adb_rdf = ArangoRDF(db, sub_graph="http://data.sfgov.org/ontology")
-
-adb_rdf.init_rdf_collections(bnode="Blank")
-
-config = adb_rdf.get_config_by_latest() # gets the last config saved
-# config = adb_rdf.get_config_by_key_value('graph', 'music')
-# config = adb_rdf.get_config_by_key_value('AnyKeySuppliedInConfig', 'SomeValue')
-
-# Re-import Exported data
-adb_graph = adb_rdf.import_rdf(f"./examples/data/rdfExport.xml", format="xml", config=config)
+print('--------------------')
+print(g2.serialize())
+print('--------------------')
+print(adb_mapping_2.serialize())
+print('--------------------')
 ```

--- a/site/content/3.11/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.11/data-science/adapters/arangordf-adapter/_index.md
@@ -29,12 +29,6 @@ Check the resources below to get started:
 
 ## Resources
 
-Watch this
-[lunch & learn session](https://www.arangodb.com/resources/lunch-sessions/graph-beyond-lunch-break-2-11-arangordf/) to get an
-introduction on ArangoRDF - an RDF adapter developed with the community
-as a first step at bringing RDF graphs into ArangoDB.
-- Note: Since the recording of this session, ArangoRDF has been overhauled and extended. Package usage has changed, so please refer to the [Quickstart](#quickstart) section below for the latest specification.
-
 The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
 is available on Github. Check it out!
 

--- a/site/content/3.12/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.12/data-science/adapters/arangordf-adapter/_index.md
@@ -21,16 +21,13 @@ the named link between two resources, represented by the graph nodes. This graph
 view is the easiest possible mental model for RDF and is often used in
 easy-to-understand visual explanations.
 
-Check the resources below to get started:
+## Resources
 
+- [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF),
+  available on GitHub
 - [RDF Primer](https://www.w3.org/TR/rdf11-concepts/)
 - [RDFLib (Python)](https://pypi.org/project/rdflib/)
 - [Example for Modeling RDF as ArangoDB Graphs](mapping-rdf-to-graphs.md)
-
-## Resources
-
-The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
-is available on Github. Check it out!
 
 ## Installation
 

--- a/site/content/3.12/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.12/data-science/adapters/arangordf-adapter/_index.md
@@ -33,6 +33,7 @@ Watch this
 [lunch & learn session](https://www.arangodb.com/resources/lunch-sessions/graph-beyond-lunch-break-2-11-arangordf/) to get an
 introduction on ArangoRDF - an RDF adapter developed with the community
 as a first step at bringing RDF graphs into ArangoDB.
+- Note: Since the recording of this session, ArangoRDF has been overhauled and extended. Package usage has changed, so please refer to the [Quickstart](#quickstart) section below for the latest specification.
 
 The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
 is available on Github. Check it out!
@@ -53,55 +54,66 @@ Check also the
 [interactive tutorial](https://colab.research.google.com/github/ArangoDB-Community/ArangoRDF/blob/main/examples/ArangoRDF.ipynb).
 
 ```py
+from rdflib import Graph
 from arango import ArangoClient
 from arango_rdf import ArangoRDF
 
-db = ArangoClient(hosts="http://localhost:8529").db(
-    "rdf", username="root", password="openSesame"
+db = ArangoClient(hosts="http://localhost:8529").db("_system_", username="root", password="")
+
+adbrdf = ArangoRDF(db)
+
+g = Graph()
+g.parse("https://raw.githubusercontent.com/stardog-union/stardog-tutorials/master/music/beatles.ttl")
+
+###################
+# RDF to ArangoDB #
+###################
+
+# 1.1: RDF-Topology Preserving Transformation (RPT)
+adbrdf.rdf_to_arangodb_by_rpt("Beatles", g, overwrite_graph=True)
+
+# 1.2: Property Graph Transformation (PGT) 
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, overwrite_graph=True)
+
+g = adbrdf.load_meta_ontology(g)
+
+# 1.3: RPT w/ Graph Contextualization
+adbrdf.rdf_to_arangodb_by_rpt("Beatles", g, contextualize_graph=True, overwrite_graph=True)
+
+# 1.4: PGT w/ Graph Contextualization
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, contextualize_graph=True, overwrite_graph=True)
+
+# 1.5: PGT w/ ArangoDB Document-to-Collection Mapping Exposed
+adb_mapping = adbrdf.build_adb_mapping_for_pgt(g)
+print(adb_mapping.serialize())
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, adb_mapping, contextualize_graph=True, overwrite_graph=True)
+
+###################
+# ArangoDB to RDF #
+###################
+
+# Start from scratch!
+g = Graph()
+g.parse("https://raw.githubusercontent.com/stardog-union/stardog-tutorials/master/music/beatles.ttl")
+adbrdf.rdf_to_arangodb_by_pgt("Beatles", g, overwrite_graph=True)
+
+# 2.1: Via Graph Name
+g2, adb_mapping_2 = adbrdf.arangodb_graph_to_rdf("Beatles", Graph())
+
+# 2.2: Via Collection Names
+g3, adb_mapping_3 = adbrdf.arangodb_collections_to_rdf(
+    "Beatles",
+    Graph(),
+    v_cols={"Album", "Band", "Class", "Property", "SoloArtist", "Song"},
+    e_cols={"artist", "member", "track", "type", "writer"},
 )
 
-# Clean up existing data and collections
-if db.has_graph("default_graph"):
-    db.delete_graph("default_graph", drop_collections=True, ignore_missing=True)
+print(len(g2), len(adb_mapping_2))
+print(len(g3), len(adb_mapping_3))
 
-# Initializes default_graph and sets RDF graph identifier (ArangoDB sub_graph)
-# Optional: sub_graph (stores graph name as the 'graph' attribute on all edges in Statement collection)
-# Optional: default_graph (name of ArangoDB Named Graph, defaults to 'default_graph',
-#           is root graph that contains all collections/relations)
-adb_rdf = ArangoRDF(db, sub_graph="http://data.sfgov.org/ontology") 
-config = {"normalize_literals": False}  # default: False
-
-# RDF Import
-adb_rdf.init_rdf_collections(bnode="Blank")
-
-# Start with importing the ontology
-adb_graph = adb_rdf.import_rdf("./examples/data/airport-ontology.owl", format="xml", config=config, save_config=True)
-
-# Next, let's import the actual graph data
-adb_graph = adb_rdf.import_rdf(f"./examples/data/sfo-aircraft-partial.ttl", format="ttl", config=config, save_config=True)
-
-
-# RDF Export
-# WARNING:
-# Exports ALL collections of the database,
-# currently does not account for default_graph or sub_graph
-# Results may vary, minifying may occur
-rdf_graph = adb_rdf.export_rdf(f"./examples/data/rdfExport.xml", format="xml")
-
-# Drop graph and ALL documents and collections to test import from exported data
-if db.has_graph("default_graph"):
-    db.delete_graph("default_graph", drop_collections=True, ignore_missing=True)
-
-# Re-initialize our RDF Graph
-# Initializes default_graph and sets RDF graph identifier (ArangoDB sub_graph)
-adb_rdf = ArangoRDF(db, sub_graph="http://data.sfgov.org/ontology")
-
-adb_rdf.init_rdf_collections(bnode="Blank")
-
-config = adb_rdf.get_config_by_latest() # gets the last config saved
-# config = adb_rdf.get_config_by_key_value('graph', 'music')
-# config = adb_rdf.get_config_by_key_value('AnyKeySuppliedInConfig', 'SomeValue')
-
-# Re-import Exported data
-adb_graph = adb_rdf.import_rdf(f"./examples/data/rdfExport.xml", format="xml", config=config)
+print('--------------------')
+print(g2.serialize())
+print('--------------------')
+print(adb_mapping_2.serialize())
+print('--------------------')
 ```

--- a/site/content/3.12/data-science/adapters/arangordf-adapter/_index.md
+++ b/site/content/3.12/data-science/adapters/arangordf-adapter/_index.md
@@ -29,12 +29,6 @@ Check the resources below to get started:
 
 ## Resources
 
-Watch this
-[lunch & learn session](https://www.arangodb.com/resources/lunch-sessions/graph-beyond-lunch-break-2-11-arangordf/) to get an
-introduction on ArangoRDF - an RDF adapter developed with the community
-as a first step at bringing RDF graphs into ArangoDB.
-- Note: Since the recording of this session, ArangoRDF has been overhauled and extended. Package usage has changed, so please refer to the [Quickstart](#quickstart) section below for the latest specification.
-
 The [ArangoRDF repository](https://github.com/ArangoDB-Community/ArangoRDF)
 is available on Github. Check it out!
 


### PR DESCRIPTION
ref: https://github.com/ArangoDB-Community/ArangoRDF/releases/tag/0.1.0

### Description

The ArangoRDF specification has changed as of ArangoRDF [0.1.0](https://github.com/ArangoDB-Community/ArangoRDF/releases/tag/0.1.0) (released Monday Dec 4 2023).

This PR addresses the changes required to keep its doc page up to date

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
