### PR TITLE
Fix headline levels for metrics, trim trailing dot

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
@@ -10,11 +10,11 @@
 {{- end }}
 {{- range $category, $metricGroup := $metricGroups.Get "metrics" }}{{/* Seems to get sorted implicitly */}}
 
-#### {{ $category }}
+### {{ $category }}
 
 {{ range $metric := $metricGroup }}
 
-##### {{ $metric.help }}
+#### {{ strings.TrimRight "." $metric.help }}
 
 {{ if eq $metric.type "histogram" -}}
 `{{ $metric.name }}` (basename)<br>


### PR DESCRIPTION
### Description

Make metric categories visible in ToC again

https://deploy-preview-383--docs-hugo.netlify.app/devel/develop/http-api/monitoring/metrics/

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
