### PR TITLE
Release notes: arangoimport auto detects the import file format

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -247,3 +247,9 @@ This following startup options of arangodump are obsolete from ArangoDB 3.12 on:
 - `--tick-end`: setting this option allowed to restrict the dumped data to some 
   time range with the MMFiles storage engine. It had no effect for the RocksDB 
   storage engine and so it is removed now.
+
+### arangoimport
+
+*arangoimport* now automatically detects the type of the import file based on
+the file extension. The default value for the `--type` option has been changed
+from `json` to `auto`.

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -251,5 +251,6 @@ This following startup options of arangodump are obsolete from ArangoDB 3.12 on:
 ### arangoimport
 
 *arangoimport* now automatically detects the type of the import file based on
-the file extension. The default value for the `--type` option has been changed
-from `json` to `auto`.
+the file extension. The default value of the `--type` startup option has been
+changed from `json` to `auto`. You might need to explicitly specify the `--type`
+in exceptional cases now whereas it was not necessary to do so previously.

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -512,5 +512,20 @@ _arangodump_ operations on the server:
   dump thread was blocked because it honored the server-side memory
   limit for dumps.
 
+### arangoimport
+
+The default value for the `--type` option has been changed from `json` to
+`auto`. *arangoimport* now automatically detects the type of the import file
+based on the file extension.
+
+The following file extensions are automatically detected:
+- .json
+- .jsonl
+- .csv
+- .tsv
+
+If the file extension doesn't correspond to any of the mentioned types, the
+import defaults to `json` format.
+
 ## Internal changes
 

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -514,18 +514,18 @@ _arangodump_ operations on the server:
 
 ### arangoimport
 
-The default value for the `--type` option has been changed from `json` to
-`auto`. *arangoimport* now automatically detects the type of the import file
+The default value for the `--type` startup option has been changed from `json`
+to `auto`. *arangoimport* now automatically detects the type of the import file
 based on the file extension.
 
 The following file extensions are automatically detected:
-- .json
-- .jsonl
-- .csv
-- .tsv
+- `.json`
+- `.jsonl`
+- `.csv`
+- `.tsv`
 
 If the file extension doesn't correspond to any of the mentioned types, the
-import defaults to `json` format.
+import defaults to the `json` format.
 
 ## Internal changes
 


### PR DESCRIPTION
### Description

arangoimport's `--type` option has been changed from `json` to `auto`; it can automatically detect the import file format.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12: https://github.com/arangodb/arangodb/pull/20248
