### PR TITLE
Fix internal links

### DIFF
--- a/site/content/3.10/arangograph/notebooks.md
+++ b/site/content/3.10/arangograph/notebooks.md
@@ -20,7 +20,7 @@ passwords, and endpoint URLs.
 
 ![ArangoGraph Notebooks Architecture](../../images/arangograph-notebooks-architecture.png)
 
-The ArangoGraph Notebook has built-in [ArangoGraph Magic Commands](.#arangograph-magic-commands)
+The ArangoGraph Notebook has built-in [ArangoGraph Magic Commands](#arangograph-magic-commands)
 that answer questions like:
 - What ArangoDB database am I connected to at the moment?
 - What data does the ArangoDB instance contain?

--- a/site/content/3.10/develop/http-api/general-request-handling.md
+++ b/site/content/3.10/develop/http-api/general-request-handling.md
@@ -139,7 +139,7 @@ HTTP request. The server executes the jobs from the queue asynchronously as fast
 as possible, while clients can continue to do other work.
 
 If the server queue is full (i.e. contains as many jobs as specified by the
-[`--server.maximal-queue-size`](../../components/arangodb-server/options.md#arangodb-server-options)
+[`--server.maximal-queue-size`](../../components/arangodb-server/options.md#--servermaximal-queue-size)
 startup option), then the request is rejected instantly with an HTTP
 `503 Service Unavailable` status code.
 

--- a/site/content/3.11/arangograph/notebooks.md
+++ b/site/content/3.11/arangograph/notebooks.md
@@ -20,7 +20,7 @@ passwords, and endpoint URLs.
 
 ![ArangoGraph Notebooks Architecture](../../images/arangograph-notebooks-architecture.png)
 
-The ArangoGraph Notebook has built-in [ArangoGraph Magic Commands](.#arangograph-magic-commands)
+The ArangoGraph Notebook has built-in [ArangoGraph Magic Commands](#arangograph-magic-commands)
 that answer questions like:
 - What ArangoDB database am I connected to at the moment?
 - What data does the ArangoDB instance contain?

--- a/site/content/3.11/develop/http-api/general-request-handling.md
+++ b/site/content/3.11/develop/http-api/general-request-handling.md
@@ -139,7 +139,7 @@ HTTP request. The server executes the jobs from the queue asynchronously as fast
 as possible, while clients can continue to do other work.
 
 If the server queue is full (i.e. contains as many jobs as specified by the
-[`--server.maximal-queue-size`](../../components/arangodb-server/options.md#arangodb-server-options)
+[`--server.maximal-queue-size`](../../components/arangodb-server/options.md#--servermaximal-queue-size)
 startup option), then the request is rejected instantly with an HTTP
 `503 Service Unavailable` status code.
 

--- a/site/content/3.11/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1072,7 +1072,7 @@ To enable tracing for traversals and path searches at startup, you can set
 `--log.level graphs=trace`.
 
 To enable or disable it at runtime, you can call the
-[`PUT /_admin/log/level`](../../develop/http-api/monitoring/logs.md#set-the-sersver-log-levels)
+[`PUT /_admin/log/level`](../../develop/http-api/monitoring/logs.md#set-the-server-log-levels)
 endpoint of the HTTP API and set the log level using a request body like
 `{"graphs":"TRACE"}`.
 

--- a/site/content/3.12/arangograph/notebooks.md
+++ b/site/content/3.12/arangograph/notebooks.md
@@ -20,7 +20,7 @@ passwords, and endpoint URLs.
 
 ![ArangoGraph Notebooks Architecture](../../images/arangograph-notebooks-architecture.png)
 
-The ArangoGraph Notebook has built-in [ArangoGraph Magic Commands](.#arangograph-magic-commands)
+The ArangoGraph Notebook has built-in [ArangoGraph Magic Commands](#arangograph-magic-commands)
 that answer questions like:
 - What ArangoDB database am I connected to at the moment?
 - What data does the ArangoDB instance contain?

--- a/site/content/3.12/develop/http-api/general-request-handling.md
+++ b/site/content/3.12/develop/http-api/general-request-handling.md
@@ -139,7 +139,7 @@ HTTP request. The server executes the jobs from the queue asynchronously as fast
 as possible, while clients can continue to do other work.
 
 If the server queue is full (i.e. contains as many jobs as specified by the
-[`--server.maximal-queue-size`](../../components/arangodb-server/options.md#arangodb-server-options)
+[`--server.maximal-queue-size`](../../components/arangodb-server/options.md#--servermaximal-queue-size)
 startup option), then the request is rejected instantly with an HTTP
 `503 Service Unavailable` status code.
 

--- a/site/content/3.12/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/3.12/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1072,7 +1072,7 @@ To enable tracing for traversals and path searches at startup, you can set
 `--log.level graphs=trace`.
 
 To enable or disable it at runtime, you can call the
-[`PUT /_admin/log/level`](../../develop/http-api/monitoring/logs.md#set-the-sersver-log-levels)
+[`PUT /_admin/log/level`](../../develop/http-api/monitoring/logs.md#set-the-server-log-levels)
 endpoint of the HTTP API and set the log level using a request body like
 `{"graphs":"TRACE"}`.
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -93,7 +93,7 @@ memory limit and not just 56% of it.
 
 ## Higher reported memory usage for AQL queries
 
-Due to the [improved memory accounting in v3.12](whats-new-in-3-12.md#improved-memory-accounting),
+Due to the [improved memory accounting in v3.12](whats-new-in-3-12.md#improved-memory-accounting-and-usage),
 certain AQL queries may now get aborted because they exceed the defined
 memory limit but didn't get killed in previous versions. This is because of the
 more accurate memory tracking that reports a higher (actual) usage now. It allows

--- a/site/themes/arangodb-docs-theme/layouts/partials/content-footer.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/content-footer.html
@@ -60,21 +60,17 @@
 
 
 <span class="prev">
-  {{ with $prev }}
-    {{- if eq (len .Ancestors) 1 }}
-      <a class="nav nav-prev link" href="" title="">
-      </a>
-    {{ else }}
-        <a class="nav nav-prev link" href="{{ .RelPermalink }}">
-          <i class="fas fa-chevron-left fa-fw"></i><p>{{.Params.menuTitle | markdownify }}</p></a>
-        {{- end}}
-  {{ end }}
-  
+{{- with $prev }}
+  {{- if ne (len .Ancestors) 1 }}
+    <a class="nav nav-prev link" href="{{ .RelPermalink }}">
+      <i class="fas fa-chevron-left fa-fw"></i><p>{{ .Params.menuTitle | markdownify }}</p></a>
+  {{- end}}
+{{- end }}
 </span>
 
 <span class="next">
-  {{ with $next }}
-            <a class="nav nav-next link" href="{{ .RelPermalink }}">
-              <p>{{.Params.menuTitle | markdownify }}</p><i class="fas fa-chevron-right fa-fw"></i></a>
-          {{- end }}
+{{- with $next }}
+  <a class="nav nav-next link" href="{{ .RelPermalink }}">
+    <p>{{ .Params.menuTitle | markdownify }}</p><i class="fas fa-chevron-right fa-fw"></i></a>
+{{- end }}
 </span>


### PR DESCRIPTION
### Description

Discovered by htmltest. It also complains about a few links that are not easy to fix, so we cannot add it the CI yet. These links are in `` ```openapi ``  blocks and the links in Swagger are currently broken.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
