### PR TITLE
[DE-726] removed deprecated asyncExecutor (DE-726)

### DIFF
--- a/site/content/3.10/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.10/develop/drivers/java/reference-version-7/driver-setup.md
@@ -91,7 +91,6 @@ Here are examples to integrate configuration properties from different sources:
 - `loadBalancingStrategy(LoadBalancingStrategy)`: load balancing strategy, possible values are: `NONE`, `ROUND_ROBIN`, `ONE_RANDOM`, (default: `NONE`)
 - `responseQueueTimeSamples(Integer)`:            amount of samples kept for queue time metrics, (default: `10`)
 - `serde(ArangoSerde)`:                           serde to serialize and deserialize user-data
-- `asyncExecutor(Executor)`:                      downstream `java.util.concurrent.Executor` that will be used to consume the responses of the async API
 
 ### Config File Properties
 

--- a/site/content/3.11/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.11/develop/drivers/java/reference-version-7/driver-setup.md
@@ -91,7 +91,6 @@ Here are examples to integrate configuration properties from different sources:
 - `loadBalancingStrategy(LoadBalancingStrategy)`: load balancing strategy, possible values are: `NONE`, `ROUND_ROBIN`, `ONE_RANDOM`, (default: `NONE`)
 - `responseQueueTimeSamples(Integer)`:            amount of samples kept for queue time metrics, (default: `10`)
 - `serde(ArangoSerde)`:                           serde to serialize and deserialize user-data
-- `asyncExecutor(Executor)`:                      downstream `java.util.concurrent.Executor` that will be used to consume the responses of the async API
 
 ### Config File Properties
 

--- a/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
@@ -91,7 +91,6 @@ Here are examples to integrate configuration properties from different sources:
 - `loadBalancingStrategy(LoadBalancingStrategy)`: load balancing strategy, possible values are: `NONE`, `ROUND_ROBIN`, `ONE_RANDOM`, (default: `NONE`)
 - `responseQueueTimeSamples(Integer)`:            amount of samples kept for queue time metrics, (default: `10`)
 - `serde(ArangoSerde)`:                           serde to serialize and deserialize user-data
-- `asyncExecutor(Executor)`:                      downstream `java.util.concurrent.Executor` that will be used to consume the responses of the async API
 
 ### Config File Properties
 


### PR DESCRIPTION
### Description

Removed `asyncExecutor()` configuration method, since deprecated since https://github.com/arangodb/arangodb-java-driver/commit/81a15993e20b2e49b01060fe095d6e7a16e70eeb