### PR TITLE
Added `arangodb_aql_cursors_memory_usage` metric to memory accounting list

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -163,6 +163,7 @@ ongoing dumps, ArangoSearch parallelism and used file descriptors:
 The following new metrics for improved memory observability have been added:
 
 - `arangodb_agency_node_memory_usage`
+- `arangodb_aql_cursors_memory_usage`
 - `arangodb_index_estimates_memory_usage`
 - `arangodb_internal_cluster_info_memory_usage`
 - `arangodb_requests_memory_usage`

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -75,6 +75,7 @@ The following new metrics have been added for memory observability:
 | Label | Description |
 |:------|:------------|
 | `arangodb_agency_node_memory_usage` | Memory used by Agency store/cache. |
+| `arangodb_aql_cursors_memory_usage` | Total memory usage of active AQL query result cursors.  |
 | `arangodb_index_estimates_memory_usage` | Total memory usage of all index selectivity estimates. |
 | `arangodb_internal_cluster_info_memory_usage` | Amount of memory spent in ClusterInfo. |
 | `arangodb_requests_memory_usage` | Memory consumed by incoming, queued, and currently processed requests. |


### PR DESCRIPTION
### Description

Added `arangodb_aql_cursors_memory_usage` metric to the memory accounting list.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12: https://github.com/arangodb/arangodb/pull/20215
