### PR TITLE
DOC-626 | Move storage engine content under ArangoDB Server

### DIFF
--- a/site/content/3.10/about-arangodb/features/community-edition.md
+++ b/site/content/3.10/about-arangodb/features/community-edition.md
@@ -39,7 +39,7 @@ see [arangodb.com/community-server/](https://www.arangodb.com/community-server/)
   documents, or graphs - perfect for social relations. Optional document
   validation using JSON Schema (draft-4, without remote schema support).
 
-- [**Data Storage**](../../deploy/architecture/storage-engine.md):
+- [**Data Storage**](../../components/arangodb-server/storage-engine.md):
   RocksDB storage engine to persist data and indexes on disk, with a hot set in
   memory. It uses journaling (write-ahead logging) and can take advantage of
   modern storage hardware, like SSDs and large caches.

--- a/site/content/3.10/about-arangodb/features/highlights-by-version.md
+++ b/site/content/3.10/about-arangodb/features/highlights-by-version.md
@@ -301,7 +301,7 @@ Also see [What's New in 3.5](../../release-notes/version-3.5/whats-new-in-3-5.md
   as soon as possible.
 
 - **RocksDB as Default Storage Engine**: With ArangoDB 3.4 the default
-  [storage engine](../../deploy/architecture/storage-engine.md) for fresh installations will
+  [storage engine](../../components/arangodb-server/storage-engine.md) for fresh installations will
   switch from MMFiles to RocksDB. Many optimizations have been made to RocksDB
   since the first release in 3.2. For 3.4 we optimized the binary storage
   format for improved insertion, implemented "optional caching", reduced the
@@ -342,7 +342,7 @@ Also see [What's New in 3.3](../../release-notes/version-3.3/whats-new-in-3-3.md
 
 **All Editions**
 
-- [**RocksDB Storage Engine**](../../deploy/architecture/storage-engine.md): You can now use
+- [**RocksDB Storage Engine**](../../components/arangodb-server/storage-engine.md): You can now use
   as much data in ArangoDB as you can fit on your disk. Plus, you can enjoy
   performance boosts on writes by having only document-level locks.
 

--- a/site/content/3.10/about-arangodb/use-cases.md
+++ b/site/content/3.10/about-arangodb/use-cases.md
@@ -131,7 +131,7 @@ binary large objects (BLOBs) and works best with small to medium-sized
 JSON objects.
 
 For more information about how ArangoDB persists data, see
-[Storage Engine](../deploy/architecture/storage-engine.md).
+[Storage Engine](../components/arangodb-server/storage-engine.md).
 
 ## ArangoDB as a Search Engine
 

--- a/site/content/3.10/components/arangodb-server/storage-engine.md
+++ b/site/content/3.10/components/arangodb-server/storage-engine.md
@@ -1,11 +1,13 @@
 ---
 title: Storage Engine
 menuTitle: Storage Engine
-weight: 15
+weight: 20
 description: >-
   The storage engine is responsible for persisting data on disk, holding copies
   in memory, providing indexes and caches to speed up queries
 archetype: default
+aliases:
+  - ../../deploy/architecture/storage-engine
 ---
 ArangoDB's storage engine is based on Facebook's **RocksDB** and the only
 storage engine available in ArangoDB 3.7 and above. It is the bottom layer of

--- a/site/content/3.10/deploy/architecture/_index.md
+++ b/site/content/3.10/deploy/architecture/_index.md
@@ -3,7 +3,6 @@ title: ArangoDB Architecture
 menuTitle: Architecture
 weight: 100
 description: >-
-  Technical insights into ArangoDB's scalability, sharding, the storage engine,
-  and replication
+  Technical insights into ArangoDB's scalability, sharding, and replication
 archetype: chapter
 ---

--- a/site/content/3.10/develop/transactions/limitations.md
+++ b/site/content/3.10/develop/transactions/limitations.md
@@ -76,7 +76,7 @@ Understanding these differences is important when designing applications that ne
 to be resilient against outages of individual servers.
 
 Cluster transactions share the underlying characteristics of the
-[storage engine](../../deploy/architecture/storage-engine.md) that is used for the cluster deployment.
+[storage engine](../../components/arangodb-server/storage-engine.md) that is used for the cluster deployment.
 A transaction started on a Coordinator translates to one transaction per involved DB-Server.
 The guarantees and characteristics of the given storage-engine apply additionally
 to the cluster specific information below.

--- a/site/content/3.10/release-notes/version-3.6/incompatible-changes-in-3-6.md
+++ b/site/content/3.10/release-notes/version-3.6/incompatible-changes-in-3-6.md
@@ -44,7 +44,7 @@ The MMFiles storage engine is deprecated starting with version
 3.6.0 and it will be removed in a future release.
 
 We recommend to switch to RocksDB even before the removal of MMFiles.
-RocksDB is the default [storage engine](../../deploy/architecture/storage-engine.md)
+RocksDB is the default [storage engine](../../components/arangodb-server/storage-engine.md)
 since v3.4.0.
 
 ## Requests statistics

--- a/site/content/3.11/about-arangodb/features/community-edition.md
+++ b/site/content/3.11/about-arangodb/features/community-edition.md
@@ -39,7 +39,7 @@ see [arangodb.com/community-server/](https://www.arangodb.com/community-server/)
   documents, or graphs - perfect for social relations. Optional document
   validation using JSON Schema (draft-4, without remote schema support).
 
-- [**Data Storage**](../../deploy/architecture/storage-engine.md):
+- [**Data Storage**](../../components/arangodb-server/storage-engine.md):
   RocksDB storage engine to persist data and indexes on disk, with a hot set in
   memory. It uses journaling (write-ahead logging) and can take advantage of
   modern storage hardware, like SSDs and large caches.

--- a/site/content/3.11/about-arangodb/features/highlights-by-version.md
+++ b/site/content/3.11/about-arangodb/features/highlights-by-version.md
@@ -327,7 +327,7 @@ Also see [What's New in 3.5](../../release-notes/version-3.5/whats-new-in-3-5.md
   as soon as possible.
 
 - **RocksDB as Default Storage Engine**: With ArangoDB 3.4 the default
-  [storage engine](../../deploy/architecture/storage-engine.md) for fresh installations will
+  [storage engine](../../components/arangodb-server/storage-engine.md) for fresh installations will
   switch from MMFiles to RocksDB. Many optimizations have been made to RocksDB
   since the first release in 3.2. For 3.4 we optimized the binary storage
   format for improved insertion, implemented "optional caching", reduced the
@@ -368,7 +368,7 @@ Also see [What's New in 3.3](../../release-notes/version-3.3/whats-new-in-3-3.md
 
 **All Editions**
 
-- [**RocksDB Storage Engine**](../../deploy/architecture/storage-engine.md): You can now use
+- [**RocksDB Storage Engine**](../../components/arangodb-server/storage-engine.md): You can now use
   as much data in ArangoDB as you can fit on your disk. Plus, you can enjoy
   performance boosts on writes by having only document-level locks.
 

--- a/site/content/3.11/about-arangodb/use-cases.md
+++ b/site/content/3.11/about-arangodb/use-cases.md
@@ -131,7 +131,7 @@ binary large objects (BLOBs) and works best with small to medium-sized
 JSON objects.
 
 For more information about how ArangoDB persists data, see
-[Storage Engine](../deploy/architecture/storage-engine.md).
+[Storage Engine](../components/arangodb-server/storage-engine.md).
 
 ## ArangoDB as a Search Engine
 

--- a/site/content/3.11/components/arangodb-server/storage-engine.md
+++ b/site/content/3.11/components/arangodb-server/storage-engine.md
@@ -1,11 +1,13 @@
 ---
 title: Storage Engine
 menuTitle: Storage Engine
-weight: 15
+weight: 20
 description: >-
   The storage engine is responsible for persisting data on disk, holding copies
   in memory, providing indexes and caches to speed up queries
 archetype: default
+aliases:
+  - ../../deploy/architecture/storage-engine
 ---
 ArangoDB's storage engine is based on Facebook's **RocksDB** and the only
 storage engine available in ArangoDB 3.7 and above. It is the bottom layer of

--- a/site/content/3.11/deploy/architecture/_index.md
+++ b/site/content/3.11/deploy/architecture/_index.md
@@ -3,7 +3,6 @@ title: ArangoDB Architecture
 menuTitle: Architecture
 weight: 100
 description: >-
-  Technical insights into ArangoDB's scalability, sharding, the storage engine,
-  and replication
+  Technical insights into ArangoDB's scalability, sharding, and replication
 archetype: chapter
 ---

--- a/site/content/3.11/develop/transactions/limitations.md
+++ b/site/content/3.11/develop/transactions/limitations.md
@@ -76,7 +76,7 @@ Understanding these differences is important when designing applications that ne
 to be resilient against outages of individual servers.
 
 Cluster transactions share the underlying characteristics of the
-[storage engine](../../deploy/architecture/storage-engine.md) that is used for the cluster deployment.
+[storage engine](../../components/arangodb-server/storage-engine.md) that is used for the cluster deployment.
 A transaction started on a Coordinator translates to one transaction per involved DB-Server.
 The guarantees and characteristics of the given storage-engine apply additionally
 to the cluster specific information below.

--- a/site/content/3.11/release-notes/version-3.6/incompatible-changes-in-3-6.md
+++ b/site/content/3.11/release-notes/version-3.6/incompatible-changes-in-3-6.md
@@ -44,7 +44,7 @@ The MMFiles storage engine is deprecated starting with version
 3.6.0 and it will be removed in a future release.
 
 We recommend to switch to RocksDB even before the removal of MMFiles.
-RocksDB is the default [storage engine](../../deploy/architecture/storage-engine.md)
+RocksDB is the default [storage engine](../../components/arangodb-server/storage-engine.md)
 since v3.4.0.
 
 ## Requests statistics

--- a/site/content/3.12/about-arangodb/features/community-edition.md
+++ b/site/content/3.12/about-arangodb/features/community-edition.md
@@ -39,7 +39,7 @@ see [arangodb.com/community-server/](https://www.arangodb.com/community-server/)
   documents, or graphs - perfect for social relations. Optional document
   validation using JSON Schema (draft-4, without remote schema support).
 
-- [**Data Storage**](../../deploy/architecture/storage-engine.md):
+- [**Data Storage**](../../components/arangodb-server/storage-engine.md):
   RocksDB storage engine to persist data and indexes on disk, with a hot set in
   memory. It uses journaling (write-ahead logging) and can take advantage of
   modern storage hardware, like SSDs and large caches.

--- a/site/content/3.12/about-arangodb/features/highlights-by-version.md
+++ b/site/content/3.12/about-arangodb/features/highlights-by-version.md
@@ -341,7 +341,7 @@ Also see [What's New in 3.5](../../release-notes/version-3.5/whats-new-in-3-5.md
   as soon as possible.
 
 - **RocksDB as Default Storage Engine**: With ArangoDB 3.4 the default
-  [storage engine](../../deploy/architecture/storage-engine.md) for fresh installations will
+  [storage engine](../../components/arangodb-server/storage-engine.md) for fresh installations will
   switch from MMFiles to RocksDB. Many optimizations have been made to RocksDB
   since the first release in 3.2. For 3.4 we optimized the binary storage
   format for improved insertion, implemented "optional caching", reduced the
@@ -382,7 +382,7 @@ Also see [What's New in 3.3](../../release-notes/version-3.3/whats-new-in-3-3.md
 
 **All Editions**
 
-- [**RocksDB Storage Engine**](../../deploy/architecture/storage-engine.md): You can now use
+- [**RocksDB Storage Engine**](../../components/arangodb-server/storage-engine.md): You can now use
   as much data in ArangoDB as you can fit on your disk. Plus, you can enjoy
   performance boosts on writes by having only document-level locks.
 

--- a/site/content/3.12/about-arangodb/use-cases.md
+++ b/site/content/3.12/about-arangodb/use-cases.md
@@ -131,7 +131,7 @@ binary large objects (BLOBs) and works best with small to medium-sized
 JSON objects.
 
 For more information about how ArangoDB persists data, see
-[Storage Engine](../deploy/architecture/storage-engine.md).
+[Storage Engine](../components/arangodb-server/storage-engine.md).
 
 ## ArangoDB as a Search Engine
 

--- a/site/content/3.12/components/arangodb-server/storage-engine.md
+++ b/site/content/3.12/components/arangodb-server/storage-engine.md
@@ -1,11 +1,13 @@
 ---
 title: Storage Engine
 menuTitle: Storage Engine
-weight: 15
+weight: 20
 description: >-
   The storage engine is responsible for persisting data on disk, holding copies
   in memory, providing indexes and caches to speed up queries
 archetype: default
+aliases:
+  - ../../deploy/architecture/storage-engine
 ---
 ArangoDB's storage engine is based on Facebook's **RocksDB** and the only
 storage engine available in ArangoDB 3.7 and above. It is the bottom layer of

--- a/site/content/3.12/deploy/architecture/_index.md
+++ b/site/content/3.12/deploy/architecture/_index.md
@@ -3,7 +3,6 @@ title: ArangoDB Architecture
 menuTitle: Architecture
 weight: 100
 description: >-
-  Technical insights into ArangoDB's scalability, sharding, the storage engine,
-  and replication
+  Technical insights into ArangoDB's scalability, sharding, and replication
 archetype: chapter
 ---

--- a/site/content/3.12/develop/transactions/limitations.md
+++ b/site/content/3.12/develop/transactions/limitations.md
@@ -76,7 +76,7 @@ Understanding these differences is important when designing applications that ne
 to be resilient against outages of individual servers.
 
 Cluster transactions share the underlying characteristics of the
-[storage engine](../../deploy/architecture/storage-engine.md) that is used for the cluster deployment.
+[storage engine](../../components/arangodb-server/storage-engine.md) that is used for the cluster deployment.
 A transaction started on a Coordinator translates to one transaction per involved DB-Server.
 The guarantees and characteristics of the given storage-engine apply additionally
 to the cluster specific information below.

--- a/site/content/3.12/release-notes/version-3.6/incompatible-changes-in-3-6.md
+++ b/site/content/3.12/release-notes/version-3.6/incompatible-changes-in-3-6.md
@@ -44,7 +44,7 @@ The MMFiles storage engine is deprecated starting with version
 3.6.0 and it will be removed in a future release.
 
 We recommend to switch to RocksDB even before the removal of MMFiles.
-RocksDB is the default [storage engine](../../deploy/architecture/storage-engine.md)
+RocksDB is the default [storage engine](../../components/arangodb-server/storage-engine.md)
 since v3.4.0.
 
 ## Requests statistics


### PR DESCRIPTION
### Description

Moved the Storage engine content under ArangoDB Server.
