### PR TITLE
Add possible `mode` values to `put /_admin/cluster/maintenance/<server-id>`

### DIFF
--- a/site/content/3.10/develop/http-api/cluster.md
+++ b/site/content/3.10/develop/http-api/cluster.md
@@ -346,6 +346,8 @@ paths:
         maintenance mode, so that no attempts are made to re-distribute the data in a
         cluster for such planned events. DB-Servers in maintenance mode are not
         considered viable failover targets because they are likely restarted soon.
+
+        Possible values for `mode` are `"maintenance"` and `"normal"`.
       parameters:
         - name: DB-Server-ID
           in: path

--- a/site/content/3.11/develop/http-api/cluster.md
+++ b/site/content/3.11/develop/http-api/cluster.md
@@ -346,6 +346,8 @@ paths:
         maintenance mode, so that no attempts are made to re-distribute the data in a
         cluster for such planned events. DB-Servers in maintenance mode are not
         considered viable failover targets because they are likely restarted soon.
+
+        Possible values for `mode` are `"maintenance"` and `"normal"`.
       parameters:
         - name: DB-Server-ID
           in: path

--- a/site/content/3.12/develop/http-api/cluster.md
+++ b/site/content/3.12/develop/http-api/cluster.md
@@ -346,6 +346,8 @@ paths:
         maintenance mode, so that no attempts are made to re-distribute the data in a
         cluster for such planned events. DB-Servers in maintenance mode are not
         considered viable failover targets because they are likely restarted soon.
+
+        Possible values for `mode` are `"maintenance"` and `"normal"`.
       parameters:
         - name: DB-Server-ID
           in: path


### PR DESCRIPTION
### Description

Added a sentence to save users an extra click/search for its [documentation page](https://docs.arangodb.com/3.11/develop/http-api/cluster/#set-the-maintenance-status-of-a-db-server_body_mode)


The `Rest API` description for this endpoint (in the Web UI) doesn't specify the possible `mode` values:
<img width="1304" alt="image" src="https://github.com/arangodb/docs-hugo/assets/43019056/a6b89b43-7caf-47f2-99e9-af9d00747e02">

Whereas a similar endpoint (`PUT /_admin/cluster/maintenance`) does indeed specify possible values for `mode`:
<img width="1295" alt="image" src="https://github.com/arangodb/docs-hugo/assets/43019056/72adb52b-df28-4ba8-9083-f0bd236ad9b4">


I'm aware that the possible values are also present under the `Schema` section in the `Request Body` header so feel free to close this PR if that is deemed sufficient


#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
