### PR TITLE
Release notes: Improved `move-filters-into-enumerate` optimizer rule

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -192,6 +192,13 @@ See [String functions in AQL](../../aql/functions/string.md#repeat).
 
 A numeric function `RANDOM()` has been added as an alias for the existing `RAND()`.
 
+### Improved `move-filters-into-enumerate` optimizer rule
+
+The `move-filters-into-enumerate` optimizer rule can now also move filters into
+`EnumerateListNodes` for early pruning. This can significantly improve the
+performance of queries that do a lot of filtering on longer lists of
+non-collection data.
+
 ## Indexing
 
 ### Stored values can contain the `_id` attribute


### PR DESCRIPTION
### Description

See https://github.com/arangodb/arangodb/pull/20343

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
