### PR TITLE
DOC-614 | Mention extended edge update validation in Gharial

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -72,8 +72,8 @@ The affected endpoints are `POST /_api/cursor`, `POST /_api/explain`, and
 #### Gharial API
 
 The `PATCH /_api/gharial/{graph}/edge/{collection}/{edge}` endpoint to update
-edges in named graphs now validates the referenced vertex if only the `_from`
-or `_to` edge attribute is modified. Previously, the validation only occurred if
+edges in named graphs now validates the referenced vertex when modifying either
+the `_from` or `_to` edge attribute. Previously, the validation only occurred if
 both were set in the request.
 
 #### Limit to the number of databases in a deployment

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -69,6 +69,13 @@ Moreover, a `remove-unnecessary-calculations-4` rule has been added.
 The affected endpoints are `POST /_api/cursor`, `POST /_api/explain`, and
 `GET /_api/query/rules`.
 
+#### Gharial API
+
+The `PATCH /_api/gharial/{graph}/edge/{collection}/{edge}` endpoint to update
+edges in named graphs now validates the referenced vertex if only the `_from`
+or `_to` edge attribute is modified. Previously, the validation only occurred if
+both were set in the request.
+
 #### Limit to the number of databases in a deployment
 
 <small>Introduced in: v3.10.10, v3.11.2</small>


### PR DESCRIPTION
### Description

I'm not sure whether we should mention this as an API change because this is actually bug fix

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
