### PR TITLE
DOC-614 | Some arangod exit codes changed

### DIFF
--- a/site/content/3.10/release-notes/version-3.10/incompatible-changes-in-3-10.md
+++ b/site/content/3.10/release-notes/version-3.10/incompatible-changes-in-3-10.md
@@ -196,7 +196,7 @@ HTTP status `400 Bad Request`).
 
 <small>Introduced in: v3.10.13</small>
 
-For some fatal errors like a require database upgrade or a failed version check,
+For some fatal errors like a required database upgrade or a failed version check,
 _arangod_ set the generic exit code of `1`. It now returns a different, more
 specific exit code in these cases.
 

--- a/site/content/3.10/release-notes/version-3.10/incompatible-changes-in-3-10.md
+++ b/site/content/3.10/release-notes/version-3.10/incompatible-changes-in-3-10.md
@@ -192,6 +192,14 @@ It is also an error if you specify an edge collection that is not part of the
 named graph's definition or of the list of edge collections (code `1939` and
 HTTP status `400 Bad Request`).
 
+## Exit code adjustments
+
+<small>Introduced in: v3.10.13</small>
+
+For some fatal errors like a require database upgrade or a failed version check,
+_arangod_ set the generic exit code of `1`. It now returns a different, more
+specific exit code in these cases.
+
 ## Startup Options
 
 ### Handling of Invalid Startup Options

--- a/site/content/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -255,7 +255,7 @@ the result array for the respective documents, along with the successful ones:
 
 <small>Introduced in: v3.10.13, v3.11.7</small>
 
-For some fatal errors like a require database upgrade or a failed version check,
+For some fatal errors like a required database upgrade or a failed version check,
 _arangod_ set the generic exit code of `1`. It now returns a different, more
 specific exit code in these cases.
 

--- a/site/content/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -251,6 +251,14 @@ the result array for the respective documents, along with the successful ones:
 {"_key":"valid","_id":"coll/valid","_rev":"_gG9JHsW---"}
 ```
 
+## Exit code adjustments
+
+<small>Introduced in: v3.10.13, v3.11.7</small>
+
+For some fatal errors like a require database upgrade or a failed version check,
+_arangod_ set the generic exit code of `1`. It now returns a different, more
+specific exit code in these cases.
+
 ## Batch-reading an empty list of documents succeeds
 
 <small>Introduced in: v3.11.1</small>

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -123,7 +123,7 @@ can cause previously working Stream Transactions to fail.
 
 <small>Introduced in: v3.10.13, v3.11.7, v3.12.0</small>
 
-For some fatal errors like a require database upgrade or a failed version check,
+For some fatal errors like a required database upgrade or a failed version check,
 _arangod_ set the generic exit code of `1`. It now returns a different, more
 specific exit code in these cases.
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -119,6 +119,12 @@ can now be configured with the `--transaction.streaming-max-transaction-size`
 startup option. The default value remains 128 MiB but configuring a lower limit
 can cause previously working Stream Transactions to fail.
 
+## Exit code adjustments
+
+For some fatal errors like a require database upgrade or a failed version check,
+_arangod_ set the generic exit code of `1`. It now returns a different, more
+specific exit code in these cases.
+
 ## Client tools
 
 ### jslint feature in arangosh

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -121,6 +121,8 @@ can cause previously working Stream Transactions to fail.
 
 ## Exit code adjustments
 
+<small>Introduced in: v3.10.13, v3.11.7, v3.12.0</small>
+
 For some fatal errors like a require database upgrade or a failed version check,
 _arangod_ set the generic exit code of `1`. It now returns a different, more
 specific exit code in these cases.


### PR DESCRIPTION
### Description

Since we don't currently document exit codes, I don't see a point of telling users the exact ones that some errors now set instead of 1. I considered linking to https://github.com/arangodb/arangodb/blob/devel/lib/Basics/exitcodes.dat but we would need to adjust the link for the release to 3.12 and you can also figure out what the exit codes mean based on the error messages you get if a fatal error occurs.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
