### PR TITLE
Do not debug-dump for top-level arrays & improve array rendering in OpenAPI responses

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
@@ -122,9 +122,8 @@
                 <ul class="openapi-table">
                   <div class="openapi-table-title">Response Body</div>
                   {{ range $k, $v := $content.content }}
-                    {{ if $v.schema.items }}
+                    {{ if eq $v.schema.type "array" }}
                       {{ $required := false }}
-                      {{/* TODO: Improve array rendering */}}
                       {{- template "renderProperty" dict "title" $statusId "prop" "" "value" $v.schema "required" $required }}
                     {{ else }}
                       {{ range $prop, $value := $v.schema.properties}}
@@ -179,8 +178,8 @@
   {{ $type := $value.type }}
   {{ $anchor := printf "%s_%s" $title $prop }}
   <li class="openapi-table-row regular-font">
-    {{ if eq $value.type "array" }}
-      {{ $type = printf "[%s]" $value.items.type }}
+    {{ if and (eq $value.type "array") ($value.items.type) }}
+      {{ $type = printf "array<%s>" $value.items.type }}
     {{ else if eq $value.type "object" }}
       {{ $type = "object" }}
     {{ end }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
@@ -179,7 +179,7 @@
   {{ $anchor := printf "%s_%s" $title $prop }}
   <li class="openapi-table-row regular-font">
     {{ if and (eq $value.type "array") ($value.items.type) }}
-      {{ $type = printf "array<%s>" $value.items.type }}
+      {{ $type = printf "array of %ss" $value.items.type }}
     {{ else if eq $value.type "object" }}
       {{ $type = "object" }}
     {{ end }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
@@ -124,7 +124,7 @@
                   {{ range $k, $v := $content.content }}
                     {{ if $v.schema.items }}
                       {{ $required := false }}
-                      {{ $v }}
+                      {{/* TODO: Improve array rendering */}}
                       {{- template "renderProperty" dict "title" $statusId "prop" "" "value" $v.schema "required" $required }}
                     {{ else }}
                       {{ range $prop, $value := $v.schema.properties}}


### PR DESCRIPTION
### Description

This removes dumping the Go data structure for `type: array` (indirectly checked by looking for `items:`) at the top-level of a response schema description.

If no item type is defined for an array, still render the property (with an indicated type of `array`).

For arrays with a defined item type (excluding `items: type: ''`), display `array<type>` instead of `[type]`.

Empty item type, `array`:
- Before https://docs.arangodb.com/stable/develop/http-api/queries/aql-queries/#create-a-cursor_res_201_result
- After https://deploy-preview-427--docs-hugo.netlify.app/stable/develop/http-api/queries/aql-queries/#create-a-cursor_res_201_result

No debug-dumping of top-level arrays, `array<object>` instead of `[object]`:
- Before <https://docs.arangodb.com/stable/develop/http-api/queries/aql-queries/#list-all-aql-optimizer-rules_res_200_>
- After <https://deploy-preview-427--docs-hugo.netlify.app/stable/develop/http-api/queries/aql-queries/#list-all-aql-optimizer-rules_res_200_>

Array with no items defined:
- We don't seem to have an example for this but I tested it locally
- Now displays a clickable `array` item instead of nothing

```yaml
      responses:
        '200':
          description: |
            The list of collections
          content:
            application/json:
              schema:
                description: |
                  The data type is an array but without specification of its elements.
                type: array
```

<img width="473" alt="image" src="https://github.com/arangodb/docs-hugo/assets/7819991/7c4464a9-502f-4025-b445-53ce849f3516">


#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
