### PR TITLE
DOC-614 | Progress indication for index generation

### DIFF
--- a/site/content/3.10/release-notes/version-3.10/api-changes-in-3-10.md
+++ b/site/content/3.10/release-notes/version-3.10/api-changes-in-3-10.md
@@ -749,7 +749,7 @@ figures, and for `arangosearch` Views, `withHidden` needs to be enabled, too:
 
 #### Progress indication on the index generation
 
-<small>Introduced in: v3.10.13, v3.11.7</small>
+<small>Introduced in: v3.10.13</small>
 
 The `GET /_api/index` endpoint now returns a `progress` attribute that can
 optionally show indexes that are currently being created and indicate progress

--- a/site/content/3.10/release-notes/version-3.10/api-changes-in-3-10.md
+++ b/site/content/3.10/release-notes/version-3.10/api-changes-in-3-10.md
@@ -747,6 +747,22 @@ figures, and for `arangosearch` Views, `withHidden` needs to be enabled, too:
 }
 ```
 
+#### Progress indication on the index generation
+
+<small>Introduced in: v3.10.13, v3.11.7</small>
+
+The `GET /_api/index` endpoint now returns a `progress` attribute that can
+optionally show indexes that are currently being created and indicate progress
+on the index generation.
+
+To return indexes that are not yet fully built but are in the building phase,
+add the option `withHidden=true` to `GET /_api/index?collection=<collectionName>`.
+
+```
+curl --header 'accept: application/json' --dump -
+"http://localhost:8529/_api/index?collection=myCollection&withHidden=true"
+```
+
 #### Document API
 
 <small>Introduced in: v3.9.6, v3.10.2</small>

--- a/site/content/3.11/release-notes/version-3.10/api-changes-in-3-10.md
+++ b/site/content/3.11/release-notes/version-3.10/api-changes-in-3-10.md
@@ -747,6 +747,22 @@ figures, and for `arangosearch` Views, `withHidden` needs to be enabled, too:
 }
 ```
 
+#### Progress indication on the index generation
+
+<small>Introduced in: v3.10.13</small>
+
+The `GET /_api/index` endpoint now returns a `progress` attribute that can
+optionally show indexes that are currently being created and indicate progress
+on the index generation.
+
+To return indexes that are not yet fully built but are in the building phase,
+add the option `withHidden=true` to `GET /_api/index?collection=<collectionName>`.
+
+```
+curl --header 'accept: application/json' --dump -
+"http://localhost:8529/_api/index?collection=myCollection&withHidden=true"
+```
+
 #### Document API
 
 <small>Introduced in: v3.9.6, v3.10.2</small>

--- a/site/content/3.11/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/api-changes-in-3-11.md
@@ -467,7 +467,7 @@ Also see the [HTTP interface for cluster maintenance](../../develop/http-api/clu
 
 ##### Progress indication on the index generation
 
-<small>Introduced in: v3.10.13</small>
+<small>Introduced in: v3.10.13, v3.11.7</small>
 
 The `GET /_api/index` endpoint now returns a `progress` attribute that can
 optionally show indexes that are currently being created and indicate progress

--- a/site/content/3.11/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/api-changes-in-3-11.md
@@ -463,6 +463,24 @@ Also see the [HTTP interface for cluster maintenance](../../develop/http-api/clu
   threshold for the maximum number of `OR` sub-nodes in the internal
   representation of an AQL `FILTER` condition and defaults to `786432`.
 
+#### Index API  
+
+##### Progress indication on the index generation
+
+<small>Introduced in: v3.10.13</small>
+
+The `GET /_api/index` endpoint now returns a `progress` attribute that can
+optionally show indexes that are currently being created and indicate progress
+on the index generation.
+
+To return indexes that are not yet fully built but are in the building phase,
+add the option `withHidden=true` to `GET /_api/index?collection=<collectionName>`.
+
+```
+curl --header 'accept: application/json' --dump -
+"http://localhost:8529/_api/index?collection=myCollection&withHidden=true"
+```  
+
 ### Endpoints deprecated
 
 The `GET /_admin/database/target-version` endpoint is deprecated in favor of the

--- a/site/content/3.12/release-notes/version-3.10/api-changes-in-3-10.md
+++ b/site/content/3.12/release-notes/version-3.10/api-changes-in-3-10.md
@@ -747,6 +747,22 @@ figures, and for `arangosearch` Views, `withHidden` needs to be enabled, too:
 }
 ```
 
+#### Progress indication on the index generation
+
+<small>Introduced in: v3.10.13</small>
+
+The `GET /_api/index` endpoint now returns a `progress` attribute that can
+optionally show indexes that are currently being created and indicate progress
+on the index generation.
+
+To return indexes that are not yet fully built but are in the building phase,
+add the option `withHidden=true` to `GET /_api/index?collection=<collectionName>`.
+
+```
+curl --header 'accept: application/json' --dump -
+"http://localhost:8529/_api/index?collection=myCollection&withHidden=true"
+```
+
 #### Document API
 
 <small>Introduced in: v3.9.6, v3.10.2</small>

--- a/site/content/3.12/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/3.12/release-notes/version-3.11/api-changes-in-3-11.md
@@ -467,7 +467,7 @@ Also see the [HTTP interface for cluster maintenance](../../develop/http-api/clu
 
 ##### Progress indication on the index generation
 
-<small>Introduced in: v3.10.13</small>
+<small>Introduced in: v3.10.13, v3.11.7</small>
 
 The `GET /_api/index` endpoint now returns a `progress` attribute that can
 optionally show indexes that are currently being created and indicate progress

--- a/site/content/3.12/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/3.12/release-notes/version-3.11/api-changes-in-3-11.md
@@ -463,6 +463,24 @@ Also see the [HTTP interface for cluster maintenance](../../develop/http-api/clu
   threshold for the maximum number of `OR` sub-nodes in the internal
   representation of an AQL `FILTER` condition and defaults to `786432`.
 
+#### Index API  
+
+##### Progress indication on the index generation
+
+<small>Introduced in: v3.10.13</small>
+
+The `GET /_api/index` endpoint now returns a `progress` attribute that can
+optionally show indexes that are currently being created and indicate progress
+on the index generation.
+
+To return indexes that are not yet fully built but are in the building phase,
+add the option `withHidden=true` to `GET /_api/index?collection=<collectionName>`.
+
+```
+curl --header 'accept: application/json' --dump -
+"http://localhost:8529/_api/index?collection=myCollection&withHidden=true"
+```  
+
 ### Endpoints deprecated
 
 The `GET /_admin/database/target-version` endpoint is deprecated in favor of the

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -209,12 +209,30 @@ for details.
 
 #### Index API
 
+##### `optimizeTopK` for inverted indexes
+
 Indexes of type `inverted` accept a new `optimizeTopK` property for the
 ArangoSearch WAND optimization. It is an array of strings, optional, and
 defaults to `[]`.
 
 See the [inverted index `optimizeTopK` property](../../develop/http-api/indexes/inverted.md)
 for details.
+
+##### Progress indication on the index generation
+
+<small>Introduced in: v3.10.13, v3.11.7</small>
+
+The `GET /_api/index` endpoint now returns a `progress` attribute that can
+optionally show indexes that are currently being created and indicate progress
+on the index generation.
+
+To return indexes that are not yet fully built but are in the building phase,
+add the option `withHidden=true` to `GET /_api/index?collection=<collectionName>`.
+
+```
+curl --header 'accept: application/json' --dump -
+"http://localhost:8529/_api/index?collection=myCollection&withHidden=true"
+```
 
 #### Optimizer rule descriptions
 


### PR DESCRIPTION
### Description

Relates to https://github.com/arangodb/arangodb/pull/18516 and backports.

Added release notes. 

Unclear why the response body of  `GET /_api/index` endpoint is not documented in the first place. To add the new `progress` attribute returned by this endpoint in the HTTP API docs, the endpoint description needs to be reworked and include the response body. 
