### PR TITLE
DOC-614 | Changed startup option defaults, audit log escaping, cluster compaction

### DIFF
--- a/site/content/3.11/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1318,10 +1318,18 @@ The following startup options have been added:
 
 - `--cache.max-spare-memory-usage`: the maximum memory usage for spare tables
   in the in-memory cache.
+
 - `--cache.high-water-multiplier`: controls the cache's effective memory usage
   limit. The user-defined memory limit (i.e. `--cache.size`) is multiplied with
   this value to create the effective memory limit, from which on the cache tries
-  to free up memory by evicting the oldest entries.
+  to free up memory by evicting the oldest entries. The default value is `0.56`,
+  matching the previously hardcoded 56% for the cache subsystem.
+
+  You can increase the multiplier to make the cache subsystem use more memory, but
+  this may overcommit memory because the cache memory reclamation procedure is
+  asynchronous and can run in parallel to other tasks that insert new data.
+  In case a deployment's memory usage is already close to the maximum, increasing
+  the multiplier can lead to out-of-memory (OOM) kills.
 
 The following metrics have been added:
 

--- a/site/content/3.12/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/3.12/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1318,10 +1318,18 @@ The following startup options have been added:
 
 - `--cache.max-spare-memory-usage`: the maximum memory usage for spare tables
   in the in-memory cache.
+
 - `--cache.high-water-multiplier`: controls the cache's effective memory usage
   limit. The user-defined memory limit (i.e. `--cache.size`) is multiplied with
   this value to create the effective memory limit, from which on the cache tries
-  to free up memory by evicting the oldest entries.
+  to free up memory by evicting the oldest entries. The default value is `0.56`,
+  matching the previously hardcoded 56% for the cache subsystem.
+
+  You can increase the multiplier to make the cache subsystem use more memory, but
+  this may overcommit memory because the cache memory reclamation procedure is
+  asynchronous and can run in parallel to other tasks that insert new data.
+  In case a deployment's memory usage is already close to the maximum, increasing
+  the multiplier can lead to out-of-memory (OOM) kills.
 
 The following metrics have been added:
 

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -262,6 +262,12 @@ the query. In that case, `warnings` contains an empty array.
 In previous versions, no `warnings` attribute was returned when parsing a query
 produced no warnings.
 
+#### Per-collection compaction in cluster
+
+The `PUT /_api/collection/{collection-name}/compact` endpoint can now be used
+to start the compaction for a specific collection in cluster deployments.
+This feature was previously available for single servers only.
+
 #### Metrics API
 
 The metrics endpoint includes the following new metrics about AQL queries,

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -62,6 +62,13 @@ It is not sufficient to take a hot backup of a little-endian deployment and
 restore it because when restoring a hot backup, the original database format is
 restored as it was at time of the backup.
 
+## Control character escaping in audit log
+
+The audit log feature of the Enterprise Edition previously logged query strings
+verbatim. Control characters, in particular line breaks, can cause issues with
+parsing the audit log. They are now escaped for query strings which often contain
+line breaks.
+
 ## Higher reported memory usage for AQL queries
 
 Due to the [improved memory accounting in v3.12](whats-new-in-3-12.md#improved-memory-accounting-and-usage),

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -67,29 +67,16 @@ restored as it was at time of the backup.
 By default, the in-memory cache subsystem uses up to 95% of its configured
 memory limit value (as configured by the `--cache.size` startup option).
 
-Previous versions of ArangoDB effectively used only 56% of the configured memory
-limit value for the cache subsystem. The 56% value was hard-coded in ArangoDB
-versions before 3.11.3, and has been configurable since then via the 
-`--cache.high-water-multiplier` startup option. To make things compatible, the 
-default value for the high water multiplier was set to 56% in 3.11.
+Previous versions of ArangoDB effectively used a hard-coded 56% of the configured
+memory limit value for the cache subsystem. From version 3.11.4 on, this is
+configurable via the `--cache.high-water-multiplier` startup option.
+The default value is `0.56`, so still 56% for the cache subsystem.
 
-ArangoDB 3.12 now adjusts this default value to 95%, i.e. the cache subsystem
-uses up to 95% of the configured memory. Although this is a behavior
-change, it seems more sensible to use up to 95% of the configured limit value 
-rather than just 56%.
-The change can lead to the cache subsystem effectively using more memory than
-before. In case a deployment's memory usage is already close to the maximum,
-the change can lead to out-of-memory (OOM) kills. To avoid this, you have
-two options:
-
-1. Decrease the value of `--cache.high-water-multiplier` to 0.56, which should
-   mimic the old behavior.
-2. Leave the high water multiplier untouched, but decrease the value of the 
-   `--cache.size` startup option to about half of its current value.
-
-The second option is the recommended one, as it signals the intent more clearly,
-and makes the cache behave "as expected", i.e. use up to the configured
-memory limit and not just 56% of it.
+You can increase the multiplier to make the cache subsystem use more memory, but
+this may overcommit memory because the cache memory reclamation procedure is
+asynchronous and can run in parallel to other tasks that insert new data.
+In case a deployment's memory usage is already close to the maximum, increasing
+the multiplier can lead to out-of-memory (OOM) kills.
 
 ## Higher reported memory usage for AQL queries
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -229,22 +229,6 @@ lowered from 1 million to 100,000. The background thread for time-to-live indexe
 now removes fewer documents from a collection in each iteration to give other
 collections a chance of being cleaned up as well.
 
-### In-memory cache subsystem
-
-By default, the in-memory cache subsystem uses up to 95% of its configured
-memory limit value (as configured by the `--cache.size` startup option).
-
-Previous versions of ArangoDB effectively used a hard-coded 56% of the configured
-memory limit value for the cache subsystem. From version 3.11.4 on, this is
-configurable via the `--cache.high-water-multiplier` startup option.
-The default value is `0.56`, so still 56% for the cache subsystem.
-
-You can increase the multiplier to make the cache subsystem use more memory, but
-this may overcommit memory because the cache memory reclamation procedure is
-asynchronous and can run in parallel to other tasks that insert new data.
-In case a deployment's memory usage is already close to the maximum, increasing
-the multiplier can lead to out-of-memory (OOM) kills.
-
 ## Client tools
 
 ### arangodump

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -62,22 +62,6 @@ It is not sufficient to take a hot backup of a little-endian deployment and
 restore it because when restoring a hot backup, the original database format is
 restored as it was at time of the backup.
 
-## In-memory cache subsystem
-
-By default, the in-memory cache subsystem uses up to 95% of its configured
-memory limit value (as configured by the `--cache.size` startup option).
-
-Previous versions of ArangoDB effectively used a hard-coded 56% of the configured
-memory limit value for the cache subsystem. From version 3.11.4 on, this is
-configurable via the `--cache.high-water-multiplier` startup option.
-The default value is `0.56`, so still 56% for the cache subsystem.
-
-You can increase the multiplier to make the cache subsystem use more memory, but
-this may overcommit memory because the cache memory reclamation procedure is
-asynchronous and can run in parallel to other tasks that insert new data.
-In case a deployment's memory usage is already close to the maximum, increasing
-the multiplier can lead to out-of-memory (OOM) kills.
-
 ## Higher reported memory usage for AQL queries
 
 Due to the [improved memory accounting in v3.12](whats-new-in-3-12.md#improved-memory-accounting-and-usage),
@@ -237,6 +221,22 @@ The default value of the `--ttl.max-collection-removes` startup option has been
 lowered from 1 million to 100,000. The background thread for time-to-live indexes
 now removes fewer documents from a collection in each iteration to give other
 collections a chance of being cleaned up as well.
+
+### In-memory cache subsystem
+
+By default, the in-memory cache subsystem uses up to 95% of its configured
+memory limit value (as configured by the `--cache.size` startup option).
+
+Previous versions of ArangoDB effectively used a hard-coded 56% of the configured
+memory limit value for the cache subsystem. From version 3.11.4 on, this is
+configurable via the `--cache.high-water-multiplier` startup option.
+The default value is `0.56`, so still 56% for the cache subsystem.
+
+You can increase the multiplier to make the cache subsystem use more memory, but
+this may overcommit memory because the cache memory reclamation procedure is
+asynchronous and can run in parallel to other tasks that insert new data.
+In case a deployment's memory usage is already close to the maximum, increasing
+the multiplier can lead to out-of-memory (OOM) kills.
 
 ## Client tools
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -231,6 +231,13 @@ meant to facilitate downgrading or reverting the option change. When the option
 is set to `false`, all database objects with extended names that were created
 in the meantime should be removed manually.
 
+### Changed TTL index removal default
+
+The default value of the `--ttl.max-collection-removes` startup option has been
+lowered from 1 million to 100,000. The background thread for time-to-live indexes
+now removes fewer documents from a collection in each iteration to give other
+collections a chance of being cleaned up as well.
+
 ## Client tools
 
 ### arangodump

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -727,10 +727,18 @@ The following startup options have been added:
 
 - `--cache.max-spare-memory-usage`: the maximum memory usage for spare tables
   in the in-memory cache.
+
 - `--cache.high-water-multiplier`: controls the cache's effective memory usage
   limit. The user-defined memory limit (i.e. `--cache.size`) is multiplied with
   this value to create the effective memory limit, from which on the cache tries
-  to free up memory by evicting the oldest entries.
+  to free up memory by evicting the oldest entries. The default value is `0.56`,
+  matching the previously hardcoded 56% for the cache subsystem.
+
+  You can increase the multiplier to make the cache subsystem use more memory, but
+  this may overcommit memory because the cache memory reclamation procedure is
+  asynchronous and can run in parallel to other tasks that insert new data.
+  In case a deployment's memory usage is already close to the maximum, increasing
+  the multiplier can lead to out-of-memory (OOM) kills.
 
 The following metrics have been added:
 

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -671,6 +671,12 @@ As it is unclear if and when a client will fetch any remaining data from a
 cursor, every cursor has a server-side timeout value (TTL) after which it is
 considered inactive and garbage-collected.
 
+### Per-collection compaction in cluster
+
+The `PUT /_api/collection/{collection-name}/compact` endpoint of the HTTP API
+can now be used to start the compaction for a specific collection in cluster
+deployments. This feature was previously available for single servers only.
+
 ### RocksDB .sst file partitioning (experimental)
 
 The following experimental startup options for RockDB .sst file partitioning


### PR DESCRIPTION
### Description

- https://github.com/arangodb/arangodb/pull/20512
- https://github.com/arangodb/arangodb/pull/20541/commits/3a6520c10b2dc8b818e83086b05d16ae5da54f1d#diff-df98ba6a30c47b0a44759fde6294d15e2bb88d5df34e751d35b2a9fd032775adL62-R62
- https://github.com/arangodb/arangodb/pull/20437
- https://github.com/arangodb/arangodb/pull/20504

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
