### PR TITLE
Pre-wrap more code to avoid layout overflow

### DIFF
--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -1469,6 +1469,7 @@ code, p code {
     margin: 0;
     padding: 2px;
     word-break: break-word;
+    white-space: pre-wrap;
     border-radius: 0px;
     background: var(--gray-100);
     box-shadow: none;


### PR DESCRIPTION
### Description

Experimental change to fix code overflow in "Show details" for https://docs.arangodb.com/3.11/components/arangodb-server/options/#--auditwrite-log-level

Need to verify that this doesn't wrap code in bad ways, like in the middle of words

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
