### PR TITLE
DOC-614 | Adjustable writeConcern

### DIFF
--- a/site/content/3.10/develop/http-api/collections.md
+++ b/site/content/3.10/develop/http-api/collections.md
@@ -288,8 +288,14 @@ paths:
                       in the cluster, a shard refuses to write. Writes to shards with enough
                       up-to-date copies succeed at the same time, however. The value of
                       `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the `writeConcern`
+                      is that of the prototype collection.
                       For SatelliteCollections, the `writeConcern` is automatically controlled to
-                      equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
                     type: integer
                   shardingStrategy:
                     description: |
@@ -306,7 +312,7 @@ paths:
                   distributeShardsLike:
                     description: |
                       The name of another collection. This collection uses the `replicationFactor`,
-                      `numberOfShards` and `shardingStrategy` properties of the other collection and
+                      `numberOfShards`, `shardingStrategy`, and `writeConcern` properties of the other collection and
                       the shards of this collection are distributed in the same way as the shards of
                       the other collection.
                     type: string
@@ -1172,13 +1178,19 @@ paths:
                     in the cluster, a shard refuses to write. Writes to shards with enough
                     up-to-date copies succeed at the same time, however. The value of
                     `writeConcern` cannot be greater than `replicationFactor`.
+
+                    If `distributeShardsLike` is set, the `writeConcern`
+                    is that of the prototype collection.
                     For SatelliteCollections, the `writeConcern` is automatically controlled to
-                    equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                    equal the number of DB-Servers and has a value of `0`.
+                    Otherwise, the default value is controlled by the current database's
+                    default `writeConcern`, which uses the `--cluster.write-concern`
+                    startup option as default, which defaults to `1`. _(cluster only)_
                   type: integer
                 shardingStrategy:
                   description: |
                     This attribute specifies the name of the sharding strategy to use for
-                    the collection. Since ArangoDB 3.4 there are different sharding strategies
+                    the collection. There are different sharding strategies
                     to select from when creating a new collection. The selected `shardingStrategy`
                     value remains fixed for the collection and cannot be changed afterwards.
                     This is important to make the collection keep its sharding settings and
@@ -1209,7 +1221,7 @@ paths:
                 distributeShardsLike:
                   description: |
                     The name of another collection. If this property is set in a cluster, the
-                    collection copies the `replicationFactor`, `numberOfShards` and `shardingStrategy`
+                    collection copies the `replicationFactor`, `numberOfShards`, `shardingStrategy`, and `writeConcern`
                     properties from the specified collection (referred to as the _prototype collection_)
                     and distributes the shards of this collection in the same way as the shards of
                     the other collection. In an Enterprise Edition cluster, this data co-location is
@@ -1427,8 +1439,14 @@ paths:
                       in the cluster, a shard refuses to write. Writes to shards with enough
                       up-to-date copies succeed at the same time, however. The value of
                       `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the `writeConcern`
+                      is that of the prototype collection.
                       For SatelliteCollections, the `writeConcern` is automatically controlled to
-                      equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
                     type: integer
                   shardingStrategy:
                     description: |
@@ -1445,7 +1463,7 @@ paths:
                   distributeShardsLike:
                     description: |
                       The name of another collection. This collection uses the `replicationFactor`,
-                      `numberOfShards` and `shardingStrategy` properties of the other collection and
+                      `numberOfShards`, `shardingStrategy`, and `writeConcern` properties of the other collection and
                       the shards of this collection are distributed in the same way as the shards of
                       the other collection.
                     type: string
@@ -2104,8 +2122,14 @@ paths:
                     in the cluster, a shard refuses to write. Writes to shards with enough
                     up-to-date copies succeed at the same time, however. The value of
                     `writeConcern` cannot be greater than `replicationFactor`.
+
+                    If `distributeShardsLike` is set, the `writeConcern`
+                    is that of the prototype collection.
                     For SatelliteCollections, the `writeConcern` is automatically controlled to
-                    equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                    equal the number of DB-Servers and has a value of `0`.
+                    Otherwise, the default value is controlled by the current database's
+                    default `writeConcern`, which uses the `--cluster.write-concern`
+                    startup option as default, which defaults to `1`. _(cluster only)_
                   type: integer
       responses:
         '400':

--- a/site/content/3.10/develop/http-api/databases.md
+++ b/site/content/3.10/develop/http-api/databases.md
@@ -240,8 +240,13 @@ paths:
                         in the cluster, a shard refuses to write. Writes to shards with enough
                         up-to-date copies succeed at the same time, however. The value of
                         `writeConcern` cannot be greater than `replicationFactor`.
+
+                        If `distributeShardsLike` is set, the `writeConcern`
+                        is that of the prototype collection.
                         For SatelliteCollections, the `writeConcern` is automatically controlled to
-                        equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                        equal the number of DB-Servers and has a value of `0`.
+                        Otherwise, the default value is controlled by the `--cluster.write-concern`
+                        startup option, which defaults to `1`. _(cluster only)_
                       type: number
                 users:
                   description: |

--- a/site/content/3.10/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.10/develop/javascript-api/@arangodb/collection-object.md
@@ -266,7 +266,7 @@ In a cluster setup, the result also contains the following attributes:
 
 - `distributeShardsLike` (string):
   The name of another collection. This collection uses the `replicationFactor`,
-  `numberOfShards` and `shardingStrategy` properties of the other collection and
+  `numberOfShards`, `shardingStrategy`, `writeConcern` properties of the other collection and
   the shards of this collection are distributed in the same way as the shards of
   the other collection.
 

--- a/site/content/3.10/develop/javascript-api/@arangodb/db-object.md
+++ b/site/content/3.10/develop/javascript-api/@arangodb/db-object.md
@@ -392,7 +392,7 @@ error is thrown. For information about the naming constraints for collections, s
 
 - `distributeShardsLike` (string, _optional_, default: `""`):
   The name of another collection. If this property is set in a cluster, the
-  collection copies the `replicationFactor`, `numberOfShards` and `shardingStrategy`
+  collection copies the `replicationFactor`, `numberOfShards`, `shardingStrategy`, and `writeConcern`
   properties from the specified collection (referred to as the _prototype collection_)
   and distributes the shards of this collection in the same way as the shards of
   the other collection. In an Enterprise Edition cluster, this data co-location is

--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -288,8 +288,14 @@ paths:
                       in the cluster, a shard refuses to write. Writes to shards with enough
                       up-to-date copies succeed at the same time, however. The value of
                       `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the `writeConcern`
+                      is that of the prototype collection.
                       For SatelliteCollections, the `writeConcern` is automatically controlled to
-                      equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
                     type: integer
                   shardingStrategy:
                     description: |
@@ -306,7 +312,7 @@ paths:
                   distributeShardsLike:
                     description: |
                       The name of another collection. This collection uses the `replicationFactor`,
-                      `numberOfShards` and `shardingStrategy` properties of the other collection and
+                      `numberOfShards`, `shardingStrategy`, and `writeConcern` properties of the other collection and
                       the shards of this collection are distributed in the same way as the shards of
                       the other collection.
                     type: string
@@ -1172,8 +1178,14 @@ paths:
                     in the cluster, a shard refuses to write. Writes to shards with enough
                     up-to-date copies succeed at the same time, however. The value of
                     `writeConcern` cannot be greater than `replicationFactor`.
+
+                    If `distributeShardsLike` is set, the `writeConcern`
+                    is that of the prototype collection.
                     For SatelliteCollections, the `writeConcern` is automatically controlled to
-                    equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                    equal the number of DB-Servers and has a value of `0`.
+                    Otherwise, the default value is controlled by the current database's
+                    default `writeConcern`, which uses the `--cluster.write-concern`
+                    startup option as default, which defaults to `1`. _(cluster only)_
                   type: integer
                 shardingStrategy:
                   description: |
@@ -1209,7 +1221,7 @@ paths:
                 distributeShardsLike:
                   description: |
                     The name of another collection. If this property is set in a cluster, the
-                    collection copies the `replicationFactor`, `numberOfShards` and `shardingStrategy`
+                    collection copies the `replicationFactor`, `numberOfShards`, `shardingStrategy`, and `writeConcern`
                     properties from the specified collection (referred to as the _prototype collection_)
                     and distributes the shards of this collection in the same way as the shards of
                     the other collection. In an Enterprise Edition cluster, this data co-location is
@@ -1427,8 +1439,14 @@ paths:
                       in the cluster, a shard refuses to write. Writes to shards with enough
                       up-to-date copies succeed at the same time, however. The value of
                       `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the `writeConcern`
+                      is that of the prototype collection.
                       For SatelliteCollections, the `writeConcern` is automatically controlled to
-                      equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
                     type: integer
                   shardingStrategy:
                     description: |
@@ -1445,7 +1463,7 @@ paths:
                   distributeShardsLike:
                     description: |
                       The name of another collection. This collection uses the `replicationFactor`,
-                      `numberOfShards` and `shardingStrategy` properties of the other collection and
+                      `numberOfShards`, `shardingStrategy`, and `writeConcern` properties of the other collection and
                       the shards of this collection are distributed in the same way as the shards of
                       the other collection.
                     type: string
@@ -2104,8 +2122,14 @@ paths:
                     in the cluster, a shard refuses to write. Writes to shards with enough
                     up-to-date copies succeed at the same time, however. The value of
                     `writeConcern` cannot be greater than `replicationFactor`.
+
+                    If `distributeShardsLike` is set, the `writeConcern`
+                    is that of the prototype collection.
                     For SatelliteCollections, the `writeConcern` is automatically controlled to
-                    equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                    equal the number of DB-Servers and has a value of `0`.
+                    Otherwise, the default value is controlled by the current database's
+                    default `writeConcern`, which uses the `--cluster.write-concern`
+                    startup option as default, which defaults to `1`. _(cluster only)_
                   type: integer
       responses:
         '400':

--- a/site/content/3.11/develop/http-api/databases.md
+++ b/site/content/3.11/develop/http-api/databases.md
@@ -240,8 +240,13 @@ paths:
                         in the cluster, a shard refuses to write. Writes to shards with enough
                         up-to-date copies succeed at the same time, however. The value of
                         `writeConcern` cannot be greater than `replicationFactor`.
+
+                        If `distributeShardsLike` is set, the `writeConcern`
+                        is that of the prototype collection.
                         For SatelliteCollections, the `writeConcern` is automatically controlled to
-                        equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                        equal the number of DB-Servers and has a value of `0`.
+                        Otherwise, the default value is controlled by the `--cluster.write-concern`
+                        startup option, which defaults to `1`. _(cluster only)_
                       type: number
                 users:
                   description: |

--- a/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
@@ -266,7 +266,7 @@ In a cluster setup, the result also contains the following attributes:
 
 - `distributeShardsLike` (string):
   The name of another collection. This collection uses the `replicationFactor`,
-  `numberOfShards` and `shardingStrategy` properties of the other collection and
+  `numberOfShards`, `shardingStrategy`, `writeConcern` properties of the other collection and
   the shards of this collection are distributed in the same way as the shards of
   the other collection.
 

--- a/site/content/3.11/develop/javascript-api/@arangodb/db-object.md
+++ b/site/content/3.11/develop/javascript-api/@arangodb/db-object.md
@@ -392,7 +392,7 @@ error is thrown. For information about the naming constraints for collections, s
 
 - `distributeShardsLike` (string, _optional_, default: `""`):
   The name of another collection. If this property is set in a cluster, the
-  collection copies the `replicationFactor`, `numberOfShards` and `shardingStrategy`
+  collection copies the `replicationFactor`, `numberOfShards`, `shardingStrategy`, and `writeConcern`
   properties from the specified collection (referred to as the _prototype collection_)
   and distributes the shards of this collection in the same way as the shards of
   the other collection. In an Enterprise Edition cluster, this data co-location is

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -288,8 +288,14 @@ paths:
                       in the cluster, a shard refuses to write. Writes to shards with enough
                       up-to-date copies succeed at the same time, however. The value of
                       `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the default `writeConcern`
+                      is that of the prototype collection.
                       For SatelliteCollections, the `writeConcern` is automatically controlled to
-                      equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
                     type: integer
                   shardingStrategy:
                     description: |
@@ -1221,14 +1227,19 @@ paths:
                   type: integer
                 writeConcern:
                   description: |
-                    Write concern for this collection (default: 1).
-                    It determines how many copies of each shard are required to be
+                    Determines how many copies of each shard are required to be
                     in sync on the different DB-Servers. If there are less than these many copies
                     in the cluster, a shard refuses to write. Writes to shards with enough
                     up-to-date copies succeed at the same time, however. The value of
                     `writeConcern` cannot be greater than `replicationFactor`.
+
+                    If `distributeShardsLike` is set, the default `writeConcern`
+                    is that of the prototype collection.
                     For SatelliteCollections, the `writeConcern` is automatically controlled to
-                    equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                    equal the number of DB-Servers and has a value of `0`.
+                    Otherwise, the default value is controlled by the current database's
+                    default `writeConcern`, which uses the `--cluster.write-concern`
+                    startup option as default, which defaults to `1`. _(cluster only)_
                   type: integer
                 shardingStrategy:
                   description: |
@@ -1482,8 +1493,14 @@ paths:
                       in the cluster, a shard refuses to write. Writes to shards with enough
                       up-to-date copies succeed at the same time, however. The value of
                       `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the default `writeConcern`
+                      is that of the prototype collection.
                       For SatelliteCollections, the `writeConcern` is automatically controlled to
-                      equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
                     type: integer
                   shardingStrategy:
                     description: |
@@ -2153,14 +2170,19 @@ paths:
                   type: integer
                 writeConcern:
                   description: |
-                    Write concern for this collection (default: 1).
-                    It determines how many copies of each shard are required to be
+                    Determines how many copies of each shard are required to be
                     in sync on the different DB-Servers. If there are less than these many copies
                     in the cluster, a shard refuses to write. Writes to shards with enough
                     up-to-date copies succeed at the same time, however. The value of
                     `writeConcern` cannot be greater than `replicationFactor`.
+
+                    If `distributeShardsLike` is set, the default `writeConcern`
+                    is that of the prototype collection.
                     For SatelliteCollections, the `writeConcern` is automatically controlled to
-                    equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                    equal the number of DB-Servers and has a value of `0`.
+                    Otherwise, the default value is controlled by the current database's
+                    default `writeConcern`, which uses the `--cluster.write-concern`
+                    startup option as default, which defaults to `1`. _(cluster only)_
                   type: integer
       responses:
         '400':

--- a/site/content/3.12/develop/http-api/databases.md
+++ b/site/content/3.12/develop/http-api/databases.md
@@ -240,8 +240,11 @@ paths:
                         in the cluster, a shard refuses to write. Writes to shards with enough
                         up-to-date copies succeed at the same time, however. The value of
                         `writeConcern` cannot be greater than `replicationFactor`.
+
                         For SatelliteCollections, the `writeConcern` is automatically controlled to
-                        equal the number of DB-Servers and has a value of `0`. _(cluster only)_
+                        equal the number of DB-Servers and has a value of `0`.
+                        Otherwise, the default value is controlled by the `--cluster.write-concern`
+                        startup option, which defaults to `1`. _(cluster only)_
                       type: number
                 users:
                   description: |

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -192,11 +192,12 @@ a new `multi_delimiter` Analyzer that accepts an array of strings in a
 
 Collections that are sharded like another collection via the `distributeShardsLike`
 property use the `replicationFactor`, `numberOfShards`, and `shardingStrategy`
-properties of the prototype collection. You can independently set a `writeConcern`,
-but this property couldn't be changed after the collection creation if
-`distributeShardsLike` was used. Now, you can adjust the `writeConcern` later on.
-It still defaults to the `writeConcern` of the prototype collection if you don't
-specify it explicitly.
+properties of the prototype collection. In previous versions, the `writeConcern`
+property of the prototype collection was used as well. Now, you can independently
+set a `writeConcern` when creating a collection with `distributeShardsLike`.
+The property defaults to the `writeConcern` of the prototype collection if you
+don't specify it explicitly. You can adjust the `writeConcern` later on in
+either case.
 
 ### Privilege changes
 

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -188,6 +188,16 @@ The [`/_api/analyzer` endpoints](../../develop/http-api/analyzers.md) supports
 a new `multi_delimiter` Analyzer that accepts an array of strings in a
 `delimiter` attribute of the `properties` object.
 
+#### Adjustable `writeConcern` for collections with `distributeShardsLike`
+
+Collections that are sharded like another collection via the `distributeShardsLike`
+property use the `replicationFactor`, `numberOfShards`, and `shardingStrategy`
+properties of the prototype collection. You can independently set a `writeConcern`,
+but this property couldn't be changed after the collection creation if
+`distributeShardsLike` was used. Now, you can adjust the `writeConcern` later on.
+It still defaults to the `writeConcern` of the prototype collection if you don't
+specify it explicitly.
+
 ### Privilege changes
 
 


### PR DESCRIPTION
### Description

- Changed 3.10 and 3.11 API docs to reflect that the prototype collection controls the writeConcern
- Added explanation of the default value inheritance
- Added release notes about the writeConcern now being independent of the prototype collection

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10:
- 3.11:
- 3.12:
