### PR TITLE
remove mentions of active failover delpoyment in 3.12

### DIFF
--- a/site/content/3.12/develop/drivers/java/reference-version-6/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-6/driver-setup.md
@@ -216,21 +216,6 @@ ArangoDB arangoDB = new ArangoDB.Builder()
   .build();
 ```
 
-## Active Failover
-
-In case of an _Active Failover_ deployment the driver should be configured in
-the following way:
-- the load balancing strategy must be either set to `LoadBalancingStrategy.NONE`
-  or not set at all, since that would be the default
-- `acquireHostList` should be set to `true`
-
-```java
-ArangoDB arangoDB = new ArangoDB.Builder()
-  .loadBalancingStrategy(LoadBalancingStrategy.NONE)
-  .acquireHostList(true)
-  .build();
-```
-
 ## Connection time to live
 
 Since version 4.4 the driver supports setting a TTL (time to life) in milliseconds

--- a/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
@@ -206,20 +206,6 @@ ArangoDB arangoDB = new ArangoDB.Builder()
   .build();
 ```
 
-## Active Failover
-
-In case of an _Active Failover_ deployment the driver should be configured in
-the following way:
-- the load balancing strategy must be either set to `LoadBalancingStrategy.NONE` (default)
-- `acquireHostList` should be set to `true`
-
-```java
-ArangoDB arangoDB = new ArangoDB.Builder()
-  .loadBalancingStrategy(LoadBalancingStrategy.NONE)
-  .acquireHostList(true)
-  .build();
-```
-
 ## Connection time to live
 
 The driver supports setting a TTL (time to life) for connections:

--- a/site/content/3.12/develop/integrations/arangodb-datasource-for-apache-spark.md
+++ b/site/content/3.12/develop/integrations/arangodb-datasource-for-apache-spark.md
@@ -86,7 +86,7 @@ To use TLS secured connections to ArangoDB, set `ssl.enabled` to `true` and eith
 
 ### Supported deployment topologies
 
-The connector can work with a single server, a cluster and active failover deployments of ArangoDB.
+The connector can work with a single server and cluster deployments of ArangoDB.
 
 ## Batch Read
 


### PR DESCRIPTION
### Description

Active failover deployment is not supported in 3.12 and, therefore, must not be mentioned in the documentation.
