### PR TITLE
ArangoGraphML Featurization: Fix feature_type

### DIFF
--- a/site/content/3.10/data-science/arangographml/getting-started.md
+++ b/site/content/3.10/data-science/arangographml/getting-started.md
@@ -308,7 +308,7 @@ The Featurization Specification asks that you input the following:
     and they can all be featurized in different ways. Supplying multiple features
     results in a single concatenated feature.
     - `feature_type`: Provide the feature type. Currently, the supported types
-      include `text`, `category`, and `numerical`.
+      include `text`, `category`, and `numeric` and `label`.
     - `feature_generator` Optional: Adjust advanced feature generation parameters.
       - `feature_name`: The name of this Dict should match the attribute name of the
         document stored in ArangoDB. This overrides the name provided for the parent Dict.
@@ -319,7 +319,7 @@ The Featurization Specification asks that you input the following:
         "collectionName": {
           "features": {
             "attribute_name_1": {
-              "feature_type": 'text' # Suported types: text, category, numerical, label
+              "feature_type": 'text' # Suported types: text, category, numeric, label
               "feature_generator": { # this advanced option is optional.
                 "method": "transformer_embeddings",
                 "feature_name": "movie_title_embeddings",

--- a/site/content/3.11/data-science/arangographml/getting-started.md
+++ b/site/content/3.11/data-science/arangographml/getting-started.md
@@ -308,7 +308,7 @@ The Featurization Specification asks that you input the following:
     and they can all be featurized in different ways. Supplying multiple features
     results in a single concatenated feature.
     - `feature_type`: Provide the feature type. Currently, the supported types
-      include `text`, `category`, and `numerical`.
+      include `text`, `category`, `numeric` and `label`.
     - `feature_generator` Optional: Adjust advanced feature generation parameters.
       - `feature_name`: The name of this Dict should match the attribute name of the
         document stored in ArangoDB. This overrides the name provided for the parent Dict.
@@ -319,7 +319,7 @@ The Featurization Specification asks that you input the following:
         "collectionName": {
           "features": {
             "attribute_name_1": {
-              "feature_type": 'text' # Suported types: text, category, numerical, label
+              "feature_type": 'text' # Suported types: text, category, numeric, label
               "feature_generator": { # this advanced option is optional.
                 "method": "transformer_embeddings",
                 "feature_name": "movie_title_embeddings",

--- a/site/content/3.12/data-science/arangographml/getting-started.md
+++ b/site/content/3.12/data-science/arangographml/getting-started.md
@@ -308,7 +308,7 @@ The Featurization Specification asks that you input the following:
     and they can all be featurized in different ways. Supplying multiple features
     results in a single concatenated feature.
     - `feature_type`: Provide the feature type. Currently, the supported types
-      include `text`, `category`, and `numerical`.
+      include `text`, `category`, `numeric` and `label`.
     - `feature_generator` Optional: Adjust advanced feature generation parameters.
       - `feature_name`: The name of this Dict should match the attribute name of the
         document stored in ArangoDB. This overrides the name provided for the parent Dict.
@@ -319,7 +319,7 @@ The Featurization Specification asks that you input the following:
         "collectionName": {
           "features": {
             "attribute_name_1": {
-              "feature_type": 'text' # Suported types: text, category, numerical, label
+              "feature_type": 'text' # Suported types: text, category, numeric, label
               "feature_generator": { # this advanced option is optional.
                 "method": "transformer_embeddings",
                 "feature_name": "movie_title_embeddings",


### PR DESCRIPTION
### Description

> feature_type: Provide the feature type. Currently, the supported types include text, category, and numerical.

^ feature_type `label` is missing
^ feature_type `numerical` is invalid, the correct value is `numeric`

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 
