### PR TITLE
Bump inkeep widgets version

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/inkeep-widget.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/inkeep-widget.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
   const SCRIPT_SRC =
-    "https://unpkg.com/@inkeep/widgets-embed@0.2.258/dist/embed.js";
+    "https://unpkg.com/@inkeep/widgets-embed@0.2.278/dist/embed.js";
 
   function loadAndInitializeInkeep() {
     if (document.querySelector(`script[src="${SCRIPT_SRC}]"`)) {


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->
Bump the inkeep chat widget to the latest version (`0.2.278`).

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
