### PR TITLE
DOC-667 | Cluster metrics about read-only shards and collection shard locks

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -410,6 +410,19 @@ detached state:
 - `arangodb_network_connectivity_failures_dbservers_total`
 - `arangodb_scheduler_num_detached_threads`
 
+---
+
+<small>Introduced in: v3.12.1</small>
+
+The following metrics about cluster health and collection shard locks have been
+added:
+
+- `arangodb_vocbase_shards_read_only_by_write_concern`
+- `arangodb_collection_shard_lock_locked_exclusive`
+- `arangodb_collection_shard_lock_locked_shared`
+- `arangodb_collection_shard_lock_pending_exclusive`
+- `arangodb_collection_shard_lock_pending_shared`
+
 ### Endpoints deprecated
 
 #### JavaScript Transactions API

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1063,15 +1063,20 @@ small requests.
 Compression for all Agency traffic is disabled regardless of the settings
 of these options.
 
-### Read-only shards metric
+### Shards metric
 
 <small>Introduced in: v3.12.1</small>
 
-The following cluster health metric has been added:
+The following metrics about cluster health and collection shard locks have been
+added:
 
 | Label | Description |
 |:------|:------------|
 | `arangodb_vocbase_shards_read_only_by_write_concern` | Number of shards that are read-only due to an undercut of the write concern. |
+| `arangodb_collection_shard_lock_locked_exclusive` | Number of exclusively locked collection shards. |
+| `arangodb_collection_shard_lock_locked_shared` | Number of shared locked collection shards. |
+| `arangodb_collection_shard_lock_pending_exclusive` | Number of pending exclusive collection shard lock requests. |
+| `arangodb_collection_shard_lock_pending_shared` | Number of pending shared collection shard lock requests. |
 
 ## Client tools
 

--- a/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
@@ -410,6 +410,19 @@ detached state:
 - `arangodb_network_connectivity_failures_dbservers_total`
 - `arangodb_scheduler_num_detached_threads`
 
+---
+
+<small>Introduced in: v3.12.1</small>
+
+The following metrics about cluster health and collection shard locks have been
+added:
+
+- `arangodb_vocbase_shards_read_only_by_write_concern`
+- `arangodb_collection_shard_lock_locked_exclusive`
+- `arangodb_collection_shard_lock_locked_shared`
+- `arangodb_collection_shard_lock_pending_exclusive`
+- `arangodb_collection_shard_lock_pending_shared`
+
 ### Endpoints deprecated
 
 #### JavaScript Transactions API

--- a/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1063,15 +1063,20 @@ small requests.
 Compression for all Agency traffic is disabled regardless of the settings
 of these options.
 
-### Read-only shards metric
+### Shards metric
 
 <small>Introduced in: v3.12.1</small>
 
-The following cluster health metric has been added:
+The following metrics about cluster health and collection shard locks have been
+added:
 
 | Label | Description |
 |:------|:------------|
 | `arangodb_vocbase_shards_read_only_by_write_concern` | Number of shards that are read-only due to an undercut of the write concern. |
+| `arangodb_collection_shard_lock_locked_exclusive` | Number of exclusively locked collection shards. |
+| `arangodb_collection_shard_lock_locked_shared` | Number of shared locked collection shards. |
+| `arangodb_collection_shard_lock_pending_exclusive` | Number of pending exclusive collection shard lock requests. |
+| `arangodb_collection_shard_lock_pending_shared` | Number of pending shared collection shard lock requests. |
 
 ## Client tools
 


### PR DESCRIPTION
### Description

Waiting for https://github.com/arangodb/arangodb/pull/20726

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
