### PR TITLE
[DE-535] Java Driver: configure Vert.x instance

### DIFF
--- a/site/content/3.10/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.10/develop/drivers/java/reference-version-7/driver-setup.md
@@ -89,7 +89,33 @@ Here are examples to integrate configuration properties from different sources:
 - `acquireHostListInterval(Integer)`:             acquireHostList interval (ms), (default: `3_600_000`, 1 hour)
 - `loadBalancingStrategy(LoadBalancingStrategy)`: load balancing strategy, possible values are: `NONE`, `ROUND_ROBIN`, `ONE_RANDOM`, (default: `NONE`)
 - `responseQueueTimeSamples(Integer)`:            amount of samples kept for queue time metrics, (default: `10`)
-- `serde(ArangoSerde)`:                           serde to serialize and deserialize user-data
+- `serde(ArangoSerde)`:            serde to serialize and deserialize user-data
+- `protocolConfig(ProtocolConfig)`: configuration specific for the used protocol provider implementation
+
+### HTTP Protocol Provider Configuration
+
+The `ProtocolConfig` for the default HTTP protocol provider can be created via:
+
+```java
+HttpProtocolConfig.builder()
+  // ...
+  .build();
+```
+
+and configured using the following builder methods:
+
+- `vertx(Vertx)`: Vert.x instance to use. If not set, a new instance is created.
+
+For example, to reuse the existing Vert.x instance:
+
+```java
+HttpProtocolConfig.builder()
+  .protocolConfig(HttpProtocolConfig.builder()
+    .vertx(Vertx.currentContext().owner())
+    .build()
+  )
+  .build();
+```
 
 ### Config File Properties
 

--- a/site/content/3.11/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.11/develop/drivers/java/reference-version-7/driver-setup.md
@@ -89,7 +89,33 @@ Here are examples to integrate configuration properties from different sources:
 - `acquireHostListInterval(Integer)`:             acquireHostList interval (ms), (default: `3_600_000`, 1 hour)
 - `loadBalancingStrategy(LoadBalancingStrategy)`: load balancing strategy, possible values are: `NONE`, `ROUND_ROBIN`, `ONE_RANDOM`, (default: `NONE`)
 - `responseQueueTimeSamples(Integer)`:            amount of samples kept for queue time metrics, (default: `10`)
-- `serde(ArangoSerde)`:                           serde to serialize and deserialize user-data
+- `serde(ArangoSerde)`:            serde to serialize and deserialize user-data
+- `protocolConfig(ProtocolConfig)`: configuration specific for the used protocol provider implementation
+
+### HTTP Protocol Provider Configuration
+
+The `ProtocolConfig` for the default HTTP protocol provider can be created via:
+
+```java
+HttpProtocolConfig.builder()
+  // ...
+  .build();
+```
+
+and configured using the following builder methods:
+
+- `vertx(Vertx)`: Vert.x instance to use. If not set, a new instance is created.
+
+For example, to reuse the existing Vert.x instance:
+
+```java
+HttpProtocolConfig.builder()
+  .protocolConfig(HttpProtocolConfig.builder()
+    .vertx(Vertx.currentContext().owner())
+    .build()
+  )
+  .build();
+```
 
 ### Config File Properties
 

--- a/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
@@ -93,6 +93,7 @@ Here are examples to integrate configuration properties from different sources:
 - `compressionThreshold(Integer)`: the minimum HTTP request body size (in bytes) to trigger compression, (default: `1024`)
 - `compressionLevel`:              compression level between 0 and 9, (default: `6`)
 - `serde(ArangoSerde)`:            serde to serialize and deserialize user-data
+- `reuseVertx(Boolean)`:           reuse Vert.x instance to create HTTP connections, (default: `false`)
 
 ### Config File Properties
 
@@ -120,6 +121,7 @@ The properties read are:
 - `compression`: `NONE`, `DEFLATE` or `GZIP`
 - `compressionThreshold`
 - `compressionLevel`
+- `reuseVertx`
 
 ## SSL
 

--- a/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
@@ -93,7 +93,31 @@ Here are examples to integrate configuration properties from different sources:
 - `compressionThreshold(Integer)`: the minimum HTTP request body size (in bytes) to trigger compression, (default: `1024`)
 - `compressionLevel`:              compression level between 0 and 9, (default: `6`)
 - `serde(ArangoSerde)`:            serde to serialize and deserialize user-data
-- `reuseVertx(Boolean)`:           reuse Vert.x instance to create HTTP connections, (default: `false`)
+- `protocolConfig(ProtocolConfig)`: configuration specific for the used protocol provider implementation
+
+### HTTP Protocol Provider Configuration
+
+The `ProtocolConfig` for the default HTTP protocol provider can be created via:
+
+```java
+HttpProtocolConfig.builder()
+  // ...
+  .build();
+```
+
+and configured using the following builder methods:
+- `vertx(Vertx)`:                 Vert.x instance to use, if not set a new instance will be created
+
+For example, to reuse the existing Vert.x instance:
+
+```java
+HttpProtocolConfig.builder()
+  .protocolConfig(HttpProtocolConfig.builder()
+    .vertx(Vertx.currentContext().owner())
+    .build()
+  )
+  .build();
+```
 
 ### Config File Properties
 
@@ -121,7 +145,6 @@ The properties read are:
 - `compression`: `NONE`, `DEFLATE` or `GZIP`
 - `compressionThreshold`
 - `compressionLevel`
-- `reuseVertx`
 
 ## SSL
 

--- a/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
@@ -106,7 +106,8 @@ HttpProtocolConfig.builder()
 ```
 
 and configured using the following builder methods:
-- `vertx(Vertx)`:                 Vert.x instance to use, if not set a new instance will be created
+
+- `vertx(Vertx)`: Vert.x instance to use. If not set, a new instance is created.
 
 For example, to reuse the existing Vert.x instance:
 

--- a/site/content/3.13/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.13/develop/drivers/java/reference-version-7/driver-setup.md
@@ -93,6 +93,32 @@ Here are examples to integrate configuration properties from different sources:
 - `compressionThreshold(Integer)`: the minimum HTTP request body size (in bytes) to trigger compression, (default: `1024`)
 - `compressionLevel`:              compression level between 0 and 9, (default: `6`)
 - `serde(ArangoSerde)`:            serde to serialize and deserialize user-data
+- `protocolConfig(ProtocolConfig)`: configuration specific for the used protocol provider implementation
+
+### HTTP Protocol Provider Configuration
+
+The `ProtocolConfig` for the default HTTP protocol provider can be created via:
+
+```java
+HttpProtocolConfig.builder()
+  // ...
+  .build();
+```
+
+and configured using the following builder methods:
+
+- `vertx(Vertx)`: Vert.x instance to use. If not set, a new instance is created.
+
+For example, to reuse the existing Vert.x instance:
+
+```java
+HttpProtocolConfig.builder()
+  .protocolConfig(HttpProtocolConfig.builder()
+    .vertx(Vertx.currentContext().owner())
+    .build()
+  )
+  .build();
+```
 
 ### Config File Properties
 


### PR DESCRIPTION
### Description

documented HTTP protocol configuration to reuse Vert.x instance

- https://github.com/arangodb/arangodb-java-driver/pull/558