### PR TITLE
Redirect from /latest to /stable

### DIFF
--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -1,3 +1,5 @@
+/latest                                /stable
+
 /3.12/operations/installation/compiling/                           https://github.com/arangodb/arangodb/blob/devel/CONTRIBUTING.md
 /3.12/operations/installation/compiling/compile-on-debian/         https://github.com/arangodb/arangodb/blob/devel/CONTRIBUTING.md
 /3.12/operations/installation/compiling/running-custom-build/      https://github.com/arangodb/arangodb/blob/devel/CONTRIBUTING.md


### PR DESCRIPTION
### Description

The master service agreements still use the obsolete link that is broken since at least 2020.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
