### PR TITLE
BTS-1915: recalculateCount response doesn't include "count" in cluster

### DIFF
--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -4474,7 +4474,6 @@ paths:
                   - error
                   - code
                   - result
-                  - count
                 properties:
                   error:
                     description: |
@@ -4492,6 +4491,7 @@ paths:
                   count:
                     description: |
                       The recalculated document count.
+                      This attribute is not present when using a cluster.
                     type: integer
         '400':
           description: |

--- a/site/content/3.13/develop/http-api/collections.md
+++ b/site/content/3.13/develop/http-api/collections.md
@@ -4474,7 +4474,6 @@ paths:
                   - error
                   - code
                   - result
-                  - count
                 properties:
                   error:
                     description: |
@@ -4492,6 +4491,7 @@ paths:
                   count:
                     description: |
                       The recalculated document count.
+                      This attribute is not present when using a cluster.
                     type: integer
         '400':
           description: |


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
