### PR TITLE
Add cross-reference about inverted index restrictions when combining them in a search-alias View

### DIFF
--- a/site/content/3.10/index-and-search/arangosearch/search-alias-views-reference.md
+++ b/site/content/3.10/index-and-search/arangosearch/search-alias-views-reference.md
@@ -22,6 +22,9 @@ Some of the inverted index settings only apply if they are used in a
 `search-alias` View, whereas others equally apply whether you use an inverted
 index standalone or as part of a View.
 
+Certain settings of inverted indexes need to match if you want to add them to the
+same `search-alias` View, see the [restrictions](../indexing/working-with-indexes/inverted-indexes.md#restrictions).
+
 Inverted indexes can be managed as follows:
 - via the [Indexes HTTP API](../../develop/http-api/indexes/inverted.md)
 - through the [JavaScript API](../indexing/working-with-indexes/_index.md#creating-an-index)

--- a/site/content/3.11/index-and-search/arangosearch/search-alias-views-reference.md
+++ b/site/content/3.11/index-and-search/arangosearch/search-alias-views-reference.md
@@ -22,6 +22,9 @@ Some of the inverted index settings only apply if they are used in a
 `search-alias` View, whereas others equally apply whether you use an inverted
 index standalone or as part of a View.
 
+Certain settings of inverted indexes need to match if you want to add them to the
+same `search-alias` View, see the [restrictions](../indexing/working-with-indexes/inverted-indexes.md#restrictions).
+
 Inverted indexes can be managed as follows:
 - in the web interface, in the **COLLECTIONS** section, in the **Indexes** tab
   of a collection

--- a/site/content/3.12/index-and-search/arangosearch/search-alias-views-reference.md
+++ b/site/content/3.12/index-and-search/arangosearch/search-alias-views-reference.md
@@ -22,6 +22,9 @@ Some of the inverted index settings only apply if they are used in a
 `search-alias` View, whereas others equally apply whether you use an inverted
 index standalone or as part of a View.
 
+Certain settings of inverted indexes need to match if you want to add them to the
+same `search-alias` View, see the [restrictions](../indexing/working-with-indexes/inverted-indexes.md#restrictions).
+
 Inverted indexes can be managed as follows:
 - in the web interface, in the **COLLECTIONS** section, in the **Indexes** tab
   of a collection

--- a/site/content/3.13/index-and-search/arangosearch/search-alias-views-reference.md
+++ b/site/content/3.13/index-and-search/arangosearch/search-alias-views-reference.md
@@ -22,6 +22,9 @@ Some of the inverted index settings only apply if they are used in a
 `search-alias` View, whereas others equally apply whether you use an inverted
 index standalone or as part of a View.
 
+Certain settings of inverted indexes need to match if you want to add them to the
+same `search-alias` View, see the [restrictions](../indexing/working-with-indexes/inverted-indexes.md#restrictions).
+
 Inverted indexes can be managed as follows:
 - in the web interface, in the **COLLECTIONS** section, in the **Indexes** tab
   of a collection


### PR DESCRIPTION
### Description

Make it easier to discover the limitations for `search-alias`  Views which were only covered in the inverted index page

https://github.com/arangodb/arangodb/issues/21104#issuecomment-2196862390

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
