### PR TITLE
DOC-698 | HTTP API: Add database name parameter where meaningful

### DIFF
--- a/site/content/3.11/develop/http-api/administration.md
+++ b/site/content/3.11/develop/http-api/administration.md
@@ -5,6 +5,7 @@ weight: 110
 description: >-
   You can get information about ArangoDB servers, toggle the maintenance mode,
   shut down server nodes, and start actions like compaction
+# Internal /_admin/debug and /_api/test endpoints for maintainers not documented on purpose
 ---
 ## Information
 
@@ -12,21 +13,34 @@ description: >-
 
 ```openapi
 paths:
-  /_api/version:
+  /_db/{database-name}/_api/version:
+  # /_admin/version is an (undocumented) alias
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getVersion
       description: |
         Returns the server name and version number. The response is a JSON object
         with the following attributes:
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: details
           in: query
           required: false
           description: |
-            If set to `true`, the response will contain a `details` attribute with
-            additional information about included components and their versions. The
-            attribute names and internals of the `details` object may vary depending on
-            platform and ArangoDB version.
+            If set to `true` and if the user account you authenticate with has
+            administrate access to the `_system` database, the response contains
+            a `details` attribute with additional information about included
+            components and their versions. The attribute names and internals of
+            the `details` object may vary depending on platform and ArangoDB version.
           schema:
             type: boolean
       responses:
@@ -222,12 +236,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/engine:
+  /_db/{database-name}/_api/engine:
     get:
       operationId: getEngine
       description: |
         Returns the storage engine the server is configured to use.
         The response is a JSON object with the following attributes:
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -266,12 +291,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/time:
+  /_db/{database-name}/_admin/time:
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getTime
       description: |
         The call returns an object with the `time` attribute. This contains the
         current system time as a Unix timestamp with microsecond precision.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -305,11 +342,24 @@ paths:
 
 ```openapi
 paths:
-  /_admin/status:
+  /_db/{database-name}/_admin/status:
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getStatus
       description: |
         Returns status information about the server.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -541,6 +591,7 @@ logJsonResponse(response);
 ```openapi
 paths:
   /_admin/server/availability:
+  # Independent of database
     get:
       operationId: getServerAvailability
       description: |
@@ -596,14 +647,15 @@ paths:
 
 ```openapi
 paths:
-  /_admin/support-info:
+  /_db/_system/_admin/support-info:
     get:
+      # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getSupportInfo
       description: |
         Retrieves deployment information for support purposes. The endpoint returns data
         about the ArangoDB version used, the host (operating system, server ID, CPU and
         storage capacity, current utilization, a few metrics) and the other servers in
-        the deployment (in case of Active Failover or cluster deployments).
+        the deployment (in case of cluster deployments).
 
         As this API may reveal sensitive data about the deployment, it can only be
         accessed from inside the `_system` database. In addition, there is a policy
@@ -684,7 +736,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/server/mode:
+  /_db/{database-name}/_admin/server/mode:
     get:
       operationId: getServerMode
       description: |
@@ -694,6 +746,17 @@ paths:
         Creating or dropping of databases and collections will also fail with error code `11` (_ERROR_FORBIDDEN_).
 
         This API requires authentication.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -706,7 +769,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/server/mode:
+  /_db/{database-name}/_admin/server/mode:
     put:
       operationId: setServerMode
       description: |
@@ -718,6 +781,17 @@ paths:
 
         This is a protected API. It requires authentication and administrative
         server rights.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -750,12 +824,24 @@ status and update the license of your ArangoDB Enterprise Edition deployment.
 
 ```openapi
 paths:
-  /_admin/license:
+  /_db/{database-name}/_admin/license:
     get:
       operationId: getLicense
       description: |
         View the license information and status of an Enterprise Edition instance.
         Can be called on single servers, Coordinators, and DB-Servers.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -840,13 +926,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/license:
+  /_db/{database-name}/_admin/license:
     put:
       operationId: setLicense
       description: |
         Set a new license for an Enterprise Edition instance.
         Can be called on single servers, Coordinators, and DB-Servers.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: force
           in: query
           required: false
@@ -997,12 +1094,22 @@ x-content-type-options: nosniff
 
 ```openapi
 paths:
-  /_admin/shutdown:
+  /_db/{database-name}/_admin/shutdown:
     delete:
       operationId: startShutdown
       description: |
         This call initiates a clean shutdown sequence. Requires administrative privileges.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: soft
           in: query
           required: false
@@ -1046,7 +1153,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/shutdown:
+  /_db/{database-name}/_admin/shutdown:
     get:
       operationId: getShutdownProgress
       description: |
@@ -1066,6 +1173,17 @@ paths:
          - Ongoing low priority requests
 
         This API is only available on Coordinators.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1134,6 +1252,7 @@ paths:
 ```openapi
 paths:
   /_admin/compact:
+  # Independent of database (superuser has access to all databases that exist)
     put:
       operationId: compactAllDatabases
       description: |
@@ -1192,12 +1311,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/routing/reload:
+  /_db/{database-name}/_admin/routing/reload:
     post:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: reloadRouting
       description: |
         Reloads the routing information from the `_routing` system collection if it
         exists, and makes Foxx rebuild its local routing table on the next request.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1210,7 +1341,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/echo:
+  /_db/{database-name}/_admin/echo:
     post:
       operationId: echoRequest
       description: |
@@ -1227,6 +1358,17 @@ paths:
                   description: |
                     The request body can be of any type and is simply forwarded.
                   type: string
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1385,8 +1527,9 @@ paths:
 
 ```openapi
 paths:
-  /_admin/execute:
+  /_db/{database-name}/_admin/execute:
     post:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: executeCode
       description: |
         Executes the JavaScript code in the body on the server as the body
@@ -1403,6 +1546,15 @@ paths:
         The default value of this option is `false`, which disables the execution of
         user-defined code and disables this API endpoint entirely.
         This is also the recommended setting for production.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1453,7 +1605,7 @@ the default `_system` database and none of the other databases.
 
 ```openapi
 paths:
-  /_api/endpoint:
+  /_db/_system/_api/endpoint:
     get:
       operationId: listEndpoints
       description: |

--- a/site/content/3.11/develop/http-api/analyzers.md
+++ b/site/content/3.11/develop/http-api/analyzers.md
@@ -16,11 +16,20 @@ introduction and the available types, properties and features.
 
 ```openapi
 paths:
-  /_api/analyzer:
+  /_db/{database-name}/_api/analyzer:
     post:
       operationId: createAnalyzer
       description: |
         Creates a new Analyzer based on the provided configuration.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -96,7 +105,7 @@ analyzers.remove(analyzerName, true);
 
 ```openapi
 paths:
-  /_api/analyzer/{analyzer-name}:
+  /_db/{database-name}/_api/analyzer/{analyzer-name}:
     get:
       operationId: getAnalyzer
       description: |
@@ -107,6 +116,14 @@ paths:
         - `properties`: the properties used to configure the specified type
         - `features`: the set of features to set on the Analyzer generated fields
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: analyzer-name
           in: path
           required: true
@@ -152,7 +169,7 @@ analyzers.remove(analyzerName, true);
 
 ```openapi
 paths:
-  /_api/analyzer:
+  /_db/{database-name}/_api/analyzer:
     get:
       operationId: listAnalyzers
       description: |
@@ -162,6 +179,15 @@ paths:
         - `type`: the Analyzer type
         - `properties`: the properties used to configure the specified type
         - `features`: the set of features to set on the Analyzer generated fields
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -190,7 +216,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/analyzer/{analyzer-name}:
+  /_db/{database-name}/_api/analyzer/{analyzer-name}:
     delete:
       operationId: deleteAnalyzer
       description: |
@@ -201,6 +227,14 @@ paths:
         - `error`: `false`
         - `name`: The name of the removed Analyzer
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: analyzer-name
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/authentication.md
+++ b/site/content/3.11/develop/http-api/authentication.md
@@ -174,6 +174,7 @@ Please note that all JWT tokens must contain the `iss` field with string value
 ```openapi
 paths:
   /_open/auth:
+  # Independent of database
     post:
       operationId: createSessionToken
       description: |
@@ -281,7 +282,7 @@ may use the following RESTful API. A `POST` request reloads the secret, a
 
 ```openapi
 paths:
-  /_admin/server/jwt:
+  /_db/{database-name}/_admin/server/jwt:
     get:
       operationId: getServerJwtSecrets
       description: |
@@ -289,6 +290,18 @@ paths:
 
         To utilize the API a superuser JWT token is necessary, otherwise the response
         will be _HTTP 403 Forbidden_.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: ''
@@ -343,6 +356,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/jwt:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: reloadServerJwtSecrets
       description: |

--- a/site/content/3.11/develop/http-api/batch-requests.md
+++ b/site/content/3.11/develop/http-api/batch-requests.md
@@ -227,7 +227,7 @@ in a batch part will be ignored.
 
 ```openapi
 paths:
-  /_api/batch:
+  /_db/{database-name}/_api/batch:
     post:
       operationId: executeBatchRequest
       description: |
@@ -267,6 +267,15 @@ paths:
         original client request. Client can additionally use the `Content-Id`
         MIME header in a batch part to define an individual id for each batch part.
         The server will return this id is the batch part responses, too.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.11/develop/http-api/cluster.md
+++ b/site/content/3.11/develop/http-api/cluster.md
@@ -9,6 +9,9 @@ description: >-
 ---
 ## Monitoring
 
+The permissions required to use the `/_admin/cluster/*` endpoints depends on the
+setting of the [`--cluster.api-jwt-policy` startup option](../../components/arangodb-server/options.md#--clusterapi-jwt-policy).
+
 ### Get the statistics of a DB-Server
 
 ```openapi

--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -29,7 +29,7 @@ http://localhost:8529/_api/collection/demo
 
 ```openapi
 paths:
-  /_api/collection:
+  /_db/{database-name}/_api/collection:
     get:
       operationId: listCollections
       description: |
@@ -39,6 +39,14 @@ paths:
         By providing the optional `excludeSystem` query parameter with a value of
         `true`, all system collections are excluded from the response.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: excludeSystem
           in: query
           required: false
@@ -75,7 +83,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}:
+  /_db/{database-name}/_api/collection/{collection-name}:
     get:
       operationId: getCollection
       description: |
@@ -103,6 +111,14 @@ paths:
 
         - `isSystem`: If `true` then the collection is a system collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -123,7 +139,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/properties:
+  /_db/{database-name}/_api/collection/{collection-name}/properties:
     get:
       operationId: getCollectionProperties
       description: |
@@ -134,6 +150,14 @@ paths:
 
         Returns all properties of the specified collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -414,7 +438,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/count:
+  /_db/{database-name}/_api/collection/{collection-name}/count:
     get:
       operationId: getCollectionCount
       description: |
@@ -427,6 +451,14 @@ paths:
 
         - `count`: The number of documents stored in the specified collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -483,7 +515,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/figures:
+  /_db/{database-name}/_api/collection/{collection-name}/figures:
     get:
       operationId: getCollectionFigures
       description: |
@@ -495,6 +527,14 @@ paths:
         In addition to the above, the result also contains the number of documents
         and additional statistical information about the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -614,7 +654,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/responsibleShard:
+  /_db/{database-name}/_api/collection/{collection-name}/responsibleShard:
     put:
       operationId: getResponsibleShard
       description: |
@@ -631,6 +671,22 @@ paths:
         {{</* info */>}}
         This method is only available in cluster deployments on Coordinators.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: collection-name
+          in: path
+          required: true
+          description: |
+            The name of the collection.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -644,14 +700,6 @@ paths:
                     The request body must be a JSON object with at least the shard key
                     attributes set to some values, but it may also be a full document.
                   type: object
-      parameters:
-        - name: collection-name
-          in: path
-          required: true
-          description: |
-            The name of the collection.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -700,7 +748,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/shards:
+  /_db/{database-name}/_api/collection/{collection-name}/shards:
     get:
       operationId: getCollectionShards
       description: |
@@ -714,6 +762,14 @@ paths:
         This method is only available in cluster deployments on Coordinators.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -789,7 +845,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/revision:
+  /_db/{database-name}/_api/collection/{collection-name}/revision:
     get:
       operationId: getCollectionRevision
       description: |
@@ -804,6 +860,14 @@ paths:
 
         - `revision`: The collection revision id as a string.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -849,7 +913,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/checksum:
+  /_db/{database-name}/_api/collection/{collection-name}/checksum:
     get:
       operationId: getCollectionChecksum
       description: |
@@ -886,6 +950,14 @@ paths:
 
         - `revision`: The collection revision id as a string.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -969,7 +1041,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection:
+  /_db/{database-name}/_api/collection:
     post:
       operationId: createCollection
       description: |
@@ -980,6 +1052,35 @@ paths:
 
         Creates a new collection with a given name. The request must contain an
         object with the following attributes.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: waitForSyncReplication
+          in: query
+          required: false
+          description: |
+            The default is `true`, which means the server only reports success back to the
+            client when all replicas have created the collection. Set it to `false` if you want
+            faster server responses and don't care about full replication.
+          schema:
+            type: boolean
+            default: true
+        - name: enforceReplicationFactor
+          in: query
+          required: false
+          description: |
+            The default is `true`, which means the server checks if there are enough replicas
+            available at creation time and bail out otherwise. Set it to `false` to disable
+            this extra check.
+          schema:
+            type: boolean
+            default: true
       requestBody:
         content:
           application/json:
@@ -1282,25 +1383,6 @@ paths:
                     A further restriction is that whenever documents are stored or updated in the
                     collection, the value stored in the `smartJoinAttribute` must be a string.
                   type: string
-      parameters:
-        - name: waitForSyncReplication
-          in: query
-          required: false
-          description: |
-            The default is `true`, which means the server only reports success back to the
-            client when all replicas have created the collection. Set it to `false` if you want
-            faster server responses and don't care about full replication.
-          schema:
-            type: boolean
-        - name: enforceReplicationFactor
-          in: query
-          required: false
-          description: |
-            The default is `true`, which means the server checks if there are enough replicas
-            available at creation time and bail out otherwise. Set it to `false` to disable
-            this extra check.
-          schema:
-            type: boolean
       responses:
         '400':
           description: |
@@ -1589,7 +1671,7 @@ db._drop("testCollectionUsers");
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}:
+  /_db/{database-name}/_api/collection/{collection-name}:
     delete:
       operationId: deleteCollection
       description: |
@@ -1607,6 +1689,14 @@ paths:
 
         - `id`: The identifier of the dropped collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1696,7 +1786,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/truncate:
+  /_db/{database-name}/_api/collection/{collection-name}/truncate:
     put:
       operationId: truncateCollection
       description: |
@@ -1707,6 +1797,14 @@ paths:
 
         Removes all documents from the collection, but leaves the indexes intact.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1778,7 +1876,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/load:
+  /_db/{database-name}/_api/collection/{collection-name}/load:
     put:
       operationId: loadCollection
       description: |
@@ -1822,6 +1920,14 @@ paths:
 
         - `isSystem`: If `true` then the collection is a system collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1866,7 +1972,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/unload:
+  /_db/{database-name}/_api/collection/{collection-name}/unload:
     put:
       operationId: unloadCollection
       description: |
@@ -1898,6 +2004,14 @@ paths:
 
         - `isSystem`: If `true` then the collection is a system collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1941,7 +2055,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/loadIndexesIntoMemory:
+  /_db/{database-name}/_api/collection/{collection-name}/loadIndexesIntoMemory:
     put:
       operationId: loadCollectionIndexes
       description: |
@@ -1974,6 +2088,14 @@ paths:
 
         On success, this endpoint returns an object with attribute `result` set to `true`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2020,7 +2142,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/properties:
+  /_db/{database-name}/_api/collection/{collection-name}/properties:
     put:
       operationId: updateCollectionProperties
       description: |
@@ -2034,6 +2156,14 @@ paths:
         created except for the listed properties, as well as the collection name via
         the rename endpoint (but not in clusters).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2183,7 +2313,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/rename:
+  /_db/{database-name}/_api/collection/{collection-name}/rename:
     put:
       operationId: renameCollection
       description: |
@@ -2217,6 +2347,14 @@ paths:
         Renaming collections is not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2264,7 +2402,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/recalculateCount:
+  /_db/{database-name}/_api/collection/{collection-name}/recalculateCount:
     put:
       operationId: recalculateCollectionCount
       description: |
@@ -2274,6 +2412,14 @@ paths:
 
         - `result`: will be `true` if recalculating the document count succeeded.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2296,7 +2442,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/compact:
+  /_db/{database-name}/_api/collection/{collection-name}/compact:
     put:
       operationId: compactCollection
       description: |
@@ -2310,6 +2456,14 @@ paths:
         the disk data for a collection may contain a lot of outdated data for which the
         space shall be reclaimed. In this case the compaction operation can be used.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/databases.md
+++ b/site/content/3.11/develop/http-api/databases.md
@@ -62,7 +62,7 @@ Non-NFC-normalized names are rejected by the server.
 
 ```openapi
 paths:
-  /_api/database/current:
+  /_db/{database-name}/_api/database/current:
     get:
       operationId: getCurrentDatabase
       description: |
@@ -77,6 +77,15 @@ paths:
         - `sharding`: the default sharding method for collections created in this database
         - `replicationFactor`: the default replication factor for collections in this database
         - `writeConcern`: the default write concern for collections in this database
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -110,12 +119,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database/user:
+  /_db/{database-name}/_api/database/user:
     get:
       operationId: listUserAccessibleDatabases
       description: |
         Retrieves the list of all databases the current user can access without
         specifying a different username or password.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -146,7 +166,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database:
+  /_db/_system/_api/database:
     get:
       operationId: listDatabases
       description: |
@@ -188,7 +208,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database:
+  /_db/_system/_api/database:
     post:
       operationId: createDatabase
       description: |
@@ -376,7 +396,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database/{database-name}:
+  /_db/_system/_api/database/{database-name}:
     delete:
       operationId: deleteDatabase
       description: |

--- a/site/content/3.11/develop/http-api/documents.md
+++ b/site/content/3.11/develop/http-api/documents.md
@@ -75,7 +75,7 @@ endpoints to request and delete multiple documents in one request.
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     get:
       operationId: getDocument
       description: |
@@ -85,6 +85,14 @@ paths:
         - `_key`, containing the document key that uniquely identifies a document within the collection.
         - `_rev`, containing the document revision.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -220,7 +228,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     head:
       operationId: getDocumentHeader
       description: |
@@ -228,6 +236,14 @@ paths:
         can use this call to get the current revision of a document or check if
         the document was deleted.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -325,7 +341,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     post:
       operationId: createDocument
       description: |
@@ -368,6 +384,14 @@ paths:
         generated document, the complete new document is returned under
         the `new` attribute in the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -726,7 +750,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     put:
       operationId: replaceDocument
       description: |
@@ -798,6 +822,14 @@ paths:
                     A JSON representation of a single document.
                   type: object
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1018,7 +1050,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     patch:
       operationId: updateDocument
       description: |
@@ -1097,6 +1129,14 @@ paths:
                     A JSON representation of a document update as an object.
                   type: object
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1341,7 +1381,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     delete:
       operationId: deleteDocument
       description: |
@@ -1361,6 +1401,14 @@ paths:
         the complete previous revision of the document
         is returned under the `old` attribute in the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1595,7 +1643,7 @@ contains a JSON array of the same length.
 
 ```openapi
 paths:
-  /_api/document/{collection}#get:
+  /_db/{database-name}/_api/document/{collection}#get:
     put:
       operationId: getDocuments
       description: |
@@ -1624,6 +1672,14 @@ paths:
         - `_key`, containing the document key that uniquely identifies a document within the collection.
         - `_rev`, containing the document revision.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1634,6 +1690,7 @@ paths:
         - name: onlyget
           in: query
           required: true
+          example: true
           description: |
             This parameter is required to be `true`, otherwise a replace
             operation is executed!
@@ -1726,7 +1783,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}#multiple:
+  /_db/{database-name}/_api/document/{collection}#multiple:
     post:
       operationId: createDocuments
       description: |
@@ -1776,6 +1833,14 @@ paths:
         `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
         has happened, and in 10 cases the error 1205 ("illegal document handle").
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2031,7 +2096,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     put:
       operationId: replaceDocuments
       description: |
@@ -2103,6 +2168,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2224,7 +2297,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     patch:
       operationId: updateDocuments
       description: |
@@ -2303,6 +2376,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2446,7 +2527,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     delete:
       operationId: deleteDocuments
       description: |
@@ -2499,6 +2580,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/foxx.md
+++ b/site/content/3.11/develop/http-api/foxx.md
@@ -15,7 +15,7 @@ For more information on Foxx and its JavaScript APIs see the
 
 ```openapi
 paths:
-  /_api/foxx:
+  /_db/{database-name}/_api/foxx:
     get:
       operationId: listFoxxServices
       description: |
@@ -33,6 +33,14 @@ paths:
         - `name`: a string identifying the service type
         - `version`: a semver-compatible version string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: excludeSystem
           in: query
           required: false
@@ -52,7 +60,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     get:
       operationId: getFoxxServiceDescription
       description: |
@@ -71,6 +79,14 @@ paths:
         - `name`: a string identifying the service type
         - `version`: a semver-compatible version string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -93,7 +109,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx:
+  /_db/{database-name}/_api/foxx:
     post:
       operationId: createFoxxService
       description: |
@@ -127,6 +143,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -167,7 +191,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     delete:
       operationId: deleteFoxxService
       description: |
@@ -201,7 +225,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     put:
       operationId: replaceFoxxService
       description: |
@@ -240,6 +264,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -287,7 +319,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     patch:
       operationId: upgradeFoxxService
       description: |
@@ -326,6 +358,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -375,7 +415,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     get:
       operationId: getFoxxConfiguration
       description: |
@@ -384,6 +424,14 @@ paths:
         Returns an object mapping the configuration option names to their definitions
         including a human-friendly `title` and the `current` value (if any).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -403,13 +451,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     patch:
       operationId: updateFoxxConfiguration
       description: |
         Replaces the given service's configuration.
 
         Returns an object mapping all configuration option names to their new values.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -423,14 +487,6 @@ paths:
                     A JSON object mapping configuration option names to their new values.
                     Any omitted options will be ignored.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -443,13 +499,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     put:
       operationId: replaceFoxxConfiguration
       description: |
         Replaces the given service's configuration completely.
 
         Returns an object mapping all configuration option names to their new values.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -463,14 +535,6 @@ paths:
                     A JSON object mapping configuration option names to their new values.
                     Any omitted options will be reset to their default values or marked as unconfigured.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -483,7 +547,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     get:
       operationId: getFoxxDependencies
       description: |
@@ -492,6 +556,14 @@ paths:
         Returns an object mapping the dependency names to their definitions
         including a human-friendly `title` and the `current` mount path (if any).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -511,13 +583,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     patch:
       operationId: updateFoxxDependencies
       description: |
         Replaces the given service's dependencies.
 
         Returns an object mapping all dependency names to their new mount paths.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -531,14 +619,6 @@ paths:
                     A JSON object mapping dependency names to their new mount paths.
                     Any omitted dependencies will be ignored.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -551,13 +631,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     put:
       operationId: replaceFoxxDependencies
       description: |
         Replaces the given service's dependencies completely.
 
         Returns an object mapping all dependency names to their new mount paths.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -571,14 +667,6 @@ paths:
                     A JSON object mapping dependency names to their new mount paths.
                     Any omitted dependencies will be disabled.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -593,7 +681,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/scripts:
+  /_db/{database-name}/_api/foxx/scripts:
     get:
       operationId: listFoxxScripts
       description: |
@@ -601,6 +689,14 @@ paths:
 
         Returns an object mapping the raw script names to human-friendly names.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -620,25 +716,22 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/scripts/{name}:
+  /_db/{database-name}/_api/foxx/scripts/{name}:
     post:
       operationId: runFoxxScript
       description: |
         Runs the given script for the service at the given mount path.
 
         Returns the exports of the script, if any.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                data:
-                  description: |
-                    An arbitrary JSON value that will be parsed and passed to the
-                    script as its first argument.
-                  type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: name
           in: path
           required: true
@@ -653,6 +746,17 @@ paths:
             Mount path of the installed service.
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  description: |
+                    An arbitrary JSON value that will be parsed and passed to the
+                    script as its first argument.
+                  type: json
       responses:
         '200':
           description: |
@@ -665,7 +769,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/tests:
+  /_db/{database-name}/_api/foxx/tests:
     post:
       operationId: runFoxxTests
       description: |
@@ -692,6 +796,14 @@ paths:
 
         Otherwise the response body will be formatted as non-prettyprinted JSON.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -733,7 +845,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/development:
+  /_db/{database-name}/_api/foxx/development:
     post:
       operationId: enableFoxxDevelopmentMode
       description: |
@@ -748,6 +860,14 @@ paths:
         Coordinators. This means you should treat your Coordinators as inconsistent
         as long as any service is running in development mode.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -767,7 +887,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/development:
+  /_db/{database-name}/_api/foxx/development:
     delete:
       operationId: disableFoxxDevelopmentMode
       description: |
@@ -777,6 +897,14 @@ paths:
         replace the service on all other Coordinators with the version on this
         Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -796,12 +924,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/readme:
+  /_db/{database-name}/_api/foxx/readme:
     get:
       operationId: getFoxxReadme
       description: |
         Fetches the service's README or README.md file's contents if any.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -824,7 +960,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/swagger:
+  /_db/{database-name}/_api/foxx/swagger:
     get:
       operationId: getFoxxSwaggerDescription
       description: |
@@ -832,6 +968,14 @@ paths:
 
         The response body will be an OpenAPI 2.0 compatible JSON description of the service API.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -851,7 +995,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/download:
+  /_db/{database-name}/_api/foxx/download:
     post:
       operationId: downloadFoxxService
       description: |
@@ -862,6 +1006,14 @@ paths:
         Otherwise the bundle will represent the version of a service that
         is installed on that ArangoDB instance.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -884,7 +1036,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/commit:
+  /_db/{database-name}/_api/foxx/commit:
     post:
       operationId: commitFoxxServiceState
       description: |
@@ -892,6 +1044,14 @@ paths:
 
         This can be used to resolve service conflicts between Coordinators that cannot be fixed automatically due to missing data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: replace
           in: query
           required: false

--- a/site/content/3.11/develop/http-api/graphs/edges.md
+++ b/site/content/3.11/develop/http-api/graphs/edges.md
@@ -27,13 +27,21 @@ for details.
 
 ```openapi
 paths:
-  /_api/edges/{collection-id}:
+  /_db/{database-name}/_api/edges/{collection-id}:
     get:
       operationId: getVertexEdges
       description: |
         Returns an array of edges starting or ending in the vertex identified by
         `vertex`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-id
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.11/develop/http-api/graphs/named-graphs.md
@@ -30,11 +30,20 @@ The examples use the following example graphs:
 
 ```openapi
 paths:
-  /_api/gharial:
+  /_db/{database-name}/_api/gharial:
     get:
       operationId: listGraphs
       description: |
         Lists all graphs stored in this database.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -197,13 +206,21 @@ examples.dropGraph("routeplanner");
 
 ```openapi
 paths:
-  /_api/gharial:
+  /_db/{database-name}/_api/gharial:
     post:
       operationId: createGraph
       description: |
         The creation of a graph requires the name of the graph and a
         definition of its edges.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: waitForSync
           in: query
           required: false
@@ -908,7 +925,7 @@ graph._drop("satelliteGraph", true);
 
 ```openapi
 paths:
-  /_api/gharial/{graph}:
+  /_db/{database-name}/_api/gharial/{graph}:
     get:
       operationId: getGraph
       description: |
@@ -916,6 +933,14 @@ paths:
         Returns the edge definitions as well as the orphan collections,
         or returns an error if the graph does not exist.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1116,7 +1141,7 @@ graph._drop("myGraph", true);
 
 ```openapi
 paths:
-  /_api/gharial/{graph}:
+  /_db/{database-name}/_api/gharial/{graph}:
     delete:
       operationId: deleteGraph
       description: |
@@ -1124,6 +1149,14 @@ paths:
         Optionally all collections not used by other graphs
         can be dropped as well.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1258,12 +1291,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex:
+  /_db/{database-name}/_api/gharial/{graph}/vertex:
     get:
       operationId: listVertexCollections
       description: |
         Lists all vertex collections within this graph, including orphan collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1365,13 +1406,21 @@ by [adding a new edge definition](#add-an-edge-definition) or
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex:
+  /_db/{database-name}/_api/gharial/{graph}/vertex:
     post:
       operationId: addVertexCollection
       description: |
         Adds a vertex collection to the set of orphan collections of the graph.
         If the collection does not exist, it is created.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1786,7 +1835,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}:
     delete:
       operationId: deleteVertexCollection
       description: |
@@ -1799,6 +1848,14 @@ paths:
         edge definition first in order to fully remove a vertex collection from
         the graph.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2221,12 +2278,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge:
+  /_db/{database-name}/_api/gharial/{graph}/edge:
     get:
       operationId: listEdgeCollections
       description: |
         Lists all edge collections within this graph.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2322,7 +2387,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge:
+  /_db/{database-name}/_api/gharial/{graph}/edge:
     post:
       operationId: createEdgeDefinition
       description: |
@@ -2338,6 +2403,14 @@ paths:
 
         Additionally, collection creation options can be set.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2771,13 +2844,21 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     put:
       operationId: replaceEdgeDefinition
       description: |
         Change one specific edge definition.
         This modifies all occurrences of this definition in all graphs known to your database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3227,7 +3308,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     delete:
       operationId: deleteEdgeDefinition
       description: |
@@ -3236,6 +3317,14 @@ paths:
         edge definition become orphan collections but otherwise remain untouched
         and can still be used in your queries.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3613,12 +3702,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}:
     post:
       operationId: createVertex
       description: |
         Adds a vertex to the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3900,12 +3997,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     get:
       operationId: getVertex
       description: |
         Gets a vertex from the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4166,12 +4271,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     patch:
       operationId: updateVertex
       description: |
         Updates the data of the specific vertex in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4566,12 +4679,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     put:
       operationId: replaceVertex
       description: |
         Replaces the data of a vertex in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4967,12 +5088,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     delete:
       operationId: deleteVertex
       description: |
         Removes a vertex from the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5253,7 +5382,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     post:
       operationId: createEdge
       description: |
@@ -5261,6 +5390,14 @@ paths:
         Within the body the edge has to contain a `_from` and `_to` value referencing to valid vertices in the graph.
         Furthermore, the edge has to be valid according to the edge definitions.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5630,12 +5767,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     get:
       operationId: getEdge
       description: |
         Gets an edge from the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5907,12 +6052,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     patch:
       operationId: updateEdge
       description: |
         Partially modify the data of the specific edge in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -6368,12 +6521,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     put:
       operationId: replaceEdge
       description: |
         Replaces the data of an edge in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -6839,12 +7000,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     delete:
       operationId: deleteEdge
       description: |
         Removes an edge from the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/hot-backups.md
+++ b/site/content/3.11/develop/http-api/hot-backups.md
@@ -23,11 +23,15 @@ most of all the [requirements and limitations](../../operations/backup-and-resto
 before using the API.
 {{< /warning >}}
 
+The permissions required to use the `/_admin/backup/*` endpoints depends on the
+setting of the [`--backup.options-api` startup option](../../components/arangodb-server/options.md#--serveroptions-api).
+
 ## Create a backup
 
 ```openapi
 paths:
   /_admin/backup/create:
+  # Independent of database
     post:
       operationId: createBackup
       description: |
@@ -124,6 +128,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/restore:
+  # Independent of database
     post:
       operationId: restoreBackup
       description: |
@@ -212,6 +217,7 @@ while (require("internal").time() - startTime < 10) {
 ```openapi
 paths:
   /_admin/backup/delete:
+  # Independent of database
     post:
       operationId: deleteBackup
       description: |
@@ -270,6 +276,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/list:
+  # Independent of database
     post:
       operationId: listBackups
       description: |
@@ -349,6 +356,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/upload:
+  # Independent of database
     post:
       operationId: uploadBackup
       description: |
@@ -500,6 +508,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/download:
+  # Independent of database
     post:
       operationId: downloadBackup
       description: |

--- a/site/content/3.11/develop/http-api/import.md
+++ b/site/content/3.11/develop/http-api/import.md
@@ -9,7 +9,7 @@ description: >-
 
 ```openapi
 paths:
-  /_api/import:
+  /_db/{database-name}/_api/import:
     post:
       operationId: importData
       description: |
@@ -36,6 +36,14 @@ paths:
                     multiple JSON objects separated by newlines.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.11/develop/http-api/indexes/_index.md
+++ b/site/content/3.11/develop/http-api/indexes/_index.md
@@ -27,7 +27,7 @@ http://localhost:8529/_api/index/demo/63563528
 
 ```openapi
 paths:
-  /_api/index:
+  /_db/{database-name}/_api/index:
     get:
       operationId: listIndexes
       description: |
@@ -36,6 +36,14 @@ paths:
         available in the `identifiers` attribute as an object with the index identifiers
         as object keys.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -94,7 +102,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/index/{index-id}:
+  /_db/{database-name}/_api/index/{index-id}:
     get:
       operationId: getIndex
       description: |
@@ -109,6 +117,14 @@ paths:
         `unique` or `sparse` flags, whereas others don't. Some indexes also provide
         a selectivity estimate in the `selectivityEstimate` attribute of the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: index-id
           in: path
           required: true
@@ -152,7 +168,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/index:
+  /_db/{database-name}/_api/index:
     post:
       operationId: createIndex
       description: |
@@ -232,6 +248,14 @@ paths:
         in the background, which will not write-lock the underlying collection for
         as long as if the index is built in the foreground.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -274,12 +298,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/index/{index-id}:
+  /_db/{database-name}/_api/index/{index-id}:
     delete:
       operationId: deleteIndex
       description: |
         Deletes an index with `index-id`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: index-id
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/indexes/fulltext.md
+++ b/site/content/3.11/develop/http-api/indexes/fulltext.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#fulltext:
+  /_db/{database-name}/_api/index#fulltext:
     post:
       operationId: createIndexFulltext
       description: |
@@ -20,6 +20,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.11/develop/http-api/indexes/geo-spatial.md
+++ b/site/content/3.11/develop/http-api/indexes/geo-spatial.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#geo:
+  /_db/{database-name}/_api/index#geo:
     post:
       operationId: createIndexGeo
       description: |
@@ -19,6 +19,14 @@ paths:
         the index attributes or have non-numeric values in the index attributes
         will not be indexed.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -71,7 +79,7 @@ paths:
                     If a geo-spatial index on a `location` is constructed
                     and `geoJson` is `true`, then the order within the array is longitude
                     followed by latitude. This corresponds to the format described in
-                    http://geojson.org/geojson-spec.html#positions
+                    <http://geojson.org/geojson-spec.html#positions>
                   type: boolean
                 legacyPolygons:
                   description: |

--- a/site/content/3.11/develop/http-api/indexes/inverted.md
+++ b/site/content/3.11/develop/http-api/indexes/inverted.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#inverted:
+  /_db/{database-name}/_api/index#inverted:
     post:
       operationId: createIndexInverted
       description: |
@@ -16,6 +16,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.11/develop/http-api/indexes/multi-dimensional.md
+++ b/site/content/3.11/develop/http-api/indexes/multi-dimensional.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#zkd:
+  /_db/{database-name}/_api/index#mdi:
     post:
       operationId: createIndexZkd
       description: |
@@ -16,6 +16,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.11/develop/http-api/indexes/persistent.md
+++ b/site/content/3.11/develop/http-api/indexes/persistent.md
@@ -14,7 +14,7 @@ removed in a future version.
 
 ```openapi
 paths:
-  /_api/index#persistent:
+  /_db/{database-name}/_api/index#persistent:
     post:
       operationId: createIndexPersistent
       description: |
@@ -36,6 +36,14 @@ paths:
         Unique indexes on non-shard keys are not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.11/develop/http-api/indexes/ttl.md
+++ b/site/content/3.11/develop/http-api/indexes/ttl.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#ttl:
+  /_db/{database-name}/_api/index#ttl:
     post:
       operationId: createIndexTtl
       description: |
@@ -16,6 +16,14 @@ paths:
         does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.11/develop/http-api/jobs.md
+++ b/site/content/3.11/develop/http-api/jobs.md
@@ -5,12 +5,17 @@ weight: 80
 description: >-
   The HTTP API for jobs lets you access the results of asynchronously executed
   requests and check the status of such jobs
+# All /_api/job* endpoints are also available via /_admin/job*
 ---
+For an introduction to non-blocking execution of requests and how to create
+async jobs with the `x-arango-async` request header, see
+[HTTP request handling in ArangoDB](general-request-handling.md#non-blocking-execution).
+
 ## Get the results of an async job
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     put:
       operationId: getJobResult
       description: |
@@ -24,6 +29,16 @@ paths:
         the header is not present, the job was not found and the response contains
         status information from the job manager.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -144,13 +159,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}/cancel:
+  /_db/{database-name}/_api/job/{job-id}/cancel:
     put:
       operationId: cancelJob
       description: |
         Cancels the currently running job identified by job-id. Note that it still
         might take some time to actually cancel the running async job.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -212,7 +237,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     delete:
       operationId: deleteJob
       description: |
@@ -221,6 +246,16 @@ paths:
         Clients can use this method to perform an eventual garbage collection of job
         results.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -346,7 +381,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     get:
       operationId: getJob
       description: |
@@ -356,6 +391,16 @@ paths:
         - The IDs of async jobs with a specific status
         - The processing status of a specific async job
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/monitoring/logs.md
+++ b/site/content/3.11/develop/http-api/monitoring/logs.md
@@ -12,6 +12,9 @@ on the [log startup options](../../../components/arangodb-server/options.md#log)
 See [Log levels](../../../operations/administration/log-levels.md) for a detailed
 description of the `FATAL`, `ERROR`, and other levels of log messages.
 
+The permissions required to use the `/_admin/log*` endpoints depends on the
+setting of the [`--log.api-enabled` startup option](../../../components/arangodb-server/options.md#--logapi-enabled).
+
 ## Get the global server logs
 
 ```openapi
@@ -319,12 +322,18 @@ paths:
         the adjusted log levels being the object values.
 
         Possible log levels are:
-        - FATAL - There will be no way out of this. ArangoDB will go down after this message.
-        - ERROR - This is an error. you should investigate and fix it. It may harm your production.
-        - WARNING - This may be serious application-wise, but we don't know.
-        - INFO - Something has happened, take notice, but no drama attached.
-        - DEBUG - output debug messages
-        - TRACE - trace - prepare your log to be flooded - don't use in production.
+        - `FATAL` - Only critical errors are logged after which the _arangod_
+          process terminates.
+        - `ERROR` - Only errors are logged. You should investigate and fix errors
+          as they may harm your production.
+        - `WARNING` - Errors and warnings are logged. Warnings may be serious
+          application-wise and can indicate issues that might lead to errors
+          later on.
+        - `INFO` - Errors, warnings, and general information is logged.
+        - `DEBUG` - Outputs debug messages used in the development of ArangoDB
+          in addition to the above.
+        - `TRACE` - Logs detailed tracing of operations in addition to the above.
+          This can flood the log. Don't use this log level in production.
 
         This API can be turned off via the startup option `--log.api-enabled`. In case
         the API is disabled, all requests will be responded to with HTTP 403. If the
@@ -350,231 +359,276 @@ paths:
                   type: string
                 agency:
                   description: |
-                    One of the possible log topics.
+                    Agents use this log topic to inform about any activity
+                    including the RAFT consensus gossip.
                   type: string
                 agencycomm:
                   description: |
-                    One of the possible log topics.
+                    DB-Servers and Coordinators log the requests they send to the
+                    Agency.
                   type: string
                 agencystore:
                   description: |
-                    One of the possible log topics.
+                    Optional verbose logging of Agency write operations.
                   type: string
                 aql:
                   description: |
-                    One of the possible log topics.
+                    Logs information about the AQL query optimization and
+                    execution. DB-Servers and Coordinators log the cluster-internal
+                    communication around AQL queries. It also reports the AQL
+                    memory limit on startup.
                   type: string
                 arangosearch:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to ArangoSearch including Analyzers,
+                    the column cache, and the commit and consolidation threads.
                   type: string
                 audit-authentication:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether events such as successful logins and
+                    missing or wrong credentials are written to the audit log
+                    (_Enterprise Edition only_).
                   type: string
                 audit-authorization:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether events such as users trying to access databases
+                    without the necessary permissions are written to the audit log
+                    (_Enterprise Edition only_).
                   type: string
                 audit-collection:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether events about collections creation, truncation,
+                    and deletion are written to the audit log (_Enterprise Edition only_).
                   type: string
                 audit-database:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether events about database creation and deletion
+                    are written to the audit log (_Enterprise Edition only_).
                   type: string
                 audit-document:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether document read and write events are written
+                    to the audit log (_Enterprise Edition only_).
                   type: string
                 audit-hotbackup:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether the Hot Backup creation, restore, and delete
+                    events are written to the audit log (_Enterprise Edition only_).
                   type: string
                 audit-service:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether the start and stop events of the audit
+                    service are written to the audit log (_Enterprise Edition only_).
                   type: string
                 audit-view:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Controls whether events about View creation and deletion
+                    are written to the audit log (_Enterprise Edition only_).
                   type: string
                 authentication:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to authentication, for example, when a
+                    JWT secret is generated or a token is validated against a secret.
                   type: string
                 authorization:
                   description: |
-                    One of the possible log topics.
+                    Logs when a user has insufficient permissions for a request.
                   type: string
                 backup:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to Hot Backup (_Enterprise Edition only_).
                   type: string
                 bench:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to benchmarking with _arangobench_.
                   type: string
                 cache:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to caching documents and index entries
+                    as well as the cache configuration on startup.
                   type: string
                 cluster:
                   description: |
-                    One of the possible log topics.
-                  type: string
-                clustercomm:
-                  description: |
-                    One of the possible log topics.
-                  type: string
-                collector:
-                  description: |
-                    One of the possible log topics.
+                    Logs information related to the cluster-internal communication
+                    as well as cluster operations. This includes changes to the
+                    state and readiness of DB-Servers and connectivity checks
+                    on Coordinators.
                   type: string
                 communication:
                   description: |
-                    One of the possible log topics.
+                    Logs lower-level network connection and communication events.
                   type: string
                 config:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to the startup options and server
+                    configuration.
                   type: string
                 crash:
                   description: |
-                    One of the possible log topics.
+                    Logs information about a fatal error including a backtrace
+                    before the process terminates.
                   type: string
                 development:
                   description: |
-                    One of the possible log topics.
+                    This log topic is reserved for the development of ArangoDB.
                   type: string
                 dump:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to dumping data with _arangodump_.
                   type: string
                 engines:
                   description: |
-                    One of the possible log topics.
+                    Logs various information related to ArangoDB's use of the
+                    RocksDB storage engine, like the initialization and
+                    file operations.
+                    
+                    RocksDB's internal log messages are passed through using the
+                    `rocksdb` log topic.
                   type: string
                 flush:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to flushing data from memory to disk.
                   type: string
                 general:
                   description: |
-                    One of the possible log topics.
+                    Logs all messages of general interest and that don't fit
+                    under any of the other log topics. For example, it reports
+                    the ArangoDB version and the detected operating system and
+                    memory on startup.
                   type: string
                 graphs:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to graph operations including
+                    graph traversal and path search tracing.
                   type: string
                 heartbeat:
                   description: |
-                    One of the possible log topics.
+                    Logs everything related to the cluster heartbeat for
+                    monitoring the intra-connectivity.
                   type: string
                 httpclient:
                   description: |
-                    One of the possible log topics.
+                    Logs the activity of the HTTP request subsystem that is used
+                    in replication, client tools, and V8.
                   type: string
                 ldap:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Logs everything related to LDAP authentication (_Enterprise Edition only_).
                   type: string
                 libiresearch:
                   description: |
-                    One of the possible log topics.
+                    Logs the internal log messages of IResearch, the underlying
+                    library of ArangoSearch.
                   type: string
                 license:
                   description: |
-                    One of the possible log topics (_Enterprise Edition only_).
+                    Logs events related to the license management like the
+                    expiration of a license (_Enterprise Edition only_).
                   type: string
                 maintenance:
                   description: |
-                    One of the possible log topics.
+                    Logs the operations of the cluster maintenance including
+                    shard locking and collection creation.
                   type: string
                 memory:
                   description: |
-                    One of the possible log topics.
+                    Logs the memory configuration on startup and reports
+                    problems with memory alignment and operating system settings.
                   type: string
                 mmap:
                   description: |
-                    One of the possible log topics.
-                  type: string
-                performance:
-                  description: |
-                    One of the possible log topics.
+                    Unused log topic for information related to memory mapping.
                   type: string
                 pregel:
                   description: |
-                    One of the possible log topics.
+                    Logs everything related to Pregel graph processing.
                   type: string
                 queries:
                   description: |
-                    One of the possible log topics.
+                    Logs slow queries as well as internal details about the
+                    execution of AQL queries at low log levels.
                   type: string
                 replication:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to the data replication within a cluster.
                   type: string
                 requests:
                   description: |
-                    One of the possible log topics.
+                    Logs the handling of internal and external requests and
+                    can include IP addresses, endpoints, and HTTP headers and
+                    bodies when using low log levels.
+
+                    It overlaps with the network `communication` log topic.
                   type: string
                 restore:
                   description: |
-                    One of the possible log topics.
+                    This log topic is only used by _arangorestore_.
                   type: string
                 rocksdb:
                   description: |
-                    One of the possible log topics.
+                    Logs RocksDB's internal log messages as well RocksDB
+                    background errors.
+
+                    Information related to ArangoDB's use of the
+                    RocksDB storage engine uses the `engines` log topic.
                   type: string
                 security:
                   description: |
-                    One of the possible log topics.
+                    Logs the security configuration for V8.
                   type: string
                 ssl:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to the in-transit encryption of
+                    network communication using SSL/TLS.
                   type: string
                 startup:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to the startup and shutdown of a
+                    server process as well as anything related to upgrading the
+                    database directory.
                   type: string
                 statistics:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to processing server statistics.
+                    This is independent of server metrics.
                   type: string
                 supervision:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to the Agency's cluster supervision.
                   type: string
                 syscall:
                   description: |
-                    One of the possible log topics.
+                    Logs events related to calling operating system functions.
+                    It reports problems related to file descriptors and the
+                    server process monitoring.
                   type: string
                 threads:
                   description: |
-                    One of the possible log topics.
+                    Logs information related to the use of operating system
+                    threads and the threading configuration of ArangoDB.
                   type: string
                 trx:
                   description: |
-                    One of the possible log topics.
+                    Logs information about transaction management.
                   type: string
                 ttl:
                   description: |
-                    One of the possible log topics.
+                    Logs the activity of the background thread for
+                    time-to-live (TTL) indexes.
                   type: string
                 validation:
                   description: |
-                    One of the possible log topics.
+                    Logs when the schema validation fails for a document.
                   type: string
                 v8:
                   description: |
-                    One of the possible log topics.
+                    Logs various information related to ArangoDB's use of the
+                    V8 JavaScript engine, like the initialization as well as
+                    entering and exiting contexts.
                   type: string
                 views:
                   description: |
-                    One of the possible log topics.
+                    Logs certain events related to ArangoSearch Views.
                   type: string
       responses:
         '200':

--- a/site/content/3.11/develop/http-api/monitoring/metrics.md
+++ b/site/content/3.11/develop/http-api/monitoring/metrics.md
@@ -19,13 +19,19 @@ coupled to specific internals that may be replaced by other mechanisms in the
 future.
 {{< /warning >}}
 
+Whether the `/_admin/metrics*` endpoints are available depends on the setting of
+the [`--server.export-metrics-api` startup option](../../../components/arangodb-server/options.md#--serverexport-metrics-api).
+For additional document read and write metrics, the
+[`--server.export-read-write-metrics` startup option](../../../components/arangodb-server/options.md#--serverexport-read-write-metrics)
+needs to be enabled.
+
 ## Metrics API v2
 
 ### Get the metrics
 
 ```openapi
 paths:
-  /_admin/metrics/v2:
+  /_db/{database-name}/_admin/metrics/v2:
     get:
       operationId: getMetricsV2
       description: |
@@ -41,6 +47,17 @@ paths:
         The API then needs to be added to the Prometheus configuration file
         for collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false
@@ -83,7 +100,7 @@ logPlainResponse(response);
 
 ```openapi
 paths:
-  /_admin/usage-metrics:
+  /_db/{database-name}/_admin/usage-metrics:
     get:
       operationId: getUsageMetrics
       description: |
@@ -94,6 +111,17 @@ paths:
         usage metrics, or to `enabled-per-shard-per-user` to make DB-Servers collect
         usage metrics per shard and per user whenever a shard is accessed.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false
@@ -116,7 +144,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/metrics:
+  /_db/{database-name}/_admin/metrics:
     get:
       operationId: getMetrics
       description: |
@@ -138,6 +166,17 @@ paths:
         The API then needs to be added to the Prometheus configuration file
         for collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false

--- a/site/content/3.11/develop/http-api/monitoring/statistics.md
+++ b/site/content/3.11/develop/http-api/monitoring/statistics.md
@@ -10,7 +10,7 @@ description: >-
 
 ```openapi
 paths:
-  /_admin/statistics:
+  /_db/{database-name}/_admin/statistics:
     get:
       operationId: getStatistics
       description: |
@@ -42,6 +42,18 @@ paths:
         expect in a cluster setup using a single Coordinator querying this Coordinator.
         Just with the difference that cluster transactions have no notion of
         intermediate commits and will not increase the value.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -525,7 +537,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/statistics-description:
+  /_db/{database-name}/_admin/statistics-description:
     get:
       operationId: getStatisticsDescription
       description: |
@@ -554,6 +566,18 @@ paths:
         - `type`: Either `current`, `accumulated`, or `distribution`.
         - `cuts`: The distribution vector.
         - `units`: Units in which the figure is measured.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.11/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.11/develop/http-api/queries/aql-queries.md
@@ -268,7 +268,7 @@ the cursor, even before you requested the last batch.
 
 ```openapi
 paths:
-  /_api/cursor:
+  /_db/{database-name}/_api/cursor:
     post:
       operationId: createAqlQueryCursor
       description: |
@@ -280,6 +280,14 @@ paths:
         bind parameters. These values need to be passed in a JSON representation in
         the body of the POST request.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: x-arango-allow-dirty-read
           in: header
           required: false
@@ -1322,12 +1330,20 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     post:
       operationId: getNextAqlQueryCursorBatch
       description: |
         If the cursor is still alive, returns an object with the next query result batch.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -1801,7 +1817,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     put:
       operationId: getNextAqlQueryCursorBatchPut
       description: |
@@ -1829,6 +1845,14 @@ paths:
         the cursor is exhausted.  Once the `hasMore` attribute has a value of
         `false`, the client can stop.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -1929,7 +1953,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}/{batch-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}/{batch-identifier}:
     post:
       operationId: getPreviousAqlQueryCursorBatch
       description: |
@@ -1958,6 +1982,14 @@ paths:
         successfully received and processed the batch so that the server can free up
         resources.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -2472,7 +2504,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     delete:
       operationId: deleteAqlQueryCursor
       description: |
@@ -2486,6 +2518,14 @@ paths:
         Note: the server will also destroy abandoned cursors automatically after a
         certain server-controlled timeout to avoid resource leakage.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -2548,7 +2588,7 @@ list.
 
 ```openapi
 paths:
-  /_api/query/properties:
+  /_db/{database-name}/_api/query/properties:
     get:
       operationId: getAqlQueryTrackingProperties
       description: |
@@ -2579,6 +2619,15 @@ paths:
           list of queries. Query strings can have arbitrary lengths, and this property
           can be used to save memory in case very long query strings are used. The
           value is specified in bytes.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -2594,7 +2643,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/properties:
+  /_db/{database-name}/_api/query/properties:
     put:
       operationId: updateAqlQueryTrackingProperties
       description: |
@@ -2603,6 +2652,15 @@ paths:
 
         After the properties have been changed, the current set of properties will
         be returned in the HTTP response.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2668,7 +2726,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/current:
+  /_db/{database-name}/_api/query/current:
     get:
       operationId: listAqlQueries
       description: |
@@ -2708,13 +2766,21 @@ paths:
 
         - `stream`: whether or not the query uses a streaming cursor
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will return the currently running queries in all databases,
             not just the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2737,7 +2803,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/slow:
+  /_db/{database-name}/_api/query/slow:
     get:
       operationId: listSlowAqlQueries
       description: |
@@ -2771,13 +2837,21 @@ paths:
 
         - `stream`: whether or not the query uses a streaming cursor
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will return the slow queries from all databases, not just
             the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2800,19 +2874,27 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/slow:
+  /_db/{database-name}/_api/query/slow:
     delete:
       operationId: clearSlowAqlQueryList
       description: |
         Clears the list of slow AQL queries for the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will clear the slow query history in all databases, not just
             the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2839,13 +2921,21 @@ soon as it reaches a cancelation point.
 
 ```openapi
 paths:
-  /_api/query/{query-id}:
+  /_db/{database-name}/_api/query/{query-id}:
     delete:
       operationId: deleteAqlQuery
       description: |
         Kills a running query in the currently selected database. The query will be
         terminated at the next cancelation point.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: query-id
           in: path
           required: true
@@ -2859,7 +2949,7 @@ paths:
           description: |
             If set to `true`, will attempt to kill the specified query in all databases,
             not just the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2895,7 +2985,7 @@ You can also retrieve a list of all query optimizer rules and their properties.
 
 ```openapi
 paths:
-  /_api/explain:
+  /_db/{database-name}/_api/explain:
     post:
       operationId: explainAqlQuery
       description: |
@@ -2937,6 +3027,15 @@ paths:
 
         - `variables`: array of variables used in the query (note: this may contain
           internal variables created by the optimizer)
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3185,12 +3284,23 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/query:
+  /_db/{database-name}/_api/query:
     post:
       operationId: parseAqlQuery
       description: |
         This endpoint is for query validation only. To actually query the database,
         see `/api/cursor`.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3264,11 +3374,22 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/query/rules:
+  /_db/{database-name}/_api/query/rules:
     get:
       operationId: getAqlQueryOptimizerRules
       description: |
         A list of all optimizer rules and their properties.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.11/develop/http-api/queries/aql-query-results-cache.md
+++ b/site/content/3.11/develop/http-api/queries/aql-query-results-cache.md
@@ -9,7 +9,7 @@ description: >-
 
 ```openapi
 paths:
-  /_api/query-cache/entries:
+  /_db/{database-name}/_api/query-cache/entries:
     get:
       operationId: listQueryCacheResults
       description: |
@@ -28,6 +28,15 @@ paths:
           again afterwards)
         - `runTime`: the query's run time
         - `dataSources`: an array of collections/Views the query was using
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -43,11 +52,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache:
+  /_db/{database-name}/_api/query-cache:
     delete:
       operationId: deleteAqlQueryCache
       description: |
         Clears all results stored in the AQL query results cache for the current database.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -64,7 +82,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache/properties:
+  /_db/{database-name}/_api/query-cache/properties:
     get:
       operationId: getQueryCacheProperties
       description: |
@@ -85,6 +103,17 @@ paths:
 
         - `includeSystem`: whether or not results of queries that involve system collections will be
           stored in the query results cache.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -100,7 +129,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache/properties:
+  /_db/{database-name}/_api/query-cache/properties:
     put:
       operationId: setQueryCacheProperties
       description: |
@@ -114,6 +143,17 @@ paths:
         The properties need to be passed in the `properties` attribute in the body
         of the HTTP request. `properties` needs to be a JSON object with the following
         properties:
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.11/develop/http-api/queries/user-defined-aql-functions.md
+++ b/site/content/3.11/develop/http-api/queries/user-defined-aql-functions.md
@@ -20,7 +20,7 @@ collection directly, but only via the dedicated interfaces.
 
 ```openapi
 paths:
-  /_api/aqlfunction:
+  /_db/{database-name}/_api/aqlfunction:
     post:
       operationId: createAqlUserFunction
       description: |
@@ -29,6 +29,15 @@ paths:
 
         In case of success, HTTP 200 is returned.
         If the function isn't valid etc. HTTP 400 including a detailed error message will be returned.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -164,13 +173,21 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/aqlfunction/{name}:
+  /_db/{database-name}/_api/aqlfunction/{name}:
     delete:
       operationId: deleteAqlUserFunction
       description: |
         Deletes an existing user-defined function (UDF) or function group identified by
         `name` from the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: name
           in: path
           required: true
@@ -319,7 +336,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/aqlfunction:
+  /_db/{database-name}/_api/aqlfunction:
     get:
       operationId: listAqlUserFunctions
       description: |
@@ -328,6 +345,14 @@ paths:
 
         The call returns a JSON array with status codes and all user functions found under `result`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: namespace
           in: query
           required: false

--- a/site/content/3.11/develop/http-api/replication/other-replication-commands.md
+++ b/site/content/3.11/develop/http-api/replication/other-replication-commands.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/replication/server-id:
+  /_db/{database-name}/_api/replication/server-id:
     get:
       operationId: getReplicationServerId
       description: |
@@ -17,6 +17,15 @@ paths:
 
         The body of the response is a JSON object with the attribute `serverId`. The
         server id is returned as a string.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.11/develop/http-api/replication/replication-applier.md
+++ b/site/content/3.11/develop/http-api/replication/replication-applier.md
@@ -11,7 +11,7 @@ configuration of an ArangoDB database's replication applier.
 
 ```openapi
 paths:
-  /_api/replication/applier-config:
+  /_db/{database-name}/_api/replication/applier-config:
     get:
       operationId: getReplicationApplierConfig
       description: |
@@ -109,6 +109,14 @@ paths:
         - `restrictCollections`: the optional array of collections to include or exclude,
           based on the setting of `restrictType`
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -150,7 +158,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-config:
+  /_db/{database-name}/_api/replication/applier-config:
     put:
       operationId: updateReplicationApplierConfig
       description: |
@@ -162,6 +170,14 @@ paths:
         In case of success, the body of the response is a JSON object with the updated
         configuration.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -380,7 +396,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-start:
+  /_db/{database-name}/_api/replication/applier-start:
     put:
       operationId: startReplicationApplier
       description: |
@@ -396,6 +412,14 @@ paths:
         To detect replication applier errors after the applier was started, use the
         `/_api/replication/applier-state` API instead.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -462,13 +486,21 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-stop:
+  /_db/{database-name}/_api/replication/applier-stop:
     put:
       operationId: stopReplicationApplier
       description: |
         Stops the replication applier. This will return immediately if the
         replication applier is not running.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -522,7 +554,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-state:
+  /_db/{database-name}/_api/replication/applier-state:
     get:
       operationId: getReplicationApplierState
       description: |
@@ -621,6 +653,14 @@ paths:
         values are only meaningful when compared to each other. Higher tick values mean
         "later in time" than lower tick values.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -684,7 +724,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/make-follower:
+  /_db/{database-name}/_api/replication/make-follower:
     put:
       operationId: makeReplicationFollower
       description: |
@@ -802,8 +842,17 @@ paths:
         "later in time" than lower tick values.
 
         {{</* info */>}}
-        This endpoint is not supported on Coordinators in cluster deployments.
+        This endpoint is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.11/develop/http-api/replication/replication-dump.md
+++ b/site/content/3.11/develop/http-api/replication/replication-dump.md
@@ -16,7 +16,7 @@ or the incremental data synchronization.
 
 ```openapi
 paths:
-  /_api/replication/inventory:
+  /_db/{database-name}/_api/replication/inventory:
     get:
       operationId: getReplicationInventory
       description: |
@@ -100,6 +100,14 @@ paths:
         under which each key represents a database name, and the value conforms to the above description.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: includeSystem
           in: query
           required: false
@@ -153,7 +161,7 @@ dumped.
 
 ```openapi
 paths:
-  /_api/replication/batch:
+  /_db/{database-name}/_api/replication/batch:
     post:
       operationId: createReplicationBatch
       description: |
@@ -177,6 +185,14 @@ paths:
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: state
           in: query
           required: false
@@ -218,7 +234,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/batch/{id}:
+  /_db/{database-name}/_api/replication/batch/{id}:
     delete:
       operationId: deleteReplicationBatch
       description: |
@@ -235,6 +251,14 @@ paths:
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -260,7 +284,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/batch/{id}:
+  /_db/{database-name}/_api/replication/batch/{id}:
     put:
       operationId: extendReplicationBatch
       description: |
@@ -279,6 +303,22 @@ paths:
         The very same request is forwarded synchronously to that DB-Server.
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: |
+            The id of the batch.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -291,14 +331,6 @@ paths:
                   description: |
                     the time-to-live for the new batch (in seconds)
                   type: integer
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: |
-            The id of the batch.
-          schema:
-            type: string
       responses:
         '204':
           description: |
@@ -333,7 +365,7 @@ parts of the dump results in the same order as they are provided.
 
 ```openapi
 paths:
-  /_api/replication/dump:
+  /_db/{database-name}/_api/replication/dump:
     get:
       operationId: getReplicationDump
       description: |
@@ -378,6 +410,14 @@ paths:
         There will be no distinction between inserts and updates when calling this method.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -425,7 +465,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/tree:
+  /_db/{database-name}/_api/replication/revisions/tree:
     get:
       operationId: getReplicationRevisionTree
       description: |
@@ -467,6 +507,14 @@ paths:
         root is at index `0`, its children at indices `[1, branchingFactor]`, and so
         on.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -508,7 +556,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/tree:
+  /_db/{database-name}/_api/replication/revisions/tree:
     post:
       operationId: rebuildReplicationRevisionTree
       description: |
@@ -521,6 +569,14 @@ paths:
 
         If successful, there will be no return body.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -555,7 +611,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/ranges:
+  /_db/{database-name}/_api/replication/revisions/ranges:
     put:
       operationId: listReplicationRevisionRanges
       description: |
@@ -613,6 +669,14 @@ paths:
         in JavaScript, as it handles all numbers as floating point, and can only
         represent up to `2^53-1` faithfully.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -661,7 +725,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/documents:
+  /_db/{database-name}/_api/replication/revisions/documents:
     put:
       operationId: listReplicationRevisionDocuments
       description: |
@@ -701,6 +765,14 @@ paths:
         in JavaScript, as it handles all numbers as floating point, and can only
         represent up to `2^53-1` faithfully.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -742,7 +814,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/sync:
+  /_db/{database-name}/_api/replication/sync:
     put:
       operationId: startReplicationSync
       description: |
@@ -776,8 +848,17 @@ paths:
         Use with caution!
 
         {{</* info */>}}
-        This method is not supported on Coordinators in cluster deployments.
+        This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -864,7 +945,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/clusterInventory:
+  /_db/{database-name}/_api/replication/clusterInventory:
     get:
       operationId: getReplicationClusterInventory
       description: |
@@ -876,6 +957,14 @@ paths:
         just that the `indexes` attribute there is relocated to adjust it to
         the data format of arangodump.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: includeSystem
           in: query
           required: false

--- a/site/content/3.11/develop/http-api/replication/replication-logger.md
+++ b/site/content/3.11/develop/http-api/replication/replication-logger.md
@@ -24,7 +24,7 @@ by a tick *date*) is still available on the Leader.
 
 ```openapi
 paths:
-  /_api/replication/logger-state:
+  /_db/{database-name}/_api/replication/logger-state:
     get:
       operationId: getReplicationLoggerState
       description: |
@@ -65,6 +65,15 @@ paths:
           - `lastServedTick`: last tick value served to this client via the WAL tailing API
 
           - `time`: date and time when this client last called the WAL tailing API
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -102,7 +111,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-follow:
+  /_db/{database-name}/_api/replication/logger-follow:
     get:
       operationId: getReplicationLoggerFollow
       description: |
@@ -199,9 +208,17 @@ paths:
           to sleep for a while before calling the logger again.
 
         {{</* info */>}}
-        This method is not supported on Coordinators in cluster deployments.
+        This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: from
           in: query
           required: false
@@ -334,7 +351,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-first-tick:
+  /_db/{database-name}/_api/replication/logger-first-tick:
     get:
       operationId: getReplicationLoggerFirstTick
       description: |
@@ -349,8 +366,17 @@ paths:
         log.
 
         {{</* info */>}}
-        This method is not supported on Coordinators in cluster deployments.
+        This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -388,7 +414,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-tick-ranges:
+  /_db/{database-name}/_api/replication/logger-tick-ranges:
     get:
       operationId: getReplicationLoggerTickRanges
       description: |
@@ -407,6 +433,15 @@ paths:
         - `tickMin`: minimum tick value contained in logfile
 
         - `tickMax`: maximum tick value contained in logfile
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.11/develop/http-api/replication/write-ahead-log.md
+++ b/site/content/3.11/develop/http-api/replication/write-ahead-log.md
@@ -15,7 +15,7 @@ as a user is not supported. This API replaces some of the APIs in `/_api/replica
 
 ```openapi
 paths:
-  /_api/wal/range:
+  /_db/{database-name}/_api/wal/range:
     get:
       operationId: getWalRange
       description: |
@@ -28,6 +28,17 @@ paths:
         - `tickMax`: maximum tick available
         - `time`: the server time as string in format `YYYY-MM-DDTHH:MM:SSZ`
         - `server`: An object with fields `version` and `serverId`
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -66,7 +77,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/wal/lastTick:
+  /_db/{database-name}/_api/wal/lastTick:
     get:
       operationId: getWalLastTick
       description: |
@@ -79,8 +90,19 @@ paths:
         - `server`: An object with fields `version` and `serverId`
 
         {{</* info */>}}
-        This method is not supported on Coordinators in cluster deployments.
+        This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -118,7 +140,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/wal/tail:
+  /_db/{database-name}/_api/wal/tail:
     get:
       operationId: getWalTail
       description: |
@@ -221,9 +243,19 @@ paths:
           to sleep for a while before calling the logger again.
 
         {{</* info */>}}
-        This method is not supported on Coordinators in cluster deployments.
+        This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -272,7 +304,6 @@ paths:
           description: |
             The ID of the client used to tail results. The server uses this to
             keep operations until the client has fetched them. Must be a positive integer.
-
             {{</* info */>}}
             Either `syncerId` or `serverId` is required to fetch all operations.
             {{</* /info */>}}
@@ -285,7 +316,6 @@ paths:
             The ID of the client machine. If `syncerId` is unset, the server uses
             this to keep operations until the client has fetched them. Must be a positive
             integer.
-
             {{</* info */>}}
             Either `syncerId` or `serverId` is required to fetch all operations.
             {{</* /info */>}}

--- a/site/content/3.11/develop/http-api/security.md
+++ b/site/content/3.11/develop/http-api/security.md
@@ -20,7 +20,7 @@ See [Audit logging](../../operations/security/audit-logging.md#configuration).
 
 ```openapi
 paths:
-  /_admin/server/tls:
+  /_db/{database-name}/_admin/server/tls:
     get:
       operationId: getServerTls
       description: |
@@ -48,6 +48,18 @@ paths:
             JSON string with the SHA256 of the private key.
 
         This API requires authentication.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -61,6 +73,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/tls:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: reloadServerTls
       description: |
@@ -88,6 +101,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/encryption:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: rotateEncryptionAtRestKey
       description: |

--- a/site/content/3.11/develop/http-api/tasks.md
+++ b/site/content/3.11/develop/http-api/tasks.md
@@ -10,11 +10,22 @@ description: >-
 
 ```openapi
 paths:
-  /_api/tasks/:
+  /_db/{database-name}/_api/tasks/:
     get:
       operationId: listTasks
       description: |
         fetches all existing tasks on the server
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -96,12 +107,22 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     get:
       operationId: getTask
       description: |
         fetches one existing task on the server specified by `id`
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -202,11 +223,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/tasks:
+  /_db/{database-name}/_api/tasks:
     post:
       operationId: createTask
       description: |
         creates a new task with a generated id
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -325,15 +355,14 @@ assert(response.code === 200);
 logJsonResponse(response);
 
 // Cleanup:
-logCurlRequest('DELETE', url + response.parsedBody.id);
-
+curlRequest('DELETE', url + response.parsedBody.id);
 ```
 
 ## Create a task with ID
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     put:
       operationId: createTaskWithId
       description: |
@@ -341,6 +370,14 @@ paths:
 
         Not compatible with load balancers.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -417,12 +454,22 @@ curlRequest('DELETE', url + 'sampleTask');
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     delete:
       operationId: deleteTask
       description: |
         Deletes the task identified by `id` on the server.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has administrate access
+            to this database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/transactions/javascript-transactions.md
+++ b/site/content/3.11/develop/http-api/transactions/javascript-transactions.md
@@ -26,7 +26,7 @@ refer to [Transactions](../../transactions/_index.md).
 
 ```openapi
 paths:
-  /_api/transaction:
+  /_db/{database-name}/_api/transaction:
     post:
       operationId: executeJavaScriptTransaction
       description: |
@@ -65,6 +65,15 @@ paths:
         an error.
         Any other errors will be returned with any of the return codes
         *HTTP 400*, *HTTP 409*, or *HTTP 500*.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.11/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/3.11/develop/http-api/transactions/stream-transactions.md
@@ -37,7 +37,7 @@ Supported transactional API operations include:
 
 ```openapi
 paths:
-  /_api/transaction/begin:
+  /_db/{database-name}/_api/transaction/begin:
     post:
       operationId: beginStreamTransaction
       description: |
@@ -79,6 +79,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: x-arango-allow-dirty-read
           in: header
           required: false
@@ -106,7 +114,7 @@ paths:
                     transaction must be declared with the `write` or `exclusive` attribute or it
                     will fail, whereas non-declared collections from which is solely read will be
                     added lazily.
-                  type: string
+                  type: object
                 waitForSync:
                   description: |
                     an optional boolean flag that, if set, will force the
@@ -197,7 +205,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     get:
       operationId: getStreamTransaction
       description: |
@@ -208,6 +216,14 @@ paths:
 
         - `status`: the status of the transaction. One of "running", "committed" or "aborted".
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -263,7 +279,7 @@ db._drop("products");
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     put:
       operationId: commitStreamTransaction
       description: |
@@ -297,6 +313,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -356,7 +380,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     delete:
       operationId: abortStreamTransaction
       description: |
@@ -390,6 +414,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -449,7 +481,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/transaction:
+  /_db/{database-name}/_api/transaction:
     get:
       operationId: listStreamTransactions
       description: |
@@ -461,6 +493,15 @@ paths:
 
         - `id`: the transaction's id
         - `state`: the transaction's status
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.11/develop/http-api/users.md
+++ b/site/content/3.11/develop/http-api/users.md
@@ -6,6 +6,8 @@ description: >-
   The HTTP API for user management lets you create, modify, delete, and list
   ArangoDB user accounts, as well as grant and revoke permissions for databases
   and collections
+# GET|PUT|DELETE /_api/user/{user}/config and GET /_api/user/{user}/config/{key}
+# endpoints not documented on purpose because they are only used by the web interface
 ---
 The interface provides the means to manage database system users. All
 users managed through this interface are stored in the protected `_users`
@@ -29,12 +31,23 @@ User management operations are not included in ArangoDB's replication.
 
 ```openapi
 paths:
-  /_api/user:
+  /_db/{database-name}/_api/user:
     post:
       operationId: createUser
       description: |
         Create a new user. You need server access level *Administrate* in order to
         execute this REST call.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -108,7 +121,7 @@ require("@arangodb/users").remove("admin@example");
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     put:
       operationId: replaceUserData
       description: |
@@ -116,6 +129,16 @@ paths:
         *Administrate* in order to execute this REST call. Additionally, users can
         change their own data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -193,7 +216,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     patch:
       operationId: updateUserData
       description: |
@@ -201,6 +224,16 @@ paths:
         *Administrate* in order to execute this REST call. Additionally, users can
         change their own data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -276,7 +309,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     delete:
       operationId: deleteUser
       description: |
@@ -285,6 +318,16 @@ paths:
         You need *Administrate* permissions for the server access level in order to
         execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -333,7 +376,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     get:
       operationId: getUser
       description: |
@@ -341,6 +384,16 @@ paths:
         yourself or you need the *Administrate* server access level in order to
         execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -390,7 +443,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/:
+  /_db/{database-name}/_api/user/:
     get:
       operationId: listUsers
       description: |
@@ -405,6 +458,17 @@ paths:
         - `active`: An optional flag that specifies whether the user is active.
         - `extra`: A JSON object with extra user information. It is used by the web
           interface to store graph viewer settings and saved queries.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -441,7 +505,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     put:
       operationId: setUserDatabasePermissions
       description: |
@@ -463,6 +527,16 @@ paths:
                     - Use "none" to set the database access level to *No access*.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -474,7 +548,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to set the access level for.
           schema:
             type: string
       responses:
@@ -521,7 +595,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     put:
       operationId: setUserCollectionPermissions
       description: |
@@ -545,6 +619,16 @@ paths:
                     Use "none" to set the collection level access to *No access*.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -556,14 +640,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to set the access level for.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection.
+            The name of the collection to set the access level for.
           schema:
             type: string
       responses:
@@ -614,7 +698,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     delete:
       operationId: deleteUserDatabasePermissions
       description: |
@@ -625,6 +709,16 @@ paths:
         You need write permissions (*Administrate* access level) for the `_system`
         database in order to execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -636,7 +730,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to clear the access level for.
           schema:
             type: string
       responses:
@@ -676,7 +770,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     delete:
       operationId: deleteUserCollectionPermissions
       description: |
@@ -688,6 +782,16 @@ paths:
         You need write permissions (*Administrate* access level) for the `_system`
         database in order to execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -699,14 +803,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to clear the access level for.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection.
+            The name of the collection to clear the access level for.
           schema:
             type: string
       responses:
@@ -749,7 +853,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/:
+  /_db/{database-name}/_api/user/{user}/database/:
     get:
       operationId: listUserDatabases
       description: |
@@ -766,6 +870,16 @@ paths:
         In case you specified `full`, the result will contain the permissions
         for the databases as well as the permissions for the collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -843,12 +957,22 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     get:
       operationId: getUserDatabasePermissions
       description: |
         Fetch the database access level for a specific database
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -860,7 +984,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database to query
+            The name of the database to query the access level of.
           schema:
             type: string
       responses:
@@ -906,12 +1030,22 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     get:
       operationId: getUserCollectionPermissions
       description: |
         Returns the collection access level for a specific collection
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -923,14 +1057,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database to query
+            The name of the database to query the access level of.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection
+            The name of the collection to query the access level of.
           schema:
             type: string
       responses:

--- a/site/content/3.11/develop/http-api/views/arangosearch-views.md
+++ b/site/content/3.11/develop/http-api/views/arangosearch-views.md
@@ -10,12 +10,21 @@ description: >-
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     post:
       operationId: createView
       description: |
         Creates a new View with a given name and properties if it does not
         already exist.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -310,7 +319,7 @@ db._dropView("products");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     get:
       operationId: getView
       description: |
@@ -319,6 +328,14 @@ paths:
         - `name`: The name of the View
         - `type`: The type of the View as string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -372,7 +389,7 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     get:
       operationId: getViewProperties
       description: |
@@ -381,6 +398,14 @@ paths:
         The result is an object with a full description of a specific View, including
         View type dependent properties.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -441,7 +466,7 @@ db._drop("books");
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     get:
       operationId: listViews
       description: |
@@ -450,6 +475,15 @@ paths:
         - `id`
         - `name`
         - `type`
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -482,7 +516,7 @@ db._dropView("reviewsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     put:
       operationId: replaceViewProperties
       description: |
@@ -494,6 +528,14 @@ paths:
         - `type`: The View type
         - all additional `arangosearch` View implementation-specific properties
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -648,7 +690,7 @@ db._dropView(view.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     patch:
       operationId: updateViewProperties
       description: |
@@ -660,6 +702,14 @@ paths:
         - `type`: The View type
         - all additional `arangosearch` View implementation-specific properties
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -814,7 +864,7 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/rename:
+  /_db/{database-name}/_api/view/{view-name}/rename:
     put:
       operationId: renameView
       description: |
@@ -830,6 +880,14 @@ paths:
         Renaming Views is not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -869,7 +927,7 @@ db._dropView("catalogView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     delete:
       operationId: deleteView
       description: |
@@ -880,6 +938,14 @@ paths:
         - `error`: `false`
         - `id`: The identifier of the dropped View
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true

--- a/site/content/3.11/develop/http-api/views/search-alias-views.md
+++ b/site/content/3.11/develop/http-api/views/search-alias-views.md
@@ -10,12 +10,21 @@ description: >-
 
 ```openapi
 paths:
-  /_api/view#searchalias:
+  /_db/{database-name}/_api/view#searchalias:
     post:
       operationId: createViewSearchAlias
       description: |
         Creates a new View with a given name and properties if it does not
         already exist.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -95,7 +104,7 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     get:
       operationId: getView
       description: |
@@ -104,6 +113,14 @@ paths:
         - `name`: The name of the View
         - `type`: The type of the View as string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -157,7 +174,7 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     get:
       operationId: getViewPropertiesSearchAlias
       description: |
@@ -166,6 +183,14 @@ paths:
         The result is an object with a full description of a specific View, including
         View type dependent properties.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -228,7 +253,7 @@ db._drop("books");
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     get:
       operationId: listViews
       description: |
@@ -237,6 +262,15 @@ paths:
         - `id`
         - `name`
         - `type`
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -269,12 +303,20 @@ db._dropView("reviewsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     put:
       operationId: replaceViewPropertiesSearchAlias
       description: |
         Replaces the list of indexes of a `search-alias` View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -389,12 +431,20 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     patch:
       operationId: updateViewPropertiesSearchAlias
       description: |
         Updates the list of indexes of a `search-alias` View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -514,7 +564,7 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/rename:
+  /_db/{database-name}/_api/view/{view-name}/rename:
     put:
       operationId: renameView
       description: |
@@ -530,6 +580,14 @@ paths:
         Renaming Views is not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -569,7 +627,7 @@ db._dropView("catalogView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     delete:
       operationId: deleteView
       description: |
@@ -580,6 +638,14 @@ paths:
         - `error`: `false`
         - `id`: The identifier of the dropped View
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/administration.md
+++ b/site/content/3.12/develop/http-api/administration.md
@@ -5,6 +5,7 @@ weight: 110
 description: >-
   You can get information about ArangoDB servers, toggle the maintenance mode,
   shut down server nodes, and start actions like compaction
+# Internal /_admin/debug and /_api/test endpoints for maintainers not documented on purpose
 ---
 ## Information
 
@@ -12,21 +13,34 @@ description: >-
 
 ```openapi
 paths:
-  /_api/version:
+  /_db/{database-name}/_api/version:
+  # /_admin/version is an (undocumented) alias
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getVersion
       description: |
         Returns the server name and version number. The response is a JSON object
         with the following attributes:
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: details
           in: query
           required: false
           description: |
-            If set to `true`, the response will contain a `details` attribute with
-            additional information about included components and their versions. The
-            attribute names and internals of the `details` object may vary depending on
-            platform and ArangoDB version.
+            If set to `true` and if the user account you authenticate with has
+            administrate access to the `_system` database, the response contains
+            a `details` attribute with additional information about included
+            components and their versions. The attribute names and internals of
+            the `details` object may vary depending on platform and ArangoDB version.
           schema:
             type: boolean
       responses:
@@ -222,12 +236,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/engine:
+  /_db/{database-name}/_api/engine:
     get:
       operationId: getEngine
       description: |
         Returns the storage engine the server is configured to use.
         The response is a JSON object with the following attributes:
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -266,12 +291,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/time:
+  /_db/{database-name}/_admin/time:
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getTime
       description: |
         The call returns an object with the `time` attribute. This contains the
         current system time as a Unix timestamp with microsecond precision.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -305,11 +342,24 @@ paths:
 
 ```openapi
 paths:
-  /_admin/status:
+  /_db/{database-name}/_admin/status:
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getStatus
       description: |
         Returns status information about the server.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -541,6 +591,7 @@ logJsonResponse(response);
 ```openapi
 paths:
   /_admin/server/availability:
+  # Independent of database
     get:
       operationId: getServerAvailability
       description: |
@@ -575,8 +626,9 @@ paths:
 
 ```openapi
 paths:
-  /_admin/support-info:
+  /_db/_system/_admin/support-info:
     get:
+      # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getSupportInfo
       description: |
         Retrieves deployment information for support purposes. The endpoint returns data
@@ -659,11 +711,14 @@ logJsonResponse(response);
 
 ## Startup options
 
+The permissions required to use the `/_admin/options*` endpoints depends on the
+setting of the [`--server.options-api` startup option](../../components/arangodb-server/options.md#--serveroptions-api).
+
 ### Get the startup option configuration
 
 ```openapi
 paths:
-  /_admin/options:
+  /_db/_system/_admin/options:
     get:
       operationId: getEffectiveStartupOptions
       description: |
@@ -702,7 +757,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/options-description:
+  /_db/_system/_admin/options-description:
     get:
       operationId: getAvailableStartupOptions
       description: |
@@ -789,7 +844,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/server/mode:
+  /_db/{database-name}/_admin/server/mode:
     get:
       operationId: getServerMode
       description: |
@@ -799,6 +854,17 @@ paths:
         Creating or dropping of databases and collections will also fail with error code `11` (_ERROR_FORBIDDEN_).
 
         This API requires authentication.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -811,7 +877,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/server/mode:
+  /_db/{database-name}/_admin/server/mode:
     put:
       operationId: setServerMode
       description: |
@@ -823,6 +889,17 @@ paths:
 
         This is a protected API. It requires authentication and administrative
         server rights.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -855,12 +932,24 @@ status and update the license of your ArangoDB Enterprise Edition deployment.
 
 ```openapi
 paths:
-  /_admin/license:
+  /_db/{database-name}/_admin/license:
     get:
       operationId: getLicense
       description: |
         View the license information and status of an Enterprise Edition instance.
         Can be called on single servers, Coordinators, and DB-Servers.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -945,13 +1034,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/license:
+  /_db/{database-name}/_admin/license:
     put:
       operationId: setLicense
       description: |
         Set a new license for an Enterprise Edition instance.
         Can be called on single servers, Coordinators, and DB-Servers.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: force
           in: query
           required: false
@@ -1102,12 +1202,22 @@ x-content-type-options: nosniff
 
 ```openapi
 paths:
-  /_admin/shutdown:
+  /_db/{database-name}/_admin/shutdown:
     delete:
       operationId: startShutdown
       description: |
         This call initiates a clean shutdown sequence. Requires administrative privileges.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: soft
           in: query
           required: false
@@ -1150,7 +1260,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/shutdown:
+  /_db/{database-name}/_admin/shutdown:
     get:
       operationId: getShutdownProgress
       description: |
@@ -1169,6 +1279,17 @@ paths:
          - Ongoing low priority requests
 
         This API is only available on Coordinators.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1232,6 +1353,7 @@ paths:
 ```openapi
 paths:
   /_admin/compact:
+  # Independent of database (superuser has access to all databases that exist)
     put:
       operationId: compactAllDatabases
       description: |
@@ -1290,12 +1412,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/routing/reload:
+  /_db/{database-name}/_admin/routing/reload:
     post:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: reloadRouting
       description: |
         Reloads the routing information from the `_routing` system collection if it
         exists, and makes Foxx rebuild its local routing table on the next request.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1308,7 +1442,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/echo:
+  /_db/{database-name}/_admin/echo:
     post:
       operationId: echoRequest
       description: |
@@ -1325,6 +1459,17 @@ paths:
                   description: |
                     The request body can be of any type and is simply forwarded.
                   type: string
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1483,8 +1628,9 @@ paths:
 
 ```openapi
 paths:
-  /_admin/execute:
+  /_db/{database-name}/_admin/execute:
     post:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: executeCode
       description: |
         Executes the JavaScript code in the body on the server as the body
@@ -1501,6 +1647,15 @@ paths:
         The default value of this option is `false`, which disables the execution of
         user-defined code and disables this API endpoint entirely.
         This is also the recommended setting for production.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1551,7 +1706,7 @@ the default `_system` database and none of the other databases.
 
 ```openapi
 paths:
-  /_api/endpoint:
+  /_db/_system/_api/endpoint:
     get:
       operationId: listEndpoints
       description: |

--- a/site/content/3.12/develop/http-api/analyzers.md
+++ b/site/content/3.12/develop/http-api/analyzers.md
@@ -16,11 +16,20 @@ introduction and the available types, properties and features.
 
 ```openapi
 paths:
-  /_api/analyzer:
+  /_db/{database-name}/_api/analyzer:
     post:
       operationId: createAnalyzer
       description: |
         Creates a new Analyzer based on the provided configuration.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -96,7 +105,7 @@ analyzers.remove(analyzerName, true);
 
 ```openapi
 paths:
-  /_api/analyzer/{analyzer-name}:
+  /_db/{database-name}/_api/analyzer/{analyzer-name}:
     get:
       operationId: getAnalyzer
       description: |
@@ -107,6 +116,14 @@ paths:
         - `properties`: the properties used to configure the specified type
         - `features`: the set of features to set on the Analyzer generated fields
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: analyzer-name
           in: path
           required: true
@@ -152,7 +169,7 @@ analyzers.remove(analyzerName, true);
 
 ```openapi
 paths:
-  /_api/analyzer:
+  /_db/{database-name}/_api/analyzer:
     get:
       operationId: listAnalyzers
       description: |
@@ -162,6 +179,15 @@ paths:
         - `type`: the Analyzer type
         - `properties`: the properties used to configure the specified type
         - `features`: the set of features to set on the Analyzer generated fields
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -190,7 +216,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/analyzer/{analyzer-name}:
+  /_db/{database-name}/_api/analyzer/{analyzer-name}:
     delete:
       operationId: deleteAnalyzer
       description: |
@@ -201,6 +227,14 @@ paths:
         - `error`: `false`
         - `name`: The name of the removed Analyzer
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: analyzer-name
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/authentication.md
+++ b/site/content/3.12/develop/http-api/authentication.md
@@ -174,6 +174,7 @@ Please note that all JWT tokens must contain the `iss` field with string value
 ```openapi
 paths:
   /_open/auth:
+  # Independent of database
     post:
       operationId: createSessionToken
       description: |
@@ -281,7 +282,7 @@ may use the following RESTful API. A `POST` request reloads the secret, a
 
 ```openapi
 paths:
-  /_admin/server/jwt:
+  /_db/{database-name}/_admin/server/jwt:
     get:
       operationId: getServerJwtSecrets
       description: |
@@ -289,6 +290,18 @@ paths:
 
         To utilize the API a superuser JWT token is necessary, otherwise the response
         will be _HTTP 403 Forbidden_.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: ''
@@ -343,6 +356,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/jwt:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: reloadServerJwtSecrets
       description: |

--- a/site/content/3.12/develop/http-api/batch-requests.md
+++ b/site/content/3.12/develop/http-api/batch-requests.md
@@ -227,7 +227,7 @@ in a batch part will be ignored.
 
 ```openapi
 paths:
-  /_api/batch:
+  /_db/{database-name}/_api/batch:
     post:
       operationId: executeBatchRequest
       description: |
@@ -267,6 +267,15 @@ paths:
         original client request. Client can additionally use the `Content-Id`
         MIME header in a batch part to define an individual id for each batch part.
         The server will return this id is the batch part responses, too.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.12/develop/http-api/cluster.md
+++ b/site/content/3.12/develop/http-api/cluster.md
@@ -9,6 +9,9 @@ description: >-
 ---
 ## Monitoring
 
+The permissions required to use the `/_admin/cluster/*` endpoints depends on the
+setting of the [`--cluster.api-jwt-policy` startup option](../../components/arangodb-server/options.md#--clusterapi-jwt-policy).
+
 ### Get the statistics of a DB-Server
 
 ```openapi

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -29,13 +29,21 @@ http://localhost:8529/_api/collection/demo
 
 ```openapi
 paths:
-  /_api/collection:
+  /_db/{database-name}/_api/collection:
     get:
       operationId: listCollections
       description: |
         Returns basic information for all collections in the current database,
         optionally excluding system collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: excludeSystem
           in: query
           required: false
@@ -139,12 +147,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}:
+  /_db/{database-name}/_api/collection/{collection-name}:
     get:
       operationId: getCollection
       description: |
         Returns the basic information about a specific collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -261,12 +277,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/properties:
+  /_db/{database-name}/_api/collection/{collection-name}/properties:
     get:
       operationId: getCollectionProperties
       description: |
         Returns all properties of the specified collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -578,12 +602,20 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/count:
+  /_db/{database-name}/_api/collection/{collection-name}/count:
     get:
       operationId: getCollectionCount
       description: |
         Get the number of documents in a collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -892,13 +924,21 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/figures:
+  /_db/{database-name}/_api/collection/{collection-name}/figures:
     get:
       operationId: getCollectionFigures
       description: |
         Get the number of documents and additional statistical information
         about the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1312,7 +1352,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/responsibleShard:
+  /_db/{database-name}/_api/collection/{collection-name}/responsibleShard:
     put:
       operationId: getResponsibleShard
       description: |
@@ -1329,6 +1369,22 @@ paths:
         {{</* info */>}}
         This method is only available in cluster deployments on Coordinators.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: collection-name
+          in: path
+          required: true
+          description: |
+            The name of the collection.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1342,14 +1398,6 @@ paths:
                     The request body must be a JSON object with at least the shard key
                     attributes set to some values, but it may also be a full document.
                   type: object
-      parameters:
-        - name: collection-name
-          in: path
-          required: true
-          description: |
-            The name of the collection.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -1501,7 +1549,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/shards:
+  /_db/{database-name}/_api/collection/{collection-name}/shards:
     get:
       operationId: getCollectionShards
       description: |
@@ -1515,6 +1563,14 @@ paths:
         This method is only available in cluster deployments on Coordinators.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1674,7 +1730,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/revision:
+  /_db/{database-name}/_api/collection/{collection-name}/revision:
     get:
       operationId: getCollectionRevision
       description: |
@@ -1682,6 +1738,14 @@ paths:
         The revision ID is a server-generated string that clients can use to
         check whether data in a collection has changed since the last revision check.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2034,7 +2098,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/checksum:
+  /_db/{database-name}/_api/collection/{collection-name}/checksum:
     get:
       operationId: getCollectionChecksum
       description: |
@@ -2060,6 +2124,14 @@ paths:
         Including user-defined attributes will make the checksumming slower.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2218,11 +2290,22 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/key-generators:
+  /_db/{database-name}/_api/key-generators:
     get:
       operationId: getKeyGenerators
       description: |
         Returns the available key generators for collections.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -2271,12 +2354,41 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection:
+  /_db/{database-name}/_api/collection:
     post:
       operationId: createCollection
       description: |
         Creates a new collection with a given name. The request must contain an
         object with the following attributes.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: waitForSyncReplication
+          in: query
+          required: false
+          description: |
+            The default is `true`, which means the server only reports success back to the
+            client when all replicas have created the collection. Set it to `false` if you want
+            faster server responses and don't care about full replication.
+          schema:
+            type: boolean
+            default: true
+        - name: enforceReplicationFactor
+          in: query
+          required: false
+          description: |
+            The default is `true`, which means the server checks if there are enough replicas
+            available at creation time and bail out otherwise. Set it to `false` to disable
+            this extra check.
+          schema:
+            type: boolean
+            default: true
       requestBody:
         content:
           application/json:
@@ -2584,27 +2696,6 @@ paths:
                     A further restriction is that whenever documents are stored or updated in the
                     collection, the value stored in the `smartJoinAttribute` must be a string.
                   type: string
-      parameters:
-        - name: waitForSyncReplication
-          in: query
-          required: false
-          description: |
-            The default is `true`, which means the server only reports success back to the
-            client when all replicas have created the collection. Set it to `false` if you want
-            faster server responses and don't care about full replication.
-          schema:
-            type: boolean
-            default: true
-        - name: enforceReplicationFactor
-          in: query
-          required: false
-          description: |
-            The default is `true`, which means the server checks if there are enough replicas
-            available at creation time and bail out otherwise. Set it to `false` to disable
-            this extra check.
-          schema:
-            type: boolean
-            default: true
       responses:
         '200':
           description: |
@@ -2924,12 +3015,20 @@ db._drop("testCollectionUsers");
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}:
+  /_db/{database-name}/_api/collection/{collection-name}:
     delete:
       operationId: deleteCollection
       description: |
         Delete the collection identified by `collection-name` and all its documents.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3105,12 +3204,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/truncate:
+  /_db/{database-name}/_api/collection/{collection-name}/truncate:
     put:
       operationId: truncateCollection
       description: |
         Removes all documents from the collection, but leaves the indexes intact.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3270,7 +3377,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/load:
+  /_db/{database-name}/_api/collection/{collection-name}/load:
     put:
       operationId: loadCollection
       description: |
@@ -3283,6 +3390,14 @@ paths:
         Since ArangoDB version 3.9.0 this API does nothing. Previously, it used to
         load a collection into memory.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3453,7 +3568,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/unload:
+  /_db/{database-name}/_api/collection/{collection-name}/unload:
     put:
       operationId: unloadCollection
       description: |
@@ -3466,6 +3581,14 @@ paths:
         Since ArangoDB version 3.9.0 this API does nothing. Previously it used to
         unload a collection from memory, while preserving all documents.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3632,7 +3755,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/loadIndexesIntoMemory:
+  /_db/{database-name}/_api/collection/{collection-name}/loadIndexesIntoMemory:
     put:
       operationId: loadCollectionIndexes
       description: |
@@ -3658,6 +3781,14 @@ paths:
         It is guaranteed that the in-memory cache data is consistent with the stored
         index data at all times.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3788,7 +3919,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/properties:
+  /_db/{database-name}/_api/collection/{collection-name}/properties:
     put:
       operationId: updateCollectionProperties
       description: |
@@ -3797,6 +3928,14 @@ paths:
         created except for the listed properties, as well as the collection name via
         the rename endpoint (but not in clusters).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -4255,7 +4394,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/rename:
+  /_db/{database-name}/_api/collection/{collection-name}/rename:
     put:
       operationId: renameCollection
       description: |
@@ -4268,6 +4407,14 @@ paths:
         If renaming the collection succeeds, then the collection is also renamed in
         all graph definitions inside the `_graphs` collection in the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -4449,12 +4596,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/recalculateCount:
+  /_db/{database-name}/_api/collection/{collection-name}/recalculateCount:
     put:
       operationId: recalculateCollectionCount
       description: |
         Recalculates the document count of a collection, if it ever becomes inconsistent.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -4563,7 +4718,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/compact:
+  /_db/{database-name}/_api/collection/{collection-name}/compact:
     put:
       operationId: compactCollection
       description: |
@@ -4577,6 +4732,14 @@ paths:
         the disk data for a collection may contain a lot of outdated data for which the
         space shall be reclaimed. In this case the compaction operation can be used.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/databases.md
+++ b/site/content/3.12/develop/http-api/databases.md
@@ -62,7 +62,7 @@ Non-NFC-normalized names are rejected by the server.
 
 ```openapi
 paths:
-  /_api/database/current:
+  /_db/{database-name}/_api/database/current:
     get:
       operationId: getCurrentDatabase
       description: |
@@ -77,6 +77,15 @@ paths:
         - `sharding`: the default sharding method for collections created in this database
         - `replicationFactor`: the default replication factor for collections in this database
         - `writeConcern`: the default write concern for collections in this database
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -110,12 +119,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database/user:
+  /_db/{database-name}/_api/database/user:
     get:
       operationId: listUserAccessibleDatabases
       description: |
         Retrieves the list of all databases the current user can access without
         specifying a different username or password.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -146,7 +166,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database:
+  /_db/_system/_api/database:
     get:
       operationId: listDatabases
       description: |
@@ -188,7 +208,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database:
+  /_db/_system/_api/database:
     post:
       operationId: createDatabase
       description: |
@@ -374,7 +394,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database/{database-name}:
+  /_db/_system/_api/database/{database-name}:
     delete:
       operationId: deleteDatabase
       description: |

--- a/site/content/3.12/develop/http-api/documents.md
+++ b/site/content/3.12/develop/http-api/documents.md
@@ -75,7 +75,7 @@ endpoints to request and delete multiple documents in one request.
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     get:
       operationId: getDocument
       description: |
@@ -85,6 +85,14 @@ paths:
         - `_key`, containing the document key that uniquely identifies a document within the collection.
         - `_rev`, containing the document revision.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -220,7 +228,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     head:
       operationId: getDocumentHeader
       description: |
@@ -228,6 +236,14 @@ paths:
         can use this call to get the current revision of a document or check if
         the document was deleted.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -325,7 +341,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     post:
       operationId: createDocument
       description: |
@@ -368,6 +384,14 @@ paths:
         generated document, the complete new document is returned under
         the `new` attribute in the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -744,7 +768,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     put:
       operationId: replaceDocument
       description: |
@@ -816,6 +840,14 @@ paths:
                     A JSON representation of a single document.
                   type: object
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1061,7 +1093,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     patch:
       operationId: updateDocument
       description: |
@@ -1140,6 +1172,14 @@ paths:
                     A JSON representation of a document update as an object.
                   type: object
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1409,7 +1449,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     delete:
       operationId: deleteDocument
       description: |
@@ -1429,6 +1469,14 @@ paths:
         the complete previous revision of the document
         is returned under the `old` attribute in the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1663,7 +1711,7 @@ contains a JSON array of the same length.
 
 ```openapi
 paths:
-  /_api/document/{collection}#get:
+  /_db/{database-name}/_api/document/{collection}#get:
     put:
       operationId: getDocuments
       description: |
@@ -1692,6 +1740,14 @@ paths:
         - `_key`, containing the document key that uniquely identifies a document within the collection.
         - `_rev`, containing the document revision.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1702,6 +1758,7 @@ paths:
         - name: onlyget
           in: query
           required: true
+          example: true
           description: |
             This parameter is required to be `true`, otherwise a replace
             operation is executed!
@@ -1794,7 +1851,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}#multiple:
+  /_db/{database-name}/_api/document/{collection}#multiple:
     post:
       operationId: createDocuments
       description: |
@@ -1844,6 +1901,14 @@ paths:
         `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
         has happened, and in 10 cases the error 1205 ("illegal document handle").
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2117,7 +2182,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     put:
       operationId: replaceDocuments
       description: |
@@ -2189,6 +2254,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2335,7 +2408,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     patch:
       operationId: updateDocuments
       description: |
@@ -2414,6 +2487,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2582,7 +2663,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     delete:
       operationId: deleteDocuments
       description: |
@@ -2635,6 +2716,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/foxx.md
+++ b/site/content/3.12/develop/http-api/foxx.md
@@ -15,7 +15,7 @@ For more information on Foxx and its JavaScript APIs see the
 
 ```openapi
 paths:
-  /_api/foxx:
+  /_db/{database-name}/_api/foxx:
     get:
       operationId: listFoxxServices
       description: |
@@ -33,6 +33,14 @@ paths:
         - `name`: a string identifying the service type
         - `version`: a semver-compatible version string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: excludeSystem
           in: query
           required: false
@@ -52,7 +60,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     get:
       operationId: getFoxxServiceDescription
       description: |
@@ -71,6 +79,14 @@ paths:
         - `name`: a string identifying the service type
         - `version`: a semver-compatible version string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -93,7 +109,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx:
+  /_db/{database-name}/_api/foxx:
     post:
       operationId: createFoxxService
       description: |
@@ -127,6 +143,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -167,7 +191,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     delete:
       operationId: deleteFoxxService
       description: |
@@ -201,7 +225,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     put:
       operationId: replaceFoxxService
       description: |
@@ -240,6 +264,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -287,7 +319,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     patch:
       operationId: upgradeFoxxService
       description: |
@@ -326,6 +358,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -375,7 +415,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     get:
       operationId: getFoxxConfiguration
       description: |
@@ -384,6 +424,14 @@ paths:
         Returns an object mapping the configuration option names to their definitions
         including a human-friendly `title` and the `current` value (if any).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -403,13 +451,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     patch:
       operationId: updateFoxxConfiguration
       description: |
         Replaces the given service's configuration.
 
         Returns an object mapping all configuration option names to their new values.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -423,14 +487,6 @@ paths:
                     A JSON object mapping configuration option names to their new values.
                     Any omitted options will be ignored.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -443,13 +499,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     put:
       operationId: replaceFoxxConfiguration
       description: |
         Replaces the given service's configuration completely.
 
         Returns an object mapping all configuration option names to their new values.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -463,14 +535,6 @@ paths:
                     A JSON object mapping configuration option names to their new values.
                     Any omitted options will be reset to their default values or marked as unconfigured.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -483,7 +547,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     get:
       operationId: getFoxxDependencies
       description: |
@@ -492,6 +556,14 @@ paths:
         Returns an object mapping the dependency names to their definitions
         including a human-friendly `title` and the `current` mount path (if any).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -511,13 +583,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     patch:
       operationId: updateFoxxDependencies
       description: |
         Replaces the given service's dependencies.
 
         Returns an object mapping all dependency names to their new mount paths.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -531,14 +619,6 @@ paths:
                     A JSON object mapping dependency names to their new mount paths.
                     Any omitted dependencies will be ignored.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -551,13 +631,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     put:
       operationId: replaceFoxxDependencies
       description: |
         Replaces the given service's dependencies completely.
 
         Returns an object mapping all dependency names to their new mount paths.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -571,14 +667,6 @@ paths:
                     A JSON object mapping dependency names to their new mount paths.
                     Any omitted dependencies will be disabled.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -593,7 +681,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/scripts:
+  /_db/{database-name}/_api/foxx/scripts:
     get:
       operationId: listFoxxScripts
       description: |
@@ -601,6 +689,14 @@ paths:
 
         Returns an object mapping the raw script names to human-friendly names.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -620,25 +716,22 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/scripts/{name}:
+  /_db/{database-name}/_api/foxx/scripts/{name}:
     post:
       operationId: runFoxxScript
       description: |
         Runs the given script for the service at the given mount path.
 
         Returns the exports of the script, if any.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                data:
-                  description: |
-                    An arbitrary JSON value that will be parsed and passed to the
-                    script as its first argument.
-                  type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: name
           in: path
           required: true
@@ -653,6 +746,17 @@ paths:
             Mount path of the installed service.
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  description: |
+                    An arbitrary JSON value that will be parsed and passed to the
+                    script as its first argument.
+                  type: json
       responses:
         '200':
           description: |
@@ -665,7 +769,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/tests:
+  /_db/{database-name}/_api/foxx/tests:
     post:
       operationId: runFoxxTests
       description: |
@@ -692,6 +796,14 @@ paths:
 
         Otherwise the response body will be formatted as non-prettyprinted JSON.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -733,7 +845,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/development:
+  /_db/{database-name}/_api/foxx/development:
     post:
       operationId: enableFoxxDevelopmentMode
       description: |
@@ -748,6 +860,14 @@ paths:
         Coordinators. This means you should treat your Coordinators as inconsistent
         as long as any service is running in development mode.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -767,7 +887,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/development:
+  /_db/{database-name}/_api/foxx/development:
     delete:
       operationId: disableFoxxDevelopmentMode
       description: |
@@ -777,6 +897,14 @@ paths:
         replace the service on all other Coordinators with the version on this
         Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -796,12 +924,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/readme:
+  /_db/{database-name}/_api/foxx/readme:
     get:
       operationId: getFoxxReadme
       description: |
         Fetches the service's README or README.md file's contents if any.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -824,7 +960,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/swagger:
+  /_db/{database-name}/_api/foxx/swagger:
     get:
       operationId: getFoxxSwaggerDescription
       description: |
@@ -832,6 +968,14 @@ paths:
 
         The response body will be an OpenAPI 2.0 compatible JSON description of the service API.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -851,7 +995,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/download:
+  /_db/{database-name}/_api/foxx/download:
     post:
       operationId: downloadFoxxService
       description: |
@@ -862,6 +1006,14 @@ paths:
         Otherwise the bundle will represent the version of a service that
         is installed on that ArangoDB instance.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -884,7 +1036,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/commit:
+  /_db/{database-name}/_api/foxx/commit:
     post:
       operationId: commitFoxxServiceState
       description: |
@@ -892,6 +1044,14 @@ paths:
 
         This can be used to resolve service conflicts between Coordinators that cannot be fixed automatically due to missing data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: replace
           in: query
           required: false

--- a/site/content/3.12/develop/http-api/graphs/edges.md
+++ b/site/content/3.12/develop/http-api/graphs/edges.md
@@ -27,13 +27,21 @@ for details.
 
 ```openapi
 paths:
-  /_api/edges/{collection-id}:
+  /_db/{database-name}/_api/edges/{collection-id}:
     get:
       operationId: getVertexEdges
       description: |
         Returns an array of edges starting or ending in the vertex identified by
         `vertex`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-id
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.12/develop/http-api/graphs/named-graphs.md
@@ -30,11 +30,20 @@ The examples use the following example graphs:
 
 ```openapi
 paths:
-  /_api/gharial:
+  /_db/{database-name}/_api/gharial:
     get:
       operationId: listGraphs
       description: |
         Lists all graphs stored in this database.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -196,13 +205,21 @@ examples.dropGraph("routeplanner");
 
 ```openapi
 paths:
-  /_api/gharial:
+  /_db/{database-name}/_api/gharial:
     post:
       operationId: createGraph
       description: |
         The creation of a graph requires the name of the graph and a
         definition of its edges.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: waitForSync
           in: query
           required: false
@@ -907,7 +924,7 @@ graph._drop("satelliteGraph", true);
 
 ```openapi
 paths:
-  /_api/gharial/{graph}:
+  /_db/{database-name}/_api/gharial/{graph}:
     get:
       operationId: getGraph
       description: |
@@ -915,6 +932,14 @@ paths:
         Returns the edge definitions as well as the orphan collections,
         or returns an error if the graph does not exist.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1115,7 +1140,7 @@ graph._drop("myGraph", true);
 
 ```openapi
 paths:
-  /_api/gharial/{graph}:
+  /_db/{database-name}/_api/gharial/{graph}:
     delete:
       operationId: deleteGraph
       description: |
@@ -1123,6 +1148,14 @@ paths:
         Optionally all collections not used by other graphs
         can be dropped as well.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1256,12 +1289,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex:
+  /_db/{database-name}/_api/gharial/{graph}/vertex:
     get:
       operationId: listVertexCollections
       description: |
         Lists all vertex collections within this graph, including orphan collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1362,13 +1403,21 @@ by [adding a new edge definition](#add-an-edge-definition) or
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex:
+  /_db/{database-name}/_api/gharial/{graph}/vertex:
     post:
       operationId: addVertexCollection
       description: |
         Adds a vertex collection to the set of orphan collections of the graph.
         If the collection does not exist, it is created.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1782,7 +1831,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}:
     delete:
       operationId: deleteVertexCollection
       description: |
@@ -1795,6 +1844,14 @@ paths:
         edge definition first in order to fully remove a vertex collection from
         the graph.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2212,12 +2269,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge:
+  /_db/{database-name}/_api/gharial/{graph}/edge:
     get:
       operationId: listEdgeCollections
       description: |
         Lists all edge collections within this graph.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2312,7 +2377,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge:
+  /_db/{database-name}/_api/gharial/{graph}/edge:
     post:
       operationId: createEdgeDefinition
       description: |
@@ -2328,6 +2393,14 @@ paths:
 
         Additionally, collection creation options can be set.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2760,13 +2833,21 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     put:
       operationId: replaceEdgeDefinition
       description: |
         Change the vertex collections of one specific edge definition.
         This modifies all occurrences of this definition in all graphs known to your database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3215,7 +3296,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     delete:
       operationId: deleteEdgeDefinition
       description: |
@@ -3224,6 +3305,14 @@ paths:
         edge definition become orphan collections but otherwise remain untouched
         and can still be used in your queries.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3600,12 +3689,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}:
     post:
       operationId: createVertex
       description: |
         Adds a vertex to the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3886,12 +3983,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     get:
       operationId: getVertex
       description: |
         Gets a vertex from the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4151,12 +4256,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     patch:
       operationId: updateVertex
       description: |
         Updates the data of the specific vertex in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4550,12 +4663,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     put:
       operationId: replaceVertex
       description: |
         Replaces the data of a vertex in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4950,12 +5071,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     delete:
       operationId: deleteVertex
       description: |
         Removes a vertex from the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5235,7 +5364,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     post:
       operationId: createEdge
       description: |
@@ -5243,6 +5372,14 @@ paths:
         Within the body the edge has to contain a `_from` and `_to` value referencing to valid vertices in the graph.
         Furthermore, the edge has to be valid according to the edge definitions.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5608,12 +5745,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     get:
       operationId: getEdge
       description: |
         Gets an edge from the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5884,12 +6029,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     patch:
       operationId: updateEdge
       description: |
         Partially modify the data of the specific edge in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -6344,12 +6497,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     put:
       operationId: replaceEdge
       description: |
         Replaces the data of an edge in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -6814,12 +6975,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     delete:
       operationId: deleteEdge
       description: |
         Removes an edge from the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/hot-backups.md
+++ b/site/content/3.12/develop/http-api/hot-backups.md
@@ -23,11 +23,15 @@ most of all the [requirements and limitations](../../operations/backup-and-resto
 before using the API.
 {{< /warning >}}
 
+The permissions required to use the `/_admin/backup/*` endpoints depends on the
+setting of the [`--backup.options-api` startup option](../../components/arangodb-server/options.md#--serveroptions-api).
+
 ## Create a backup
 
 ```openapi
 paths:
   /_admin/backup/create:
+  # Independent of database
     post:
       operationId: createBackup
       description: |
@@ -124,6 +128,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/restore:
+  # Independent of database
     post:
       operationId: restoreBackup
       description: |
@@ -212,6 +217,7 @@ while (require("internal").time() - startTime < 10) {
 ```openapi
 paths:
   /_admin/backup/delete:
+  # Independent of database
     post:
       operationId: deleteBackup
       description: |
@@ -270,6 +276,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/list:
+  # Independent of database
     post:
       operationId: listBackups
       description: |
@@ -349,6 +356,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/upload:
+  # Independent of database
     post:
       operationId: uploadBackup
       description: |
@@ -500,6 +508,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/download:
+  # Independent of database
     post:
       operationId: downloadBackup
       description: |

--- a/site/content/3.12/develop/http-api/import.md
+++ b/site/content/3.12/develop/http-api/import.md
@@ -9,7 +9,7 @@ description: >-
 
 ```openapi
 paths:
-  /_api/import:
+  /_db/{database-name}/_api/import:
     post:
       operationId: importData
       description: |
@@ -36,6 +36,14 @@ paths:
                     multiple JSON objects separated by newlines.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/indexes/_index.md
+++ b/site/content/3.12/develop/http-api/indexes/_index.md
@@ -27,7 +27,7 @@ http://localhost:8529/_api/index/demo/63563528
 
 ```openapi
 paths:
-  /_api/index:
+  /_db/{database-name}/_api/index:
     get:
       operationId: listIndexes
       description: |
@@ -36,6 +36,14 @@ paths:
         available in the `identifiers` attribute as an object with the index identifiers
         as object keys.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -94,7 +102,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/index/{index-id}:
+  /_db/{database-name}/_api/index/{index-id}:
     get:
       operationId: getIndex
       description: |
@@ -109,6 +117,14 @@ paths:
         `unique` or `sparse` flags, whereas others don't. Some indexes also provide
         a selectivity estimate in the `selectivityEstimate` attribute of the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: index-id
           in: path
           required: true
@@ -152,7 +168,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/index:
+  /_db/{database-name}/_api/index:
     post:
       operationId: createIndex
       description: |
@@ -232,6 +248,14 @@ paths:
         in the background, which will not write-lock the underlying collection for
         as long as if the index is built in the foreground.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -274,12 +298,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/index/{index-id}:
+  /_db/{database-name}/_api/index/{index-id}:
     delete:
       operationId: deleteIndex
       description: |
         Deletes an index with `index-id`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: index-id
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/indexes/fulltext.md
+++ b/site/content/3.12/develop/http-api/indexes/fulltext.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#fulltext:
+  /_db/{database-name}/_api/index#fulltext:
     post:
       operationId: createIndexFulltext
       description: |
@@ -20,6 +20,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/indexes/geo-spatial.md
+++ b/site/content/3.12/develop/http-api/indexes/geo-spatial.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#geo:
+  /_db/{database-name}/_api/index#geo:
     post:
       operationId: createIndexGeo
       description: |
@@ -19,6 +19,14 @@ paths:
         the index attributes or have non-numeric values in the index attributes
         will not be indexed.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/indexes/inverted.md
+++ b/site/content/3.12/develop/http-api/indexes/inverted.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#inverted:
+  /_db/{database-name}/_api/index#inverted:
     post:
       operationId: createIndexInverted
       description: |
@@ -16,6 +16,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/indexes/multi-dimensional.md
+++ b/site/content/3.12/develop/http-api/indexes/multi-dimensional.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#mdi:
+  /_db/{database-name}/_api/index#mdi:
     post:
       operationId: createIndexMdi
       description: |
@@ -16,6 +16,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/indexes/persistent.md
+++ b/site/content/3.12/develop/http-api/indexes/persistent.md
@@ -14,7 +14,7 @@ removed in a future version.
 
 ```openapi
 paths:
-  /_api/index#persistent:
+  /_db/{database-name}/_api/index#persistent:
     post:
       operationId: createIndexPersistent
       description: |
@@ -36,6 +36,14 @@ paths:
         Unique indexes on non-shard keys are not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/indexes/ttl.md
+++ b/site/content/3.12/develop/http-api/indexes/ttl.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#ttl:
+  /_db/{database-name}/_api/index#ttl:
     post:
       operationId: createIndexTtl
       description: |
@@ -16,6 +16,14 @@ paths:
         does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/jobs.md
+++ b/site/content/3.12/develop/http-api/jobs.md
@@ -5,6 +5,7 @@ weight: 80
 description: >-
   The HTTP API for jobs lets you access the results of asynchronously executed
   requests and check the status of such jobs
+# All /_api/job* endpoints are also available via /_admin/job*
 ---
 For an introduction to non-blocking execution of requests and how to create
 async jobs with the `x-arango-async` request header, see
@@ -14,7 +15,7 @@ async jobs with the `x-arango-async` request header, see
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     put:
       operationId: getJobResult
       description: |
@@ -28,6 +29,16 @@ paths:
         the header is not present, the job was not found and the response contains
         status information from the job manager.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -148,13 +159,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}/cancel:
+  /_db/{database-name}/_api/job/{job-id}/cancel:
     put:
       operationId: cancelJob
       description: |
         Cancels the currently running job identified by job-id. Note that it still
         might take some time to actually cancel the running async job.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -216,7 +237,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     delete:
       operationId: deleteJob
       description: |
@@ -225,6 +246,16 @@ paths:
         Clients can use this method to perform an eventual garbage collection of job
         results.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -350,7 +381,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     get:
       operationId: getJob
       description: |
@@ -360,6 +391,16 @@ paths:
         - The IDs of async jobs with a specific status
         - The processing status of a specific async job
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/monitoring/logs.md
+++ b/site/content/3.12/develop/http-api/monitoring/logs.md
@@ -12,6 +12,9 @@ on the [log startup options](../../../components/arangodb-server/options.md#log)
 See [Log levels](../../../operations/administration/log-levels.md) for a detailed
 description of the `FATAL`, `ERROR`, and other levels of log messages.
 
+The permissions required to use the `/_admin/log*` endpoints depends on the
+setting of the [`--log.api-enabled` startup option](../../../components/arangodb-server/options.md#--logapi-enabled).
+
 ## Get the global server logs
 
 ```openapi

--- a/site/content/3.12/develop/http-api/monitoring/metrics.md
+++ b/site/content/3.12/develop/http-api/monitoring/metrics.md
@@ -19,13 +19,19 @@ coupled to specific internals that may be replaced by other mechanisms in the
 future.
 {{< /warning >}}
 
+Whether the `/_admin/metrics*` endpoints are available depends on the setting of
+the [`--server.export-metrics-api` startup option](../../../components/arangodb-server/options.md#--serverexport-metrics-api).
+For additional document read and write metrics, the
+[`--server.export-read-write-metrics` startup option](../../../components/arangodb-server/options.md#--serverexport-read-write-metrics)
+needs to be enabled.
+
 ## Metrics API v2
 
 ### Get the metrics
 
 ```openapi
 paths:
-  /_admin/metrics/v2:
+  /_db/{database-name}/_admin/metrics/v2:
     get:
       operationId: getMetricsV2
       description: |
@@ -41,6 +47,17 @@ paths:
         The API then needs to be added to the Prometheus configuration file
         for collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false
@@ -83,7 +100,7 @@ logPlainResponse(response);
 
 ```openapi
 paths:
-  /_admin/usage-metrics:
+  /_db/{database-name}/_admin/usage-metrics:
     get:
       operationId: getUsageMetrics
       description: |
@@ -94,6 +111,17 @@ paths:
         usage metrics, or to `enabled-per-shard-per-user` to make DB-Servers collect
         usage metrics per shard and per user whenever a shard is accessed.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false
@@ -116,7 +144,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/metrics:
+  /_db/{database-name}/_admin/metrics:
     get:
       operationId: getMetrics
       description: |
@@ -138,6 +166,17 @@ paths:
         The API then needs to be added to the Prometheus configuration file
         for collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false

--- a/site/content/3.12/develop/http-api/monitoring/statistics.md
+++ b/site/content/3.12/develop/http-api/monitoring/statistics.md
@@ -10,7 +10,7 @@ description: >-
 
 ```openapi
 paths:
-  /_admin/statistics:
+  /_db/{database-name}/_admin/statistics:
     get:
       operationId: getStatistics
       description: |
@@ -42,6 +42,18 @@ paths:
         expect in a cluster setup using a single Coordinator querying this Coordinator.
         Just with the difference that cluster transactions have no notion of
         intermediate commits and will not increase the value.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -525,7 +537,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/statistics-description:
+  /_db/{database-name}/_admin/statistics-description:
     get:
       operationId: getStatisticsDescription
       description: |
@@ -554,6 +566,18 @@ paths:
         - `type`: Either `current`, `accumulated`, or `distribution`.
         - `cuts`: The distribution vector.
         - `units`: Units in which the figure is measured.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.12/develop/http-api/queries/aql-queries.md
@@ -268,7 +268,7 @@ the cursor, even before you requested the last batch.
 
 ```openapi
 paths:
-  /_api/cursor:
+  /_db/{database-name}/_api/cursor:
     post:
       operationId: createAqlQueryCursor
       description: |
@@ -280,6 +280,14 @@ paths:
         bind parameters. These values need to be passed in a JSON representation in
         the body of the POST request.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: x-arango-allow-dirty-read
           in: header
           required: false
@@ -1323,7 +1331,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     post:
       operationId: getNextAqlQueryCursorBatch
       description: |
@@ -1332,6 +1340,14 @@ paths:
         If the cursor is not fully consumed, the time-to-live for the cursor
         is renewed by this API call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -1805,7 +1821,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     put:
       operationId: getNextAqlQueryCursorBatchPut
       description: |
@@ -1836,6 +1852,14 @@ paths:
         If the cursor is not fully consumed, the time-to-live for the cursor
         is renewed by this API call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -1936,7 +1960,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}/{batch-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}/{batch-identifier}:
     post:
       operationId: getPreviousAqlQueryCursorBatch
       description: |
@@ -1967,6 +1991,14 @@ paths:
 
         The time-to-live for the cursor is renewed by this API call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -2481,7 +2513,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     delete:
       operationId: deleteAqlQueryCursor
       description: |
@@ -2495,6 +2527,14 @@ paths:
         Note: the server will also destroy abandoned cursors automatically after a
         certain server-controlled timeout to avoid resource leakage.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -2557,7 +2597,7 @@ list.
 
 ```openapi
 paths:
-  /_api/query/properties:
+  /_db/{database-name}/_api/query/properties:
     get:
       operationId: getAqlQueryTrackingProperties
       description: |
@@ -2588,6 +2628,15 @@ paths:
           list of queries. Query strings can have arbitrary lengths, and this property
           can be used to save memory in case very long query strings are used. The
           value is specified in bytes.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -2603,7 +2652,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/properties:
+  /_db/{database-name}/_api/query/properties:
     put:
       operationId: updateAqlQueryTrackingProperties
       description: |
@@ -2612,6 +2661,15 @@ paths:
 
         After the properties have been changed, the current set of properties will
         be returned in the HTTP response.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2677,7 +2735,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/current:
+  /_db/{database-name}/_api/query/current:
     get:
       operationId: listAqlQueries
       description: |
@@ -2717,13 +2775,21 @@ paths:
 
         - `stream`: whether or not the query uses a streaming cursor
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will return the currently running queries in all databases,
             not just the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2746,7 +2812,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/slow:
+  /_db/{database-name}/_api/query/slow:
     get:
       operationId: listSlowAqlQueries
       description: |
@@ -2780,13 +2846,21 @@ paths:
 
         - `stream`: whether or not the query uses a streaming cursor
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will return the slow queries from all databases, not just
             the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2809,19 +2883,27 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/slow:
+  /_db/{database-name}/_api/query/slow:
     delete:
       operationId: clearSlowAqlQueryList
       description: |
         Clears the list of slow AQL queries for the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will clear the slow query history in all databases, not just
             the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2848,13 +2930,21 @@ soon as it reaches a cancelation point.
 
 ```openapi
 paths:
-  /_api/query/{query-id}:
+  /_db/{database-name}/_api/query/{query-id}:
     delete:
       operationId: deleteAqlQuery
       description: |
         Kills a running query in the currently selected database. The query will be
         terminated at the next cancelation point.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: query-id
           in: path
           required: true
@@ -2868,7 +2958,7 @@ paths:
           description: |
             If set to `true`, will attempt to kill the specified query in all databases,
             not just the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2904,7 +2994,7 @@ You can also retrieve a list of all query optimizer rules and their properties.
 
 ```openapi
 paths:
-  /_api/explain:
+  /_db/{database-name}/_api/explain:
     post:
       operationId: explainAqlQuery
       description: |
@@ -2946,6 +3036,15 @@ paths:
 
         - `variables`: array of variables used in the query (note: this may contain
           internal variables created by the optimizer)
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3194,12 +3293,23 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/query:
+  /_db/{database-name}/_api/query:
     post:
       operationId: parseAqlQuery
       description: |
         This endpoint is for query validation only. To actually query the database,
         see `/api/cursor`.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3273,11 +3383,22 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/query/rules:
+  /_db/{database-name}/_api/query/rules:
     get:
       operationId: getAqlQueryOptimizerRules
       description: |
         A list of all optimizer rules and their properties.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/queries/aql-query-results-cache.md
+++ b/site/content/3.12/develop/http-api/queries/aql-query-results-cache.md
@@ -9,7 +9,7 @@ description: >-
 
 ```openapi
 paths:
-  /_api/query-cache/entries:
+  /_db/{database-name}/_api/query-cache/entries:
     get:
       operationId: listQueryCacheResults
       description: |
@@ -28,6 +28,15 @@ paths:
           again afterwards)
         - `runTime`: the query's run time
         - `dataSources`: an array of collections/Views the query was using
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -43,11 +52,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache:
+  /_db/{database-name}/_api/query-cache:
     delete:
       operationId: deleteAqlQueryCache
       description: |
         Clears all results stored in the AQL query results cache for the current database.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -64,7 +82,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache/properties:
+  /_db/{database-name}/_api/query-cache/properties:
     get:
       operationId: getQueryCacheProperties
       description: |
@@ -85,6 +103,17 @@ paths:
 
         - `includeSystem`: whether or not results of queries that involve system collections will be
           stored in the query results cache.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -100,7 +129,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache/properties:
+  /_db/{database-name}/_api/query-cache/properties:
     put:
       operationId: setQueryCacheProperties
       description: |
@@ -114,6 +143,17 @@ paths:
         The properties need to be passed in the `properties` attribute in the body
         of the HTTP request. `properties` needs to be a JSON object with the following
         properties:
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.12/develop/http-api/queries/user-defined-aql-functions.md
+++ b/site/content/3.12/develop/http-api/queries/user-defined-aql-functions.md
@@ -20,7 +20,7 @@ collection directly, but only via the dedicated interfaces.
 
 ```openapi
 paths:
-  /_api/aqlfunction:
+  /_db/{database-name}/_api/aqlfunction:
     post:
       operationId: createAqlUserFunction
       description: |
@@ -29,6 +29,15 @@ paths:
 
         In case of success, HTTP 200 is returned.
         If the function isn't valid etc. HTTP 400 including a detailed error message will be returned.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -164,13 +173,21 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/aqlfunction/{name}:
+  /_db/{database-name}/_api/aqlfunction/{name}:
     delete:
       operationId: deleteAqlUserFunction
       description: |
         Deletes an existing user-defined function (UDF) or function group identified by
         `name` from the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: name
           in: path
           required: true
@@ -319,7 +336,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/aqlfunction:
+  /_db/{database-name}/_api/aqlfunction:
     get:
       operationId: listAqlUserFunctions
       description: |
@@ -328,6 +345,14 @@ paths:
 
         The call returns a JSON array with status codes and all user functions found under `result`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: namespace
           in: query
           required: false

--- a/site/content/3.12/develop/http-api/replication/other-replication-commands.md
+++ b/site/content/3.12/develop/http-api/replication/other-replication-commands.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/replication/server-id:
+  /_db/{database-name}/_api/replication/server-id:
     get:
       operationId: getReplicationServerId
       description: |
@@ -17,6 +17,15 @@ paths:
 
         The body of the response is a JSON object with the attribute `serverId`. The
         server id is returned as a string.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/replication/replication-applier.md
+++ b/site/content/3.12/develop/http-api/replication/replication-applier.md
@@ -11,7 +11,7 @@ configuration of an ArangoDB database's replication applier.
 
 ```openapi
 paths:
-  /_api/replication/applier-config:
+  /_db/{database-name}/_api/replication/applier-config:
     get:
       operationId: getReplicationApplierConfig
       description: |
@@ -109,6 +109,14 @@ paths:
         - `restrictCollections`: the optional array of collections to include or exclude,
           based on the setting of `restrictType`
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -150,7 +158,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-config:
+  /_db/{database-name}/_api/replication/applier-config:
     put:
       operationId: updateReplicationApplierConfig
       description: |
@@ -162,6 +170,14 @@ paths:
         In case of success, the body of the response is a JSON object with the updated
         configuration.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -380,7 +396,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-start:
+  /_db/{database-name}/_api/replication/applier-start:
     put:
       operationId: startReplicationApplier
       description: |
@@ -396,6 +412,14 @@ paths:
         To detect replication applier errors after the applier was started, use the
         `/_api/replication/applier-state` API instead.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -462,13 +486,21 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-stop:
+  /_db/{database-name}/_api/replication/applier-stop:
     put:
       operationId: stopReplicationApplier
       description: |
         Stops the replication applier. This will return immediately if the
         replication applier is not running.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -522,7 +554,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-state:
+  /_db/{database-name}/_api/replication/applier-state:
     get:
       operationId: getReplicationApplierState
       description: |
@@ -621,6 +653,14 @@ paths:
         values are only meaningful when compared to each other. Higher tick values mean
         "later in time" than lower tick values.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -684,7 +724,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/make-follower:
+  /_db/{database-name}/_api/replication/make-follower:
     put:
       operationId: makeReplicationFollower
       description: |
@@ -804,6 +844,15 @@ paths:
         {{</* info */>}}
         This endpoint is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.12/develop/http-api/replication/replication-dump.md
+++ b/site/content/3.12/develop/http-api/replication/replication-dump.md
@@ -16,7 +16,7 @@ or the incremental data synchronization.
 
 ```openapi
 paths:
-  /_api/replication/inventory:
+  /_db/{database-name}/_api/replication/inventory:
     get:
       operationId: getReplicationInventory
       description: |
@@ -100,6 +100,14 @@ paths:
         under which each key represents a database name, and the value conforms to the above description.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: includeSystem
           in: query
           required: false
@@ -153,7 +161,7 @@ dumped.
 
 ```openapi
 paths:
-  /_api/replication/batch:
+  /_db/{database-name}/_api/replication/batch:
     post:
       operationId: createReplicationBatch
       description: |
@@ -177,6 +185,14 @@ paths:
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: state
           in: query
           required: false
@@ -218,7 +234,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/batch/{id}:
+  /_db/{database-name}/_api/replication/batch/{id}:
     delete:
       operationId: deleteReplicationBatch
       description: |
@@ -235,6 +251,14 @@ paths:
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -260,7 +284,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/batch/{id}:
+  /_db/{database-name}/_api/replication/batch/{id}:
     put:
       operationId: extendReplicationBatch
       description: |
@@ -279,6 +303,22 @@ paths:
         The very same request is forwarded synchronously to that DB-Server.
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: |
+            The id of the batch.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -291,14 +331,6 @@ paths:
                   description: |
                     the time-to-live for the new batch (in seconds)
                   type: integer
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: |
-            The id of the batch.
-          schema:
-            type: string
       responses:
         '204':
           description: |
@@ -333,7 +365,7 @@ parts of the dump results in the same order as they are provided.
 
 ```openapi
 paths:
-  /_api/replication/dump:
+  /_db/{database-name}/_api/replication/dump:
     get:
       operationId: getReplicationDump
       description: |
@@ -378,6 +410,14 @@ paths:
         There will be no distinction between inserts and updates when calling this method.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -425,7 +465,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/tree:
+  /_db/{database-name}/_api/replication/revisions/tree:
     get:
       operationId: getReplicationRevisionTree
       description: |
@@ -467,6 +507,14 @@ paths:
         root is at index `0`, its children at indices `[1, branchingFactor]`, and so
         on.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -508,7 +556,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/tree:
+  /_db/{database-name}/_api/replication/revisions/tree:
     post:
       operationId: rebuildReplicationRevisionTree
       description: |
@@ -521,6 +569,14 @@ paths:
 
         If successful, there will be no return body.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -555,7 +611,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/ranges:
+  /_db/{database-name}/_api/replication/revisions/ranges:
     put:
       operationId: listReplicationRevisionRanges
       description: |
@@ -613,6 +669,14 @@ paths:
         in JavaScript, as it handles all numbers as floating point, and can only
         represent up to `2^53-1` faithfully.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -661,7 +725,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/documents:
+  /_db/{database-name}/_api/replication/revisions/documents:
     put:
       operationId: listReplicationRevisionDocuments
       description: |
@@ -701,6 +765,14 @@ paths:
         in JavaScript, as it handles all numbers as floating point, and can only
         represent up to `2^53-1` faithfully.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -742,7 +814,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/sync:
+  /_db/{database-name}/_api/replication/sync:
     put:
       operationId: startReplicationSync
       description: |
@@ -778,6 +850,15 @@ paths:
         {{</* info */>}}
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -864,7 +945,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/clusterInventory:
+  /_db/{database-name}/_api/replication/clusterInventory:
     get:
       operationId: getReplicationClusterInventory
       description: |
@@ -876,6 +957,14 @@ paths:
         just that the `indexes` attribute there is relocated to adjust it to
         the data format of arangodump.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: includeSystem
           in: query
           required: false

--- a/site/content/3.12/develop/http-api/replication/replication-logger.md
+++ b/site/content/3.12/develop/http-api/replication/replication-logger.md
@@ -24,7 +24,7 @@ by a tick *date*) is still available on the Leader.
 
 ```openapi
 paths:
-  /_api/replication/logger-state:
+  /_db/{database-name}/_api/replication/logger-state:
     get:
       operationId: getReplicationLoggerState
       description: |
@@ -65,6 +65,15 @@ paths:
           - `lastServedTick`: last tick value served to this client via the WAL tailing API
 
           - `time`: date and time when this client last called the WAL tailing API
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -102,7 +111,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-follow:
+  /_db/{database-name}/_api/replication/logger-follow:
     get:
       operationId: getReplicationLoggerFollow
       description: |
@@ -202,6 +211,14 @@ paths:
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: from
           in: query
           required: false
@@ -334,7 +351,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-first-tick:
+  /_db/{database-name}/_api/replication/logger-first-tick:
     get:
       operationId: getReplicationLoggerFirstTick
       description: |
@@ -351,6 +368,15 @@ paths:
         {{</* info */>}}
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -388,7 +414,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-tick-ranges:
+  /_db/{database-name}/_api/replication/logger-tick-ranges:
     get:
       operationId: getReplicationLoggerTickRanges
       description: |
@@ -407,6 +433,15 @@ paths:
         - `tickMin`: minimum tick value contained in logfile
 
         - `tickMax`: maximum tick value contained in logfile
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/replication/write-ahead-log.md
+++ b/site/content/3.12/develop/http-api/replication/write-ahead-log.md
@@ -47,17 +47,6 @@ paths:
             `_system` database.
           schema:
             type: string
-        - name: database-name
-          in: path
-          required: true
-          example: _system
-          description: |
-            The name of a database. Which database you use doesn't matter as long
-            as the user account you authenticate with has at least read access
-            to this database. If the `--server.harden` startup option is enabled,
-            administrate access to the `_system` database is required.
-          schema:
-            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/replication/write-ahead-log.md
+++ b/site/content/3.12/develop/http-api/replication/write-ahead-log.md
@@ -23,7 +23,7 @@ full cluster and can thus not be removed until Replication 1 is gone.
 
 ```openapi
 paths:
-  /_api/wal/range:
+  /_db/{database-name}/_api/wal/range:
     get:
       operationId: getWalRange
       description: |
@@ -36,6 +36,28 @@ paths:
         - `tickMax`: maximum tick available
         - `time`: the server time as string in format `YYYY-MM-DDTHH:MM:SSZ`
         - `server`: An object with fields `version` and `serverId`
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -74,7 +96,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/wal/lastTick:
+  /_db/{database-name}/_api/wal/lastTick:
     get:
       operationId: getWalLastTick
       description: |
@@ -89,6 +111,17 @@ paths:
         {{</* info */>}}
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -126,7 +159,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/wal/tail:
+  /_db/{database-name}/_api/wal/tail:
     get:
       operationId: getWalTail
       description: |
@@ -232,6 +265,16 @@ paths:
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false

--- a/site/content/3.12/develop/http-api/security.md
+++ b/site/content/3.12/develop/http-api/security.md
@@ -111,7 +111,7 @@ paths:
         new user key.
 
         This is a protected API and can only be executed with superuser rights.
-        This API is not available on coordinator nodes.
+        This API is not available on Coordinator nodes.
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/security.md
+++ b/site/content/3.12/develop/http-api/security.md
@@ -20,7 +20,7 @@ See [Audit logging](../../operations/security/audit-logging.md#configuration).
 
 ```openapi
 paths:
-  /_admin/server/tls:
+  /_db/{database-name}/_admin/server/tls:
     get:
       operationId: getServerTls
       description: |
@@ -48,6 +48,18 @@ paths:
             JSON string with the SHA256 of the private key.
 
         This API requires authentication.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -61,6 +73,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/tls:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: reloadServerTls
       description: |
@@ -88,6 +101,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/encryption:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: rotateEncryptionAtRestKey
       description: |

--- a/site/content/3.12/develop/http-api/tasks.md
+++ b/site/content/3.12/develop/http-api/tasks.md
@@ -10,11 +10,22 @@ description: >-
 
 ```openapi
 paths:
-  /_api/tasks/:
+  /_db/{database-name}/_api/tasks/:
     get:
       operationId: listTasks
       description: |
         fetches all existing tasks on the server
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -96,12 +107,22 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     get:
       operationId: getTask
       description: |
         fetches one existing task on the server specified by `id`
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -202,11 +223,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/tasks:
+  /_db/{database-name}/_api/tasks:
     post:
       operationId: createTask
       description: |
         creates a new task with a generated id
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -325,15 +355,14 @@ assert(response.code === 200);
 logJsonResponse(response);
 
 // Cleanup:
-logCurlRequest('DELETE', url + response.parsedBody.id);
-
+curlRequest('DELETE', url + response.parsedBody.id);
 ```
 
 ## Create a task with ID
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     put:
       operationId: createTaskWithId
       description: |
@@ -341,6 +370,14 @@ paths:
 
         Not compatible with load balancers.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -417,12 +454,22 @@ curlRequest('DELETE', url + 'sampleTask');
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     delete:
       operationId: deleteTask
       description: |
         Deletes the task identified by `id` on the server.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has administrate access
+            to this database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/transactions/javascript-transactions.md
+++ b/site/content/3.12/develop/http-api/transactions/javascript-transactions.md
@@ -28,7 +28,7 @@ refer to [Transactions](../../transactions/_index.md).
 
 ```openapi
 paths:
-  /_api/transaction:
+  /_db/{database-name}/_api/transaction:
     post:
       operationId: executeJavaScriptTransaction
       description: |
@@ -72,6 +72,15 @@ paths:
         an error.
         Any other errors will be returned with any of the return codes
         *HTTP 400*, *HTTP 409*, or *HTTP 500*.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.12/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/3.12/develop/http-api/transactions/stream-transactions.md
@@ -37,7 +37,7 @@ Supported transactional API operations include:
 
 ```openapi
 paths:
-  /_api/transaction/begin:
+  /_db/{database-name}/_api/transaction/begin:
     post:
       operationId: beginStreamTransaction
       description: |
@@ -79,6 +79,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: x-arango-allow-dirty-read
           in: header
           required: false
@@ -106,7 +114,7 @@ paths:
                     transaction must be declared with the `write` or `exclusive` attribute or it
                     will fail, whereas non-declared collections from which is solely read will be
                     added lazily.
-                  type: string
+                  type: object
                 waitForSync:
                   description: |
                     an optional boolean flag that, if set, will force the
@@ -197,7 +205,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     get:
       operationId: getStreamTransaction
       description: |
@@ -208,6 +216,14 @@ paths:
 
         - `status`: the status of the transaction. One of "running", "committed" or "aborted".
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -263,7 +279,7 @@ db._drop("products");
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     put:
       operationId: commitStreamTransaction
       description: |
@@ -297,6 +313,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -356,7 +380,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     delete:
       operationId: abortStreamTransaction
       description: |
@@ -390,6 +414,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -449,7 +481,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/transaction:
+  /_db/{database-name}/_api/transaction:
     get:
       operationId: listStreamTransactions
       description: |
@@ -461,6 +493,15 @@ paths:
 
         - `id`: the transaction's id
         - `state`: the transaction's status
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/users.md
+++ b/site/content/3.12/develop/http-api/users.md
@@ -6,6 +6,8 @@ description: >-
   The HTTP API for user management lets you create, modify, delete, and list
   ArangoDB user accounts, as well as grant and revoke permissions for databases
   and collections
+# GET|PUT|DELETE /_api/user/{user}/config and GET /_api/user/{user}/config/{key}
+# endpoints not documented on purpose because they are only used by the web interface
 ---
 The interface provides the means to manage database system users. All
 users managed through this interface are stored in the protected `_users`
@@ -29,12 +31,23 @@ User management operations are not included in ArangoDB's replication.
 
 ```openapi
 paths:
-  /_api/user:
+  /_db/{database-name}/_api/user:
     post:
       operationId: createUser
       description: |
         Create a new user. You need server access level *Administrate* in order to
         execute this REST call.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -108,7 +121,7 @@ require("@arangodb/users").remove("admin@example");
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     put:
       operationId: replaceUserData
       description: |
@@ -116,6 +129,16 @@ paths:
         *Administrate* in order to execute this REST call. Additionally, users can
         change their own data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -193,7 +216,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     patch:
       operationId: updateUserData
       description: |
@@ -201,6 +224,16 @@ paths:
         *Administrate* in order to execute this REST call. Additionally, users can
         change their own data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -276,7 +309,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     delete:
       operationId: deleteUser
       description: |
@@ -285,6 +318,16 @@ paths:
         You need *Administrate* permissions for the server access level in order to
         execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -333,7 +376,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     get:
       operationId: getUser
       description: |
@@ -341,6 +384,16 @@ paths:
         yourself or you need the *Administrate* server access level in order to
         execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -390,7 +443,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/:
+  /_db/{database-name}/_api/user/:
     get:
       operationId: listUsers
       description: |
@@ -405,6 +458,17 @@ paths:
         - `active`: An optional flag that specifies whether the user is active.
         - `extra`: A JSON object with extra user information. It is used by the web
           interface to store graph viewer settings and saved queries.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -441,7 +505,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     put:
       operationId: setUserDatabasePermissions
       description: |
@@ -463,6 +527,16 @@ paths:
                     - Use "none" to set the database access level to *No access*.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -474,7 +548,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to set the access level for.
           schema:
             type: string
       responses:
@@ -521,7 +595,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     put:
       operationId: setUserCollectionPermissions
       description: |
@@ -545,6 +619,16 @@ paths:
                     Use "none" to set the collection level access to *No access*.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -556,14 +640,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to set the access level for.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection.
+            The name of the collection to set the access level for.
           schema:
             type: string
       responses:
@@ -614,7 +698,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     delete:
       operationId: deleteUserDatabasePermissions
       description: |
@@ -625,6 +709,16 @@ paths:
         You need write permissions (*Administrate* access level) for the `_system`
         database in order to execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -636,7 +730,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to clear the access level for.
           schema:
             type: string
       responses:
@@ -676,7 +770,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     delete:
       operationId: deleteUserCollectionPermissions
       description: |
@@ -688,6 +782,16 @@ paths:
         You need write permissions (*Administrate* access level) for the `_system`
         database in order to execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -699,14 +803,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to clear the access level for.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection.
+            The name of the collection to clear the access level for.
           schema:
             type: string
       responses:
@@ -749,7 +853,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/:
+  /_db/{database-name}/_api/user/{user}/database/:
     get:
       operationId: listUserDatabases
       description: |
@@ -766,6 +870,16 @@ paths:
         In case you specified `full`, the result will contain the permissions
         for the databases as well as the permissions for the collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -843,12 +957,22 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     get:
       operationId: getUserDatabasePermissions
       description: |
         Fetch the database access level for a specific database
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -860,7 +984,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database to query
+            The name of the database to query the access level of.
           schema:
             type: string
       responses:
@@ -906,12 +1030,22 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     get:
       operationId: getUserCollectionPermissions
       description: |
         Returns the collection access level for a specific collection
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -923,14 +1057,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database to query
+            The name of the database to query the access level of.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection
+            The name of the collection to query the access level of.
           schema:
             type: string
       responses:

--- a/site/content/3.12/develop/http-api/views/arangosearch-views.md
+++ b/site/content/3.12/develop/http-api/views/arangosearch-views.md
@@ -10,12 +10,21 @@ description: >-
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     post:
       operationId: createView
       description: |
         Creates a new View with a given name and properties if it does not
         already exist.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -680,12 +689,20 @@ db._dropView("products");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     get:
       operationId: getView
       description: |
         Returns the basic information about a specific View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -810,12 +827,20 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     get:
       operationId: getViewProperties
       description: |
         Returns an object containing the definition of the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -1164,12 +1189,21 @@ db._drop("books");
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     get:
       operationId: listViews
       description: |
         Returns an object containing a listing of all Views in the current database,
         regardless of their type.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1253,12 +1287,20 @@ db._dropView("reviewsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     put:
       operationId: replaceViewProperties
       description: |
         Changes all properties of a View by replacing them, except for immutable properties.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -1719,12 +1761,20 @@ db._dropView(view.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     patch:
       operationId: updateViewProperties
       description: |
         Partially changes the properties of a View by updating the specified attributes.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -2185,8 +2235,9 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/rename:
+  /_db/{database-name}/_api/view/{view-name}/rename:
     put:
+    # The PATCH method can be used as an alias
       operationId: renameView
       description: |
         Renames a View.
@@ -2195,6 +2246,14 @@ paths:
         Renaming Views is not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -2521,12 +2580,20 @@ db._dropView("catalogView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     delete:
       operationId: deleteView
       description: |
         Deletes the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true

--- a/site/content/3.12/develop/http-api/views/search-alias-views.md
+++ b/site/content/3.12/develop/http-api/views/search-alias-views.md
@@ -10,12 +10,21 @@ description: >-
 
 ```openapi
 paths:
-  /_api/view#searchalias:
+  /_db/{database-name}/_api/view#searchalias:
     post:
       operationId: createViewSearchAlias
       description: |
         Creates a new View with a given name and properties if it does not
         already exist.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -200,12 +209,20 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     get:
       operationId: getView
       description: |
         Returns the basic information about a specific View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -331,12 +348,20 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     get:
       operationId: getViewPropertiesSearchAlias
       description: |
         Returns an object containing the definition of the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -504,12 +529,21 @@ db._drop("books");
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     get:
       operationId: listViews
       description: |
         Returns an object containing a listing of all Views in the current database,
         regardless of their type.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -593,12 +627,20 @@ db._dropView("reviewsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     put:
       operationId: replaceViewPropertiesSearchAlias
       description: |
         Replaces the list of indexes of a `search-alias` View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -774,12 +816,20 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     patch:
       operationId: updateViewPropertiesSearchAlias
       description: |
         Updates the list of indexes of a `search-alias` View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -963,8 +1013,9 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/rename:
+  /_db/{database-name}/_api/view/{view-name}/rename:
     put:
+    # The PATCH method can be used as an alias
       operationId: renameView
       description: |
         Renames a View.
@@ -973,6 +1024,14 @@ paths:
         Renaming Views is not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -1116,12 +1175,20 @@ db._dropView("catalogView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     delete:
       operationId: deleteView
       description: |
         Deletes the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/administration.md
+++ b/site/content/3.13/develop/http-api/administration.md
@@ -5,6 +5,7 @@ weight: 110
 description: >-
   You can get information about ArangoDB servers, toggle the maintenance mode,
   shut down server nodes, and start actions like compaction
+# Internal /_admin/debug and /_api/test endpoints for maintainers not documented on purpose
 ---
 ## Information
 
@@ -12,21 +13,34 @@ description: >-
 
 ```openapi
 paths:
-  /_api/version:
+  /_db/{database-name}/_api/version:
+  # /_admin/version is an (undocumented) alias
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getVersion
       description: |
         Returns the server name and version number. The response is a JSON object
         with the following attributes:
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: details
           in: query
           required: false
           description: |
-            If set to `true`, the response will contain a `details` attribute with
-            additional information about included components and their versions. The
-            attribute names and internals of the `details` object may vary depending on
-            platform and ArangoDB version.
+            If set to `true` and if the user account you authenticate with has
+            administrate access to the `_system` database, the response contains
+            a `details` attribute with additional information about included
+            components and their versions. The attribute names and internals of
+            the `details` object may vary depending on platform and ArangoDB version.
           schema:
             type: boolean
       responses:
@@ -222,12 +236,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/engine:
+  /_db/{database-name}/_api/engine:
     get:
       operationId: getEngine
       description: |
         Returns the storage engine the server is configured to use.
         The response is a JSON object with the following attributes:
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -266,12 +291,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/time:
+  /_db/{database-name}/_admin/time:
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getTime
       description: |
         The call returns an object with the `time` attribute. This contains the
         current system time as a Unix timestamp with microsecond precision.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -305,11 +342,24 @@ paths:
 
 ```openapi
 paths:
-  /_admin/status:
+  /_db/{database-name}/_admin/status:
     get:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getStatus
       description: |
         Returns status information about the server.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -541,6 +591,7 @@ logJsonResponse(response);
 ```openapi
 paths:
   /_admin/server/availability:
+  # Independent of database
     get:
       operationId: getServerAvailability
       description: |
@@ -575,8 +626,9 @@ paths:
 
 ```openapi
 paths:
-  /_admin/support-info:
+  /_db/_system/_admin/support-info:
     get:
+      # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: getSupportInfo
       description: |
         Retrieves deployment information for support purposes. The endpoint returns data
@@ -659,11 +711,14 @@ logJsonResponse(response);
 
 ## Startup options
 
+The permissions required to use the `/_admin/options*` endpoints depends on the
+setting of the [`--server.options-api` startup option](../../components/arangodb-server/options.md#--serveroptions-api).
+
 ### Get the startup option configuration
 
 ```openapi
 paths:
-  /_admin/options:
+  /_db/_system/_admin/options:
     get:
       operationId: getEffectiveStartupOptions
       description: |
@@ -702,7 +757,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/options-description:
+  /_db/_system/_admin/options-description:
     get:
       operationId: getAvailableStartupOptions
       description: |
@@ -789,7 +844,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/server/mode:
+  /_db/{database-name}/_admin/server/mode:
     get:
       operationId: getServerMode
       description: |
@@ -799,6 +854,17 @@ paths:
         Creating or dropping of databases and collections will also fail with error code `11` (_ERROR_FORBIDDEN_).
 
         This API requires authentication.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -811,7 +877,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/server/mode:
+  /_db/{database-name}/_admin/server/mode:
     put:
       operationId: setServerMode
       description: |
@@ -823,6 +889,17 @@ paths:
 
         This is a protected API. It requires authentication and administrative
         server rights.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -855,12 +932,24 @@ status and update the license of your ArangoDB Enterprise Edition deployment.
 
 ```openapi
 paths:
-  /_admin/license:
+  /_db/{database-name}/_admin/license:
     get:
       operationId: getLicense
       description: |
         View the license information and status of an Enterprise Edition instance.
         Can be called on single servers, Coordinators, and DB-Servers.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -945,13 +1034,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/license:
+  /_db/{database-name}/_admin/license:
     put:
       operationId: setLicense
       description: |
         Set a new license for an Enterprise Edition instance.
         Can be called on single servers, Coordinators, and DB-Servers.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: force
           in: query
           required: false
@@ -1102,12 +1202,22 @@ x-content-type-options: nosniff
 
 ```openapi
 paths:
-  /_admin/shutdown:
+  /_db/{database-name}/_admin/shutdown:
     delete:
       operationId: startShutdown
       description: |
         This call initiates a clean shutdown sequence. Requires administrative privileges.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: soft
           in: query
           required: false
@@ -1150,7 +1260,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/shutdown:
+  /_db/{database-name}/_admin/shutdown:
     get:
       operationId: getShutdownProgress
       description: |
@@ -1169,6 +1279,17 @@ paths:
          - Ongoing low priority requests
 
         This API is only available on Coordinators.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1232,6 +1353,7 @@ paths:
 ```openapi
 paths:
   /_admin/compact:
+  # Independent of database (superuser has access to all databases that exist)
     put:
       operationId: compactAllDatabases
       description: |
@@ -1290,12 +1412,24 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/routing/reload:
+  /_db/{database-name}/_admin/routing/reload:
     post:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: reloadRouting
       description: |
         Reloads the routing information from the `_routing` system collection if it
         exists, and makes Foxx rebuild its local routing table on the next request.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1308,7 +1442,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/echo:
+  /_db/{database-name}/_admin/echo:
     post:
       operationId: echoRequest
       description: |
@@ -1325,6 +1459,17 @@ paths:
                   description: |
                     The request body can be of any type and is simply forwarded.
                   type: string
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1483,8 +1628,9 @@ paths:
 
 ```openapi
 paths:
-  /_admin/execute:
+  /_db/{database-name}/_admin/execute:
     post:
+    # Technically accepts all of the following methods: HEAD, GET, POST, PATCH, PUT, DELETE
       operationId: executeCode
       description: |
         Executes the JavaScript code in the body on the server as the body
@@ -1501,6 +1647,15 @@ paths:
         The default value of this option is `false`, which disables the execution of
         user-defined code and disables this API endpoint entirely.
         This is also the recommended setting for production.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1551,7 +1706,7 @@ the default `_system` database and none of the other databases.
 
 ```openapi
 paths:
-  /_api/endpoint:
+  /_db/_system/_api/endpoint:
     get:
       operationId: listEndpoints
       description: |

--- a/site/content/3.13/develop/http-api/analyzers.md
+++ b/site/content/3.13/develop/http-api/analyzers.md
@@ -16,11 +16,20 @@ introduction and the available types, properties and features.
 
 ```openapi
 paths:
-  /_api/analyzer:
+  /_db/{database-name}/_api/analyzer:
     post:
       operationId: createAnalyzer
       description: |
         Creates a new Analyzer based on the provided configuration.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -96,7 +105,7 @@ analyzers.remove(analyzerName, true);
 
 ```openapi
 paths:
-  /_api/analyzer/{analyzer-name}:
+  /_db/{database-name}/_api/analyzer/{analyzer-name}:
     get:
       operationId: getAnalyzer
       description: |
@@ -107,6 +116,14 @@ paths:
         - `properties`: the properties used to configure the specified type
         - `features`: the set of features to set on the Analyzer generated fields
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: analyzer-name
           in: path
           required: true
@@ -152,7 +169,7 @@ analyzers.remove(analyzerName, true);
 
 ```openapi
 paths:
-  /_api/analyzer:
+  /_db/{database-name}/_api/analyzer:
     get:
       operationId: listAnalyzers
       description: |
@@ -162,6 +179,15 @@ paths:
         - `type`: the Analyzer type
         - `properties`: the properties used to configure the specified type
         - `features`: the set of features to set on the Analyzer generated fields
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -190,7 +216,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/analyzer/{analyzer-name}:
+  /_db/{database-name}/_api/analyzer/{analyzer-name}:
     delete:
       operationId: deleteAnalyzer
       description: |
@@ -201,6 +227,14 @@ paths:
         - `error`: `false`
         - `name`: The name of the removed Analyzer
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: analyzer-name
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/authentication.md
+++ b/site/content/3.13/develop/http-api/authentication.md
@@ -174,6 +174,7 @@ Please note that all JWT tokens must contain the `iss` field with string value
 ```openapi
 paths:
   /_open/auth:
+  # Independent of database
     post:
       operationId: createSessionToken
       description: |
@@ -281,7 +282,7 @@ may use the following RESTful API. A `POST` request reloads the secret, a
 
 ```openapi
 paths:
-  /_admin/server/jwt:
+  /_db/{database-name}/_admin/server/jwt:
     get:
       operationId: getServerJwtSecrets
       description: |
@@ -289,6 +290,18 @@ paths:
 
         To utilize the API a superuser JWT token is necessary, otherwise the response
         will be _HTTP 403 Forbidden_.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: ''
@@ -343,6 +356,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/jwt:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: reloadServerJwtSecrets
       description: |

--- a/site/content/3.13/develop/http-api/batch-requests.md
+++ b/site/content/3.13/develop/http-api/batch-requests.md
@@ -227,7 +227,7 @@ in a batch part will be ignored.
 
 ```openapi
 paths:
-  /_api/batch:
+  /_db/{database-name}/_api/batch:
     post:
       operationId: executeBatchRequest
       description: |
@@ -267,6 +267,15 @@ paths:
         original client request. Client can additionally use the `Content-Id`
         MIME header in a batch part to define an individual id for each batch part.
         The server will return this id is the batch part responses, too.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.13/develop/http-api/cluster.md
+++ b/site/content/3.13/develop/http-api/cluster.md
@@ -9,6 +9,9 @@ description: >-
 ---
 ## Monitoring
 
+The permissions required to use the `/_admin/cluster/*` endpoints depends on the
+setting of the [`--cluster.api-jwt-policy` startup option](../../components/arangodb-server/options.md#--clusterapi-jwt-policy).
+
 ### Get the statistics of a DB-Server
 
 ```openapi

--- a/site/content/3.13/develop/http-api/collections.md
+++ b/site/content/3.13/develop/http-api/collections.md
@@ -29,13 +29,21 @@ http://localhost:8529/_api/collection/demo
 
 ```openapi
 paths:
-  /_api/collection:
+  /_db/{database-name}/_api/collection:
     get:
       operationId: listCollections
       description: |
         Returns basic information for all collections in the current database,
         optionally excluding system collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: excludeSystem
           in: query
           required: false
@@ -139,12 +147,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}:
+  /_db/{database-name}/_api/collection/{collection-name}:
     get:
       operationId: getCollection
       description: |
         Returns the basic information about a specific collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -261,12 +277,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/properties:
+  /_db/{database-name}/_api/collection/{collection-name}/properties:
     get:
       operationId: getCollectionProperties
       description: |
         Returns all properties of the specified collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -578,12 +602,20 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/count:
+  /_db/{database-name}/_api/collection/{collection-name}/count:
     get:
       operationId: getCollectionCount
       description: |
         Get the number of documents in a collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -892,13 +924,21 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/figures:
+  /_db/{database-name}/_api/collection/{collection-name}/figures:
     get:
       operationId: getCollectionFigures
       description: |
         Get the number of documents and additional statistical information
         about the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1312,7 +1352,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/responsibleShard:
+  /_db/{database-name}/_api/collection/{collection-name}/responsibleShard:
     put:
       operationId: getResponsibleShard
       description: |
@@ -1329,6 +1369,22 @@ paths:
         {{</* info */>}}
         This method is only available in cluster deployments on Coordinators.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: collection-name
+          in: path
+          required: true
+          description: |
+            The name of the collection.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1342,14 +1398,6 @@ paths:
                     The request body must be a JSON object with at least the shard key
                     attributes set to some values, but it may also be a full document.
                   type: object
-      parameters:
-        - name: collection-name
-          in: path
-          required: true
-          description: |
-            The name of the collection.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -1501,7 +1549,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/shards:
+  /_db/{database-name}/_api/collection/{collection-name}/shards:
     get:
       operationId: getCollectionShards
       description: |
@@ -1515,6 +1563,14 @@ paths:
         This method is only available in cluster deployments on Coordinators.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -1674,7 +1730,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/revision:
+  /_db/{database-name}/_api/collection/{collection-name}/revision:
     get:
       operationId: getCollectionRevision
       description: |
@@ -1682,6 +1738,14 @@ paths:
         The revision ID is a server-generated string that clients can use to
         check whether data in a collection has changed since the last revision check.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2034,7 +2098,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/checksum:
+  /_db/{database-name}/_api/collection/{collection-name}/checksum:
     get:
       operationId: getCollectionChecksum
       description: |
@@ -2060,6 +2124,14 @@ paths:
         Including user-defined attributes will make the checksumming slower.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -2218,11 +2290,22 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/key-generators:
+  /_db/{database-name}/_api/key-generators:
     get:
       operationId: getKeyGenerators
       description: |
         Returns the available key generators for collections.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -2271,12 +2354,41 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection:
+  /_db/{database-name}/_api/collection:
     post:
       operationId: createCollection
       description: |
         Creates a new collection with a given name. The request must contain an
         object with the following attributes.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: waitForSyncReplication
+          in: query
+          required: false
+          description: |
+            The default is `true`, which means the server only reports success back to the
+            client when all replicas have created the collection. Set it to `false` if you want
+            faster server responses and don't care about full replication.
+          schema:
+            type: boolean
+            default: true
+        - name: enforceReplicationFactor
+          in: query
+          required: false
+          description: |
+            The default is `true`, which means the server checks if there are enough replicas
+            available at creation time and bail out otherwise. Set it to `false` to disable
+            this extra check.
+          schema:
+            type: boolean
+            default: true
       requestBody:
         content:
           application/json:
@@ -2584,27 +2696,6 @@ paths:
                     A further restriction is that whenever documents are stored or updated in the
                     collection, the value stored in the `smartJoinAttribute` must be a string.
                   type: string
-      parameters:
-        - name: waitForSyncReplication
-          in: query
-          required: false
-          description: |
-            The default is `true`, which means the server only reports success back to the
-            client when all replicas have created the collection. Set it to `false` if you want
-            faster server responses and don't care about full replication.
-          schema:
-            type: boolean
-            default: true
-        - name: enforceReplicationFactor
-          in: query
-          required: false
-          description: |
-            The default is `true`, which means the server checks if there are enough replicas
-            available at creation time and bail out otherwise. Set it to `false` to disable
-            this extra check.
-          schema:
-            type: boolean
-            default: true
       responses:
         '200':
           description: |
@@ -2924,12 +3015,20 @@ db._drop("testCollectionUsers");
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}:
+  /_db/{database-name}/_api/collection/{collection-name}:
     delete:
       operationId: deleteCollection
       description: |
         Delete the collection identified by `collection-name` and all its documents.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3105,12 +3204,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/truncate:
+  /_db/{database-name}/_api/collection/{collection-name}/truncate:
     put:
       operationId: truncateCollection
       description: |
         Removes all documents from the collection, but leaves the indexes intact.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3270,7 +3377,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/load:
+  /_db/{database-name}/_api/collection/{collection-name}/load:
     put:
       operationId: loadCollection
       description: |
@@ -3283,6 +3390,14 @@ paths:
         Since ArangoDB version 3.9.0 this API does nothing. Previously, it used to
         load a collection into memory.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3453,7 +3568,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/unload:
+  /_db/{database-name}/_api/collection/{collection-name}/unload:
     put:
       operationId: unloadCollection
       description: |
@@ -3466,6 +3581,14 @@ paths:
         Since ArangoDB version 3.9.0 this API does nothing. Previously it used to
         unload a collection from memory, while preserving all documents.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3632,7 +3755,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/loadIndexesIntoMemory:
+  /_db/{database-name}/_api/collection/{collection-name}/loadIndexesIntoMemory:
     put:
       operationId: loadCollectionIndexes
       description: |
@@ -3658,6 +3781,14 @@ paths:
         It is guaranteed that the in-memory cache data is consistent with the stored
         index data at all times.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -3788,7 +3919,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/properties:
+  /_db/{database-name}/_api/collection/{collection-name}/properties:
     put:
       operationId: updateCollectionProperties
       description: |
@@ -3797,6 +3928,14 @@ paths:
         created except for the listed properties, as well as the collection name via
         the rename endpoint (but not in clusters).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -4255,7 +4394,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/rename:
+  /_db/{database-name}/_api/collection/{collection-name}/rename:
     put:
       operationId: renameCollection
       description: |
@@ -4268,6 +4407,14 @@ paths:
         If renaming the collection succeeds, then the collection is also renamed in
         all graph definitions inside the `_graphs` collection in the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -4449,12 +4596,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/recalculateCount:
+  /_db/{database-name}/_api/collection/{collection-name}/recalculateCount:
     put:
       operationId: recalculateCollectionCount
       description: |
         Recalculates the document count of a collection, if it ever becomes inconsistent.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true
@@ -4563,7 +4718,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/collection/{collection-name}/compact:
+  /_db/{database-name}/_api/collection/{collection-name}/compact:
     put:
       operationId: compactCollection
       description: |
@@ -4577,6 +4732,14 @@ paths:
         the disk data for a collection may contain a lot of outdated data for which the
         space shall be reclaimed. In this case the compaction operation can be used.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-name
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/databases.md
+++ b/site/content/3.13/develop/http-api/databases.md
@@ -62,7 +62,7 @@ Non-NFC-normalized names are rejected by the server.
 
 ```openapi
 paths:
-  /_api/database/current:
+  /_db/{database-name}/_api/database/current:
     get:
       operationId: getCurrentDatabase
       description: |
@@ -77,6 +77,15 @@ paths:
         - `sharding`: the default sharding method for collections created in this database
         - `replicationFactor`: the default replication factor for collections in this database
         - `writeConcern`: the default write concern for collections in this database
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -110,12 +119,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database/user:
+  /_db/{database-name}/_api/database/user:
     get:
       operationId: listUserAccessibleDatabases
       description: |
         Retrieves the list of all databases the current user can access without
         specifying a different username or password.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -146,7 +166,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database:
+  /_db/_system/_api/database:
     get:
       operationId: listDatabases
       description: |
@@ -188,7 +208,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database:
+  /_db/_system/_api/database:
     post:
       operationId: createDatabase
       description: |
@@ -374,7 +394,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/database/{database-name}:
+  /_db/_system/_api/database/{database-name}:
     delete:
       operationId: deleteDatabase
       description: |

--- a/site/content/3.13/develop/http-api/documents.md
+++ b/site/content/3.13/develop/http-api/documents.md
@@ -75,7 +75,7 @@ endpoints to request and delete multiple documents in one request.
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     get:
       operationId: getDocument
       description: |
@@ -85,6 +85,14 @@ paths:
         - `_key`, containing the document key that uniquely identifies a document within the collection.
         - `_rev`, containing the document revision.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -220,7 +228,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     head:
       operationId: getDocumentHeader
       description: |
@@ -228,6 +236,14 @@ paths:
         can use this call to get the current revision of a document or check if
         the document was deleted.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -325,7 +341,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     post:
       operationId: createDocument
       description: |
@@ -368,6 +384,14 @@ paths:
         generated document, the complete new document is returned under
         the `new` attribute in the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -744,7 +768,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     put:
       operationId: replaceDocument
       description: |
@@ -816,6 +840,14 @@ paths:
                     A JSON representation of a single document.
                   type: object
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1061,7 +1093,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     patch:
       operationId: updateDocument
       description: |
@@ -1140,6 +1172,14 @@ paths:
                     A JSON representation of a document update as an object.
                   type: object
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1409,7 +1449,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}/{key}:
+  /_db/{database-name}/_api/document/{collection}/{key}:
     delete:
       operationId: deleteDocument
       description: |
@@ -1429,6 +1469,14 @@ paths:
         the complete previous revision of the document
         is returned under the `old` attribute in the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1663,7 +1711,7 @@ contains a JSON array of the same length.
 
 ```openapi
 paths:
-  /_api/document/{collection}#get:
+  /_db/{database-name}/_api/document/{collection}#get:
     put:
       operationId: getDocuments
       description: |
@@ -1692,6 +1740,14 @@ paths:
         - `_key`, containing the document key that uniquely identifies a document within the collection.
         - `_rev`, containing the document revision.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -1702,6 +1758,7 @@ paths:
         - name: onlyget
           in: query
           required: true
+          example: true
           description: |
             This parameter is required to be `true`, otherwise a replace
             operation is executed!
@@ -1794,7 +1851,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}#multiple:
+  /_db/{database-name}/_api/document/{collection}#multiple:
     post:
       operationId: createDocuments
       description: |
@@ -1844,6 +1901,14 @@ paths:
         `1200:17,1205:10` means that in 17 cases the error 1200 ("revision conflict")
         has happened, and in 10 cases the error 1205 ("illegal document handle").
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2117,7 +2182,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     put:
       operationId: replaceDocuments
       description: |
@@ -2189,6 +2254,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2335,7 +2408,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     patch:
       operationId: updateDocuments
       description: |
@@ -2414,6 +2487,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true
@@ -2582,7 +2663,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/document/{collection}:
+  /_db/{database-name}/_api/document/{collection}:
     delete:
       operationId: deleteDocuments
       description: |
@@ -2635,6 +2716,14 @@ paths:
                     Each element has to contain a `_key` attribute.
                   type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/foxx.md
+++ b/site/content/3.13/develop/http-api/foxx.md
@@ -15,7 +15,7 @@ For more information on Foxx and its JavaScript APIs see the
 
 ```openapi
 paths:
-  /_api/foxx:
+  /_db/{database-name}/_api/foxx:
     get:
       operationId: listFoxxServices
       description: |
@@ -33,6 +33,14 @@ paths:
         - `name`: a string identifying the service type
         - `version`: a semver-compatible version string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: excludeSystem
           in: query
           required: false
@@ -52,7 +60,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     get:
       operationId: getFoxxServiceDescription
       description: |
@@ -71,6 +79,14 @@ paths:
         - `name`: a string identifying the service type
         - `version`: a semver-compatible version string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -93,7 +109,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx:
+  /_db/{database-name}/_api/foxx:
     post:
       operationId: createFoxxService
       description: |
@@ -127,6 +143,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -167,7 +191,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     delete:
       operationId: deleteFoxxService
       description: |
@@ -201,7 +225,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     put:
       operationId: replaceFoxxService
       description: |
@@ -240,6 +264,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -287,7 +319,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/service:
+  /_db/{database-name}/_api/foxx/service:
     patch:
       operationId: upgradeFoxxService
       description: |
@@ -326,6 +358,14 @@ paths:
         Note that when using file system paths in a cluster with multiple Coordinators
         the file system path must resolve to equivalent files on every Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -375,7 +415,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     get:
       operationId: getFoxxConfiguration
       description: |
@@ -384,6 +424,14 @@ paths:
         Returns an object mapping the configuration option names to their definitions
         including a human-friendly `title` and the `current` value (if any).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -403,13 +451,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     patch:
       operationId: updateFoxxConfiguration
       description: |
         Replaces the given service's configuration.
 
         Returns an object mapping all configuration option names to their new values.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -423,14 +487,6 @@ paths:
                     A JSON object mapping configuration option names to their new values.
                     Any omitted options will be ignored.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -443,13 +499,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/configuration:
+  /_db/{database-name}/_api/foxx/configuration:
     put:
       operationId: replaceFoxxConfiguration
       description: |
         Replaces the given service's configuration completely.
 
         Returns an object mapping all configuration option names to their new values.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -463,14 +535,6 @@ paths:
                     A JSON object mapping configuration option names to their new values.
                     Any omitted options will be reset to their default values or marked as unconfigured.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -483,7 +547,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     get:
       operationId: getFoxxDependencies
       description: |
@@ -492,6 +556,14 @@ paths:
         Returns an object mapping the dependency names to their definitions
         including a human-friendly `title` and the `current` mount path (if any).
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -511,13 +583,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     patch:
       operationId: updateFoxxDependencies
       description: |
         Replaces the given service's dependencies.
 
         Returns an object mapping all dependency names to their new mount paths.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -531,14 +619,6 @@ paths:
                     A JSON object mapping dependency names to their new mount paths.
                     Any omitted dependencies will be ignored.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -551,13 +631,29 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/dependencies:
+  /_db/{database-name}/_api/foxx/dependencies:
     put:
       operationId: replaceFoxxDependencies
       description: |
         Replaces the given service's dependencies completely.
 
         Returns an object mapping all dependency names to their new mount paths.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: mount
+          in: query
+          required: true
+          description: |
+            Mount path of the installed service.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -571,14 +667,6 @@ paths:
                     A JSON object mapping dependency names to their new mount paths.
                     Any omitted dependencies will be disabled.
                   type: object
-      parameters:
-        - name: mount
-          in: query
-          required: true
-          description: |
-            Mount path of the installed service.
-          schema:
-            type: string
       responses:
         '200':
           description: |
@@ -593,7 +681,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/scripts:
+  /_db/{database-name}/_api/foxx/scripts:
     get:
       operationId: listFoxxScripts
       description: |
@@ -601,6 +689,14 @@ paths:
 
         Returns an object mapping the raw script names to human-friendly names.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -620,25 +716,22 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/scripts/{name}:
+  /_db/{database-name}/_api/foxx/scripts/{name}:
     post:
       operationId: runFoxxScript
       description: |
         Runs the given script for the service at the given mount path.
 
         Returns the exports of the script, if any.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                data:
-                  description: |
-                    An arbitrary JSON value that will be parsed and passed to the
-                    script as its first argument.
-                  type: json
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: name
           in: path
           required: true
@@ -653,6 +746,17 @@ paths:
             Mount path of the installed service.
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  description: |
+                    An arbitrary JSON value that will be parsed and passed to the
+                    script as its first argument.
+                  type: json
       responses:
         '200':
           description: |
@@ -665,7 +769,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/tests:
+  /_db/{database-name}/_api/foxx/tests:
     post:
       operationId: runFoxxTests
       description: |
@@ -692,6 +796,14 @@ paths:
 
         Otherwise the response body will be formatted as non-prettyprinted JSON.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -733,7 +845,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/development:
+  /_db/{database-name}/_api/foxx/development:
     post:
       operationId: enableFoxxDevelopmentMode
       description: |
@@ -748,6 +860,14 @@ paths:
         Coordinators. This means you should treat your Coordinators as inconsistent
         as long as any service is running in development mode.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -767,7 +887,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/development:
+  /_db/{database-name}/_api/foxx/development:
     delete:
       operationId: disableFoxxDevelopmentMode
       description: |
@@ -777,6 +897,14 @@ paths:
         replace the service on all other Coordinators with the version on this
         Coordinator.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -796,12 +924,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/readme:
+  /_db/{database-name}/_api/foxx/readme:
     get:
       operationId: getFoxxReadme
       description: |
         Fetches the service's README or README.md file's contents if any.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -824,7 +960,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/swagger:
+  /_db/{database-name}/_api/foxx/swagger:
     get:
       operationId: getFoxxSwaggerDescription
       description: |
@@ -832,6 +968,14 @@ paths:
 
         The response body will be an OpenAPI 2.0 compatible JSON description of the service API.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -851,7 +995,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/download:
+  /_db/{database-name}/_api/foxx/download:
     post:
       operationId: downloadFoxxService
       description: |
@@ -862,6 +1006,14 @@ paths:
         Otherwise the bundle will represent the version of a service that
         is installed on that ArangoDB instance.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -884,7 +1036,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/foxx/commit:
+  /_db/{database-name}/_api/foxx/commit:
     post:
       operationId: commitFoxxServiceState
       description: |
@@ -892,6 +1044,14 @@ paths:
 
         This can be used to resolve service conflicts between Coordinators that cannot be fixed automatically due to missing data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: replace
           in: query
           required: false

--- a/site/content/3.13/develop/http-api/graphs/edges.md
+++ b/site/content/3.13/develop/http-api/graphs/edges.md
@@ -27,13 +27,21 @@ for details.
 
 ```openapi
 paths:
-  /_api/edges/{collection-id}:
+  /_db/{database-name}/_api/edges/{collection-id}:
     get:
       operationId: getVertexEdges
       description: |
         Returns an array of edges starting or ending in the vertex identified by
         `vertex`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection-id
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.13/develop/http-api/graphs/named-graphs.md
@@ -30,11 +30,20 @@ The examples use the following example graphs:
 
 ```openapi
 paths:
-  /_api/gharial:
+  /_db/{database-name}/_api/gharial:
     get:
       operationId: listGraphs
       description: |
         Lists all graphs stored in this database.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -196,13 +205,21 @@ examples.dropGraph("routeplanner");
 
 ```openapi
 paths:
-  /_api/gharial:
+  /_db/{database-name}/_api/gharial:
     post:
       operationId: createGraph
       description: |
         The creation of a graph requires the name of the graph and a
         definition of its edges.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: waitForSync
           in: query
           required: false
@@ -907,7 +924,7 @@ graph._drop("satelliteGraph", true);
 
 ```openapi
 paths:
-  /_api/gharial/{graph}:
+  /_db/{database-name}/_api/gharial/{graph}:
     get:
       operationId: getGraph
       description: |
@@ -915,6 +932,14 @@ paths:
         Returns the edge definitions as well as the orphan collections,
         or returns an error if the graph does not exist.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1115,7 +1140,7 @@ graph._drop("myGraph", true);
 
 ```openapi
 paths:
-  /_api/gharial/{graph}:
+  /_db/{database-name}/_api/gharial/{graph}:
     delete:
       operationId: deleteGraph
       description: |
@@ -1123,6 +1148,14 @@ paths:
         Optionally all collections not used by other graphs
         can be dropped as well.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1256,12 +1289,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex:
+  /_db/{database-name}/_api/gharial/{graph}/vertex:
     get:
       operationId: listVertexCollections
       description: |
         Lists all vertex collections within this graph, including orphan collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1362,13 +1403,21 @@ by [adding a new edge definition](#add-an-edge-definition) or
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex:
+  /_db/{database-name}/_api/gharial/{graph}/vertex:
     post:
       operationId: addVertexCollection
       description: |
         Adds a vertex collection to the set of orphan collections of the graph.
         If the collection does not exist, it is created.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -1782,7 +1831,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}:
     delete:
       operationId: deleteVertexCollection
       description: |
@@ -1795,6 +1844,14 @@ paths:
         edge definition first in order to fully remove a vertex collection from
         the graph.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2212,12 +2269,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge:
+  /_db/{database-name}/_api/gharial/{graph}/edge:
     get:
       operationId: listEdgeCollections
       description: |
         Lists all edge collections within this graph.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2312,7 +2377,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge:
+  /_db/{database-name}/_api/gharial/{graph}/edge:
     post:
       operationId: createEdgeDefinition
       description: |
@@ -2328,6 +2393,14 @@ paths:
 
         Additionally, collection creation options can be set.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -2760,13 +2833,21 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     put:
       operationId: replaceEdgeDefinition
       description: |
         Change the vertex collections of one specific edge definition.
         This modifies all occurrences of this definition in all graphs known to your database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3215,7 +3296,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     delete:
       operationId: deleteEdgeDefinition
       description: |
@@ -3224,6 +3305,14 @@ paths:
         edge definition become orphan collections but otherwise remain untouched
         and can still be used in your queries.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3600,12 +3689,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}:
     post:
       operationId: createVertex
       description: |
         Adds a vertex to the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -3886,12 +3983,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     get:
       operationId: getVertex
       description: |
         Gets a vertex from the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4151,12 +4256,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     patch:
       operationId: updateVertex
       description: |
         Updates the data of the specific vertex in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4550,12 +4663,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     put:
       operationId: replaceVertex
       description: |
         Replaces the data of a vertex in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -4950,12 +5071,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/vertex/{collection}/{vertex}:
+  /_db/{database-name}/_api/gharial/{graph}/vertex/{collection}/{vertex}:
     delete:
       operationId: deleteVertex
       description: |
         Removes a vertex from the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5235,7 +5364,7 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}:
     post:
       operationId: createEdge
       description: |
@@ -5243,6 +5372,14 @@ paths:
         Within the body the edge has to contain a `_from` and `_to` value referencing to valid vertices in the graph.
         Furthermore, the edge has to be valid according to the edge definitions.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5608,12 +5745,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     get:
       operationId: getEdge
       description: |
         Gets an edge from the given collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -5884,12 +6029,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     patch:
       operationId: updateEdge
       description: |
         Partially modify the data of the specific edge in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -6344,12 +6497,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     put:
       operationId: replaceEdge
       description: |
         Replaces the data of an edge in the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true
@@ -6814,12 +6975,20 @@ examples.dropGraph("social");
 
 ```openapi
 paths:
-  /_api/gharial/{graph}/edge/{collection}/{edge}:
+  /_db/{database-name}/_api/gharial/{graph}/edge/{collection}/{edge}:
     delete:
       operationId: deleteEdge
       description: |
         Removes an edge from the collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: graph
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/hot-backups.md
+++ b/site/content/3.13/develop/http-api/hot-backups.md
@@ -23,11 +23,15 @@ most of all the [requirements and limitations](../../operations/backup-and-resto
 before using the API.
 {{< /warning >}}
 
+The permissions required to use the `/_admin/backup/*` endpoints depends on the
+setting of the [`--backup.options-api` startup option](../../components/arangodb-server/options.md#--serveroptions-api).
+
 ## Create a backup
 
 ```openapi
 paths:
   /_admin/backup/create:
+  # Independent of database
     post:
       operationId: createBackup
       description: |
@@ -124,6 +128,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/restore:
+  # Independent of database
     post:
       operationId: restoreBackup
       description: |
@@ -212,6 +217,7 @@ while (require("internal").time() - startTime < 10) {
 ```openapi
 paths:
   /_admin/backup/delete:
+  # Independent of database
     post:
       operationId: deleteBackup
       description: |
@@ -270,6 +276,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/list:
+  # Independent of database
     post:
       operationId: listBackups
       description: |
@@ -349,6 +356,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/upload:
+  # Independent of database
     post:
       operationId: uploadBackup
       description: |
@@ -500,6 +508,7 @@ body = {
 ```openapi
 paths:
   /_admin/backup/download:
+  # Independent of database
     post:
       operationId: downloadBackup
       description: |

--- a/site/content/3.13/develop/http-api/import.md
+++ b/site/content/3.13/develop/http-api/import.md
@@ -9,7 +9,7 @@ description: >-
 
 ```openapi
 paths:
-  /_api/import:
+  /_db/{database-name}/_api/import:
     post:
       operationId: importData
       description: |
@@ -36,6 +36,14 @@ paths:
                     multiple JSON objects separated by newlines.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.13/develop/http-api/indexes/_index.md
+++ b/site/content/3.13/develop/http-api/indexes/_index.md
@@ -27,7 +27,7 @@ http://localhost:8529/_api/index/demo/63563528
 
 ```openapi
 paths:
-  /_api/index:
+  /_db/{database-name}/_api/index:
     get:
       operationId: listIndexes
       description: |
@@ -36,6 +36,14 @@ paths:
         available in the `identifiers` attribute as an object with the index identifiers
         as object keys.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -94,7 +102,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/index/{index-id}:
+  /_db/{database-name}/_api/index/{index-id}:
     get:
       operationId: getIndex
       description: |
@@ -109,6 +117,14 @@ paths:
         `unique` or `sparse` flags, whereas others don't. Some indexes also provide
         a selectivity estimate in the `selectivityEstimate` attribute of the result.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: index-id
           in: path
           required: true
@@ -152,7 +168,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/index:
+  /_db/{database-name}/_api/index:
     post:
       operationId: createIndex
       description: |
@@ -232,6 +248,14 @@ paths:
         in the background, which will not write-lock the underlying collection for
         as long as if the index is built in the foreground.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -274,12 +298,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/index/{index-id}:
+  /_db/{database-name}/_api/index/{index-id}:
     delete:
       operationId: deleteIndex
       description: |
         Deletes an index with `index-id`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: index-id
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/indexes/fulltext.md
+++ b/site/content/3.13/develop/http-api/indexes/fulltext.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#fulltext:
+  /_db/{database-name}/_api/index#fulltext:
     post:
       operationId: createIndexFulltext
       description: |
@@ -20,6 +20,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.13/develop/http-api/indexes/geo-spatial.md
+++ b/site/content/3.13/develop/http-api/indexes/geo-spatial.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#geo:
+  /_db/{database-name}/_api/index#geo:
     post:
       operationId: createIndexGeo
       description: |
@@ -19,6 +19,14 @@ paths:
         the index attributes or have non-numeric values in the index attributes
         will not be indexed.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.13/develop/http-api/indexes/inverted.md
+++ b/site/content/3.13/develop/http-api/indexes/inverted.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#inverted:
+  /_db/{database-name}/_api/index#inverted:
     post:
       operationId: createIndexInverted
       description: |
@@ -16,6 +16,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.13/develop/http-api/indexes/multi-dimensional.md
+++ b/site/content/3.13/develop/http-api/indexes/multi-dimensional.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#mdi:
+  /_db/{database-name}/_api/index#mdi:
     post:
       operationId: createIndexMdi
       description: |
@@ -16,6 +16,14 @@ paths:
         it does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.13/develop/http-api/indexes/persistent.md
+++ b/site/content/3.13/develop/http-api/indexes/persistent.md
@@ -14,7 +14,7 @@ removed in a future version.
 
 ```openapi
 paths:
-  /_api/index#persistent:
+  /_db/{database-name}/_api/index#persistent:
     post:
       operationId: createIndexPersistent
       description: |
@@ -36,6 +36,14 @@ paths:
         Unique indexes on non-shard keys are not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.13/develop/http-api/indexes/ttl.md
+++ b/site/content/3.13/develop/http-api/indexes/ttl.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/index#ttl:
+  /_db/{database-name}/_api/index#ttl:
     post:
       operationId: createIndexTtl
       description: |
@@ -16,6 +16,14 @@ paths:
         does not already exist. The call expects an object containing the index
         details.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true

--- a/site/content/3.13/develop/http-api/jobs.md
+++ b/site/content/3.13/develop/http-api/jobs.md
@@ -5,6 +5,7 @@ weight: 80
 description: >-
   The HTTP API for jobs lets you access the results of asynchronously executed
   requests and check the status of such jobs
+# All /_api/job* endpoints are also available via /_admin/job*
 ---
 For an introduction to non-blocking execution of requests and how to create
 async jobs with the `x-arango-async` request header, see
@@ -14,7 +15,7 @@ async jobs with the `x-arango-async` request header, see
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     put:
       operationId: getJobResult
       description: |
@@ -28,6 +29,16 @@ paths:
         the header is not present, the job was not found and the response contains
         status information from the job manager.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -148,13 +159,23 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}/cancel:
+  /_db/{database-name}/_api/job/{job-id}/cancel:
     put:
       operationId: cancelJob
       description: |
         Cancels the currently running job identified by job-id. Note that it still
         might take some time to actually cancel the running async job.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -216,7 +237,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     delete:
       operationId: deleteJob
       description: |
@@ -225,6 +246,16 @@ paths:
         Clients can use this method to perform an eventual garbage collection of job
         results.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true
@@ -350,7 +381,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/job/{job-id}:
+  /_db/{database-name}/_api/job/{job-id}:
     get:
       operationId: getJob
       description: |
@@ -360,6 +391,16 @@ paths:
         - The IDs of async jobs with a specific status
         - The processing status of a specific async job
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: job-id
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/monitoring/logs.md
+++ b/site/content/3.13/develop/http-api/monitoring/logs.md
@@ -12,6 +12,9 @@ on the [log startup options](../../../components/arangodb-server/options.md#log)
 See [Log levels](../../../operations/administration/log-levels.md) for a detailed
 description of the `FATAL`, `ERROR`, and other levels of log messages.
 
+The permissions required to use the `/_admin/log*` endpoints depends on the
+setting of the [`--log.api-enabled` startup option](../../../components/arangodb-server/options.md#--logapi-enabled).
+
 ## Get the global server logs
 
 ```openapi

--- a/site/content/3.13/develop/http-api/monitoring/metrics.md
+++ b/site/content/3.13/develop/http-api/monitoring/metrics.md
@@ -19,13 +19,19 @@ coupled to specific internals that may be replaced by other mechanisms in the
 future.
 {{< /warning >}}
 
+Whether the `/_admin/metrics*` endpoints are available depends on the setting of
+the [`--server.export-metrics-api` startup option](../../../components/arangodb-server/options.md#--serverexport-metrics-api).
+For additional document read and write metrics, the
+[`--server.export-read-write-metrics` startup option](../../../components/arangodb-server/options.md#--serverexport-read-write-metrics)
+needs to be enabled.
+
 ## Metrics API v2
 
 ### Get the metrics
 
 ```openapi
 paths:
-  /_admin/metrics/v2:
+  /_db/{database-name}/_admin/metrics/v2:
     get:
       operationId: getMetricsV2
       description: |
@@ -41,6 +47,17 @@ paths:
         The API then needs to be added to the Prometheus configuration file
         for collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false
@@ -83,7 +100,7 @@ logPlainResponse(response);
 
 ```openapi
 paths:
-  /_admin/usage-metrics:
+  /_db/{database-name}/_admin/usage-metrics:
     get:
       operationId: getUsageMetrics
       description: |
@@ -94,6 +111,17 @@ paths:
         usage metrics, or to `enabled-per-shard-per-user` to make DB-Servers collect
         usage metrics per shard and per user whenever a shard is accessed.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false
@@ -116,7 +144,7 @@ paths:
 
 ```openapi
 paths:
-  /_admin/metrics:
+  /_db/{database-name}/_admin/metrics:
     get:
       operationId: getMetrics
       description: |
@@ -138,6 +166,17 @@ paths:
         The API then needs to be added to the Prometheus configuration file
         for collection.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
         - name: serverId
           in: query
           required: false

--- a/site/content/3.13/develop/http-api/monitoring/statistics.md
+++ b/site/content/3.13/develop/http-api/monitoring/statistics.md
@@ -10,7 +10,7 @@ description: >-
 
 ```openapi
 paths:
-  /_admin/statistics:
+  /_db/{database-name}/_admin/statistics:
     get:
       operationId: getStatistics
       description: |
@@ -42,6 +42,18 @@ paths:
         expect in a cluster setup using a single Coordinator querying this Coordinator.
         Just with the difference that cluster transactions have no notion of
         intermediate commits and will not increase the value.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -525,7 +537,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_admin/statistics-description:
+  /_db/{database-name}/_admin/statistics-description:
     get:
       operationId: getStatisticsDescription
       description: |
@@ -554,6 +566,18 @@ paths:
         - `type`: Either `current`, `accumulated`, or `distribution`.
         - `cuts`: The distribution vector.
         - `units`: Units in which the figure is measured.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.13/develop/http-api/queries/aql-queries.md
@@ -268,7 +268,7 @@ the cursor, even before you requested the last batch.
 
 ```openapi
 paths:
-  /_api/cursor:
+  /_db/{database-name}/_api/cursor:
     post:
       operationId: createAqlQueryCursor
       description: |
@@ -280,6 +280,14 @@ paths:
         bind parameters. These values need to be passed in a JSON representation in
         the body of the POST request.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: x-arango-allow-dirty-read
           in: header
           required: false
@@ -1323,7 +1331,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     post:
       operationId: getNextAqlQueryCursorBatch
       description: |
@@ -1332,6 +1340,14 @@ paths:
         If the cursor is not fully consumed, the time-to-live for the cursor
         is renewed by this API call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -1805,7 +1821,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     put:
       operationId: getNextAqlQueryCursorBatchPut
       description: |
@@ -1836,6 +1852,14 @@ paths:
         If the cursor is not fully consumed, the time-to-live for the cursor
         is renewed by this API call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -1936,7 +1960,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}/{batch-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}/{batch-identifier}:
     post:
       operationId: getPreviousAqlQueryCursorBatch
       description: |
@@ -1967,6 +1991,14 @@ paths:
 
         The time-to-live for the cursor is renewed by this API call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -2481,7 +2513,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/cursor/{cursor-identifier}:
+  /_db/{database-name}/_api/cursor/{cursor-identifier}:
     delete:
       operationId: deleteAqlQueryCursor
       description: |
@@ -2495,6 +2527,14 @@ paths:
         Note: the server will also destroy abandoned cursors automatically after a
         certain server-controlled timeout to avoid resource leakage.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: cursor-identifier
           in: path
           required: true
@@ -2557,7 +2597,7 @@ list.
 
 ```openapi
 paths:
-  /_api/query/properties:
+  /_db/{database-name}/_api/query/properties:
     get:
       operationId: getAqlQueryTrackingProperties
       description: |
@@ -2588,6 +2628,15 @@ paths:
           list of queries. Query strings can have arbitrary lengths, and this property
           can be used to save memory in case very long query strings are used. The
           value is specified in bytes.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -2603,7 +2652,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/properties:
+  /_db/{database-name}/_api/query/properties:
     put:
       operationId: updateAqlQueryTrackingProperties
       description: |
@@ -2612,6 +2661,15 @@ paths:
 
         After the properties have been changed, the current set of properties will
         be returned in the HTTP response.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -2677,7 +2735,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/current:
+  /_db/{database-name}/_api/query/current:
     get:
       operationId: listAqlQueries
       description: |
@@ -2717,13 +2775,21 @@ paths:
 
         - `stream`: whether or not the query uses a streaming cursor
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will return the currently running queries in all databases,
             not just the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2746,7 +2812,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/slow:
+  /_db/{database-name}/_api/query/slow:
     get:
       operationId: listSlowAqlQueries
       description: |
@@ -2780,13 +2846,21 @@ paths:
 
         - `stream`: whether or not the query uses a streaming cursor
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will return the slow queries from all databases, not just
             the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2809,19 +2883,27 @@ paths:
 
 ```openapi
 paths:
-  /_api/query/slow:
+  /_db/{database-name}/_api/query/slow:
     delete:
       operationId: clearSlowAqlQueryList
       description: |
         Clears the list of slow AQL queries for the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: all
           in: query
           required: false
           description: |
             If set to `true`, will clear the slow query history in all databases, not just
             the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2848,13 +2930,21 @@ soon as it reaches a cancelation point.
 
 ```openapi
 paths:
-  /_api/query/{query-id}:
+  /_db/{database-name}/_api/query/{query-id}:
     delete:
       operationId: deleteAqlQuery
       description: |
         Kills a running query in the currently selected database. The query will be
         terminated at the next cancelation point.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: query-id
           in: path
           required: true
@@ -2868,7 +2958,7 @@ paths:
           description: |
             If set to `true`, will attempt to kill the specified query in all databases,
             not just the selected one.
-            Using the parameter is only allowed in the system database and with superuser
+            Using the parameter is only allowed in the `_system` database and with superuser
             privileges.
           schema:
             type: boolean
@@ -2904,7 +2994,7 @@ You can also retrieve a list of all query optimizer rules and their properties.
 
 ```openapi
 paths:
-  /_api/explain:
+  /_db/{database-name}/_api/explain:
     post:
       operationId: explainAqlQuery
       description: |
@@ -2946,6 +3036,15 @@ paths:
 
         - `variables`: array of variables used in the query (note: this may contain
           internal variables created by the optimizer)
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3194,12 +3293,23 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/query:
+  /_db/{database-name}/_api/query:
     post:
       operationId: parseAqlQuery
       description: |
         This endpoint is for query validation only. To actually query the database,
         see `/api/cursor`.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3273,11 +3383,22 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/query/rules:
+  /_db/{database-name}/_api/query/rules:
     get:
       operationId: getAqlQueryOptimizerRules
       description: |
         A list of all optimizer rules and their properties.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/queries/aql-query-results-cache.md
+++ b/site/content/3.13/develop/http-api/queries/aql-query-results-cache.md
@@ -9,7 +9,7 @@ description: >-
 
 ```openapi
 paths:
-  /_api/query-cache/entries:
+  /_db/{database-name}/_api/query-cache/entries:
     get:
       operationId: listQueryCacheResults
       description: |
@@ -28,6 +28,15 @@ paths:
           again afterwards)
         - `runTime`: the query's run time
         - `dataSources`: an array of collections/Views the query was using
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -43,11 +52,20 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache:
+  /_db/{database-name}/_api/query-cache:
     delete:
       operationId: deleteAqlQueryCache
       description: |
         Clears all results stored in the AQL query results cache for the current database.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -64,7 +82,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache/properties:
+  /_db/{database-name}/_api/query-cache/properties:
     get:
       operationId: getQueryCacheProperties
       description: |
@@ -85,6 +103,17 @@ paths:
 
         - `includeSystem`: whether or not results of queries that involve system collections will be
           stored in the query results cache.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -100,7 +129,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/query-cache/properties:
+  /_db/{database-name}/_api/query-cache/properties:
     put:
       operationId: setQueryCacheProperties
       description: |
@@ -114,6 +143,17 @@ paths:
         The properties need to be passed in the `properties` attribute in the body
         of the HTTP request. `properties` needs to be a JSON object with the following
         properties:
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.13/develop/http-api/queries/user-defined-aql-functions.md
+++ b/site/content/3.13/develop/http-api/queries/user-defined-aql-functions.md
@@ -20,7 +20,7 @@ collection directly, but only via the dedicated interfaces.
 
 ```openapi
 paths:
-  /_api/aqlfunction:
+  /_db/{database-name}/_api/aqlfunction:
     post:
       operationId: createAqlUserFunction
       description: |
@@ -29,6 +29,15 @@ paths:
 
         In case of success, HTTP 200 is returned.
         If the function isn't valid etc. HTTP 400 including a detailed error message will be returned.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -164,13 +173,21 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/aqlfunction/{name}:
+  /_db/{database-name}/_api/aqlfunction/{name}:
     delete:
       operationId: deleteAqlUserFunction
       description: |
         Deletes an existing user-defined function (UDF) or function group identified by
         `name` from the current database.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: name
           in: path
           required: true
@@ -319,7 +336,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/aqlfunction:
+  /_db/{database-name}/_api/aqlfunction:
     get:
       operationId: listAqlUserFunctions
       description: |
@@ -328,6 +345,14 @@ paths:
 
         The call returns a JSON array with status codes and all user functions found under `result`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: namespace
           in: query
           required: false

--- a/site/content/3.13/develop/http-api/replication/other-replication-commands.md
+++ b/site/content/3.13/develop/http-api/replication/other-replication-commands.md
@@ -8,7 +8,7 @@ description: ''
 
 ```openapi
 paths:
-  /_api/replication/server-id:
+  /_db/{database-name}/_api/replication/server-id:
     get:
       operationId: getReplicationServerId
       description: |
@@ -17,6 +17,15 @@ paths:
 
         The body of the response is a JSON object with the attribute `serverId`. The
         server id is returned as a string.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/replication/replication-applier.md
+++ b/site/content/3.13/develop/http-api/replication/replication-applier.md
@@ -11,7 +11,7 @@ configuration of an ArangoDB database's replication applier.
 
 ```openapi
 paths:
-  /_api/replication/applier-config:
+  /_db/{database-name}/_api/replication/applier-config:
     get:
       operationId: getReplicationApplierConfig
       description: |
@@ -109,6 +109,14 @@ paths:
         - `restrictCollections`: the optional array of collections to include or exclude,
           based on the setting of `restrictType`
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -150,7 +158,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-config:
+  /_db/{database-name}/_api/replication/applier-config:
     put:
       operationId: updateReplicationApplierConfig
       description: |
@@ -162,6 +170,14 @@ paths:
         In case of success, the body of the response is a JSON object with the updated
         configuration.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -380,7 +396,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-start:
+  /_db/{database-name}/_api/replication/applier-start:
     put:
       operationId: startReplicationApplier
       description: |
@@ -396,6 +412,14 @@ paths:
         To detect replication applier errors after the applier was started, use the
         `/_api/replication/applier-state` API instead.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -462,13 +486,21 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-stop:
+  /_db/{database-name}/_api/replication/applier-stop:
     put:
       operationId: stopReplicationApplier
       description: |
         Stops the replication applier. This will return immediately if the
         replication applier is not running.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -522,7 +554,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/applier-state:
+  /_db/{database-name}/_api/replication/applier-state:
     get:
       operationId: getReplicationApplierState
       description: |
@@ -621,6 +653,14 @@ paths:
         values are only meaningful when compared to each other. Higher tick values mean
         "later in time" than lower tick values.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false
@@ -684,7 +724,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/make-follower:
+  /_db/{database-name}/_api/replication/make-follower:
     put:
       operationId: makeReplicationFollower
       description: |
@@ -804,6 +844,15 @@ paths:
         {{</* info */>}}
         This endpoint is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.13/develop/http-api/replication/replication-dump.md
+++ b/site/content/3.13/develop/http-api/replication/replication-dump.md
@@ -16,7 +16,7 @@ or the incremental data synchronization.
 
 ```openapi
 paths:
-  /_api/replication/inventory:
+  /_db/{database-name}/_api/replication/inventory:
     get:
       operationId: getReplicationInventory
       description: |
@@ -100,6 +100,14 @@ paths:
         under which each key represents a database name, and the value conforms to the above description.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: includeSystem
           in: query
           required: false
@@ -153,7 +161,7 @@ dumped.
 
 ```openapi
 paths:
-  /_api/replication/batch:
+  /_db/{database-name}/_api/replication/batch:
     post:
       operationId: createReplicationBatch
       description: |
@@ -177,6 +185,14 @@ paths:
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: state
           in: query
           required: false
@@ -218,7 +234,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/batch/{id}:
+  /_db/{database-name}/_api/replication/batch/{id}:
     delete:
       operationId: deleteReplicationBatch
       description: |
@@ -235,6 +251,14 @@ paths:
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -260,7 +284,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/batch/{id}:
+  /_db/{database-name}/_api/replication/batch/{id}:
     put:
       operationId: extendReplicationBatch
       description: |
@@ -279,6 +303,22 @@ paths:
         The very same request is forwarded synchronously to that DB-Server.
         It is an error if this attribute is not bound in the Coordinator case.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: |
+            The id of the batch.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -291,14 +331,6 @@ paths:
                   description: |
                     the time-to-live for the new batch (in seconds)
                   type: integer
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: |
-            The id of the batch.
-          schema:
-            type: string
       responses:
         '204':
           description: |
@@ -333,7 +365,7 @@ parts of the dump results in the same order as they are provided.
 
 ```openapi
 paths:
-  /_api/replication/dump:
+  /_db/{database-name}/_api/replication/dump:
     get:
       operationId: getReplicationDump
       description: |
@@ -378,6 +410,14 @@ paths:
         There will be no distinction between inserts and updates when calling this method.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -425,7 +465,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/tree:
+  /_db/{database-name}/_api/replication/revisions/tree:
     get:
       operationId: getReplicationRevisionTree
       description: |
@@ -467,6 +507,14 @@ paths:
         root is at index `0`, its children at indices `[1, branchingFactor]`, and so
         on.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -508,7 +556,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/tree:
+  /_db/{database-name}/_api/replication/revisions/tree:
     post:
       operationId: rebuildReplicationRevisionTree
       description: |
@@ -521,6 +569,14 @@ paths:
 
         If successful, there will be no return body.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -555,7 +611,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/ranges:
+  /_db/{database-name}/_api/replication/revisions/ranges:
     put:
       operationId: listReplicationRevisionRanges
       description: |
@@ -613,6 +669,14 @@ paths:
         in JavaScript, as it handles all numbers as floating point, and can only
         represent up to `2^53-1` faithfully.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -661,7 +725,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/revisions/documents:
+  /_db/{database-name}/_api/replication/revisions/documents:
     put:
       operationId: listReplicationRevisionDocuments
       description: |
@@ -701,6 +765,14 @@ paths:
         in JavaScript, as it handles all numbers as floating point, and can only
         represent up to `2^53-1` faithfully.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: collection
           in: query
           required: true
@@ -742,7 +814,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/sync:
+  /_db/{database-name}/_api/replication/sync:
     put:
       operationId: startReplicationSync
       description: |
@@ -778,6 +850,15 @@ paths:
         {{</* info */>}}
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -864,7 +945,7 @@ paths:
 
 ```openapi
 paths:
-  /_api/replication/clusterInventory:
+  /_db/{database-name}/_api/replication/clusterInventory:
     get:
       operationId: getReplicationClusterInventory
       description: |
@@ -876,6 +957,14 @@ paths:
         just that the `indexes` attribute there is relocated to adjust it to
         the data format of arangodump.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: includeSystem
           in: query
           required: false

--- a/site/content/3.13/develop/http-api/replication/replication-logger.md
+++ b/site/content/3.13/develop/http-api/replication/replication-logger.md
@@ -24,7 +24,7 @@ by a tick *date*) is still available on the Leader.
 
 ```openapi
 paths:
-  /_api/replication/logger-state:
+  /_db/{database-name}/_api/replication/logger-state:
     get:
       operationId: getReplicationLoggerState
       description: |
@@ -65,6 +65,15 @@ paths:
           - `lastServedTick`: last tick value served to this client via the WAL tailing API
 
           - `time`: date and time when this client last called the WAL tailing API
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -102,7 +111,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-follow:
+  /_db/{database-name}/_api/replication/logger-follow:
     get:
       operationId: getReplicationLoggerFollow
       description: |
@@ -202,6 +211,14 @@ paths:
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: from
           in: query
           required: false
@@ -334,7 +351,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-first-tick:
+  /_db/{database-name}/_api/replication/logger-first-tick:
     get:
       operationId: getReplicationLoggerFirstTick
       description: |
@@ -351,6 +368,15 @@ paths:
         {{</* info */>}}
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -388,7 +414,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/replication/logger-tick-ranges:
+  /_db/{database-name}/_api/replication/logger-tick-ranges:
     get:
       operationId: getReplicationLoggerTickRanges
       description: |
@@ -407,6 +433,15 @@ paths:
         - `tickMin`: minimum tick value contained in logfile
 
         - `tickMax`: maximum tick value contained in logfile
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/replication/write-ahead-log.md
+++ b/site/content/3.13/develop/http-api/replication/write-ahead-log.md
@@ -47,17 +47,6 @@ paths:
             `_system` database.
           schema:
             type: string
-        - name: database-name
-          in: path
-          required: true
-          example: _system
-          description: |
-            The name of a database. Which database you use doesn't matter as long
-            as the user account you authenticate with has at least read access
-            to this database. If the `--server.harden` startup option is enabled,
-            administrate access to the `_system` database is required.
-          schema:
-            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/replication/write-ahead-log.md
+++ b/site/content/3.13/develop/http-api/replication/write-ahead-log.md
@@ -23,7 +23,7 @@ full cluster and can thus not be removed until Replication 1 is gone.
 
 ```openapi
 paths:
-  /_api/wal/range:
+  /_db/{database-name}/_api/wal/range:
     get:
       operationId: getWalRange
       description: |
@@ -36,6 +36,28 @@ paths:
         - `tickMax`: maximum tick available
         - `time`: the server time as string in format `YYYY-MM-DDTHH:MM:SSZ`
         - `server`: An object with fields `version` and `serverId`
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -74,7 +96,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/wal/lastTick:
+  /_db/{database-name}/_api/wal/lastTick:
     get:
       operationId: getWalLastTick
       description: |
@@ -89,6 +111,17 @@ paths:
         {{</* info */>}}
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -126,7 +159,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/wal/tail:
+  /_db/{database-name}/_api/wal/tail:
     get:
       operationId: getWalTail
       description: |
@@ -232,6 +265,16 @@ paths:
         This method is not supported on a Coordinator in a cluster deployment.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. The user account you authenticate with needs
+            at least read access to this database and administrate access to the
+            `_system` database.
+          schema:
+            type: string
         - name: global
           in: query
           required: false

--- a/site/content/3.13/develop/http-api/security.md
+++ b/site/content/3.13/develop/http-api/security.md
@@ -111,7 +111,7 @@ paths:
         new user key.
 
         This is a protected API and can only be executed with superuser rights.
-        This API is not available on coordinator nodes.
+        This API is not available on Coordinator nodes.
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/security.md
+++ b/site/content/3.13/develop/http-api/security.md
@@ -20,7 +20,7 @@ See [Audit logging](../../operations/security/audit-logging.md#configuration).
 
 ```openapi
 paths:
-  /_admin/server/tls:
+  /_db/{database-name}/_admin/server/tls:
     get:
       operationId: getServerTls
       description: |
@@ -48,6 +48,18 @@ paths:
             JSON string with the SHA256 of the private key.
 
         This API requires authentication.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database. If the `--server.harden` startup option is enabled,
+            administrate access to the `_system` database is required.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -61,6 +73,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/tls:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: reloadServerTls
       description: |
@@ -88,6 +101,7 @@ paths:
 ```openapi
 paths:
   /_admin/server/encryption:
+  # Independent of database (superuser has access to all databases that exist)
     post:
       operationId: rotateEncryptionAtRestKey
       description: |

--- a/site/content/3.13/develop/http-api/tasks.md
+++ b/site/content/3.13/develop/http-api/tasks.md
@@ -10,11 +10,22 @@ description: >-
 
 ```openapi
 paths:
-  /_api/tasks/:
+  /_db/{database-name}/_api/tasks/:
     get:
       operationId: listTasks
       description: |
         fetches all existing tasks on the server
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -96,12 +107,22 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     get:
       operationId: getTask
       description: |
         fetches one existing task on the server specified by `id`
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -202,11 +223,20 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/tasks:
+  /_db/{database-name}/_api/tasks:
     post:
       operationId: createTask
       description: |
         creates a new task with a generated id
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -325,15 +355,14 @@ assert(response.code === 200);
 logJsonResponse(response);
 
 // Cleanup:
-logCurlRequest('DELETE', url + response.parsedBody.id);
-
+curlRequest('DELETE', url + response.parsedBody.id);
 ```
 
 ## Create a task with ID
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     put:
       operationId: createTaskWithId
       description: |
@@ -341,6 +370,14 @@ paths:
 
         Not compatible with load balancers.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true
@@ -417,12 +454,22 @@ curlRequest('DELETE', url + 'sampleTask');
 
 ```openapi
 paths:
-  /_api/tasks/{id}:
+  /_db/{database-name}/_api/tasks/{id}:
     delete:
       operationId: deleteTask
       description: |
         Deletes the task identified by `id` on the server.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has administrate access
+            to this database.
+          schema:
+            type: string
         - name: id
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/transactions/javascript-transactions.md
+++ b/site/content/3.13/develop/http-api/transactions/javascript-transactions.md
@@ -28,7 +28,7 @@ refer to [Transactions](../../transactions/_index.md).
 
 ```openapi
 paths:
-  /_api/transaction:
+  /_db/{database-name}/_api/transaction:
     post:
       operationId: executeJavaScriptTransaction
       description: |
@@ -72,6 +72,15 @@ paths:
         an error.
         Any other errors will be returned with any of the return codes
         *HTTP 400*, *HTTP 409*, or *HTTP 500*.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/site/content/3.13/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/3.13/develop/http-api/transactions/stream-transactions.md
@@ -37,7 +37,7 @@ Supported transactional API operations include:
 
 ```openapi
 paths:
-  /_api/transaction/begin:
+  /_db/{database-name}/_api/transaction/begin:
     post:
       operationId: beginStreamTransaction
       description: |
@@ -79,6 +79,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: x-arango-allow-dirty-read
           in: header
           required: false
@@ -106,7 +114,7 @@ paths:
                     transaction must be declared with the `write` or `exclusive` attribute or it
                     will fail, whereas non-declared collections from which is solely read will be
                     added lazily.
-                  type: string
+                  type: object
                 waitForSync:
                   description: |
                     an optional boolean flag that, if set, will force the
@@ -197,7 +205,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     get:
       operationId: getStreamTransaction
       description: |
@@ -208,6 +216,14 @@ paths:
 
         - `status`: the status of the transaction. One of "running", "committed" or "aborted".
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -263,7 +279,7 @@ db._drop("products");
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     put:
       operationId: commitStreamTransaction
       description: |
@@ -297,6 +313,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -356,7 +380,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/transaction/{transaction-id}:
+  /_db/{database-name}/_api/transaction/{transaction-id}:
     delete:
       operationId: abortStreamTransaction
       description: |
@@ -390,6 +414,14 @@ paths:
 
         - `errorMessage`: a descriptive error message
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: transaction-id
           in: path
           required: true
@@ -449,7 +481,7 @@ db._drop(cn);
 
 ```openapi
 paths:
-  /_api/transaction:
+  /_db/{database-name}/_api/transaction:
     get:
       operationId: listStreamTransactions
       description: |
@@ -461,6 +493,15 @@ paths:
 
         - `id`: the transaction's id
         - `state`: the transaction's status
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/users.md
+++ b/site/content/3.13/develop/http-api/users.md
@@ -6,6 +6,8 @@ description: >-
   The HTTP API for user management lets you create, modify, delete, and list
   ArangoDB user accounts, as well as grant and revoke permissions for databases
   and collections
+# GET|PUT|DELETE /_api/user/{user}/config and GET /_api/user/{user}/config/{key}
+# endpoints not documented on purpose because they are only used by the web interface
 ---
 The interface provides the means to manage database system users. All
 users managed through this interface are stored in the protected `_users`
@@ -29,12 +31,23 @@ User management operations are not included in ArangoDB's replication.
 
 ```openapi
 paths:
-  /_api/user:
+  /_db/{database-name}/_api/user:
     post:
       operationId: createUser
       description: |
         Create a new user. You need server access level *Administrate* in order to
         execute this REST call.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -108,7 +121,7 @@ require("@arangodb/users").remove("admin@example");
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     put:
       operationId: replaceUserData
       description: |
@@ -116,6 +129,16 @@ paths:
         *Administrate* in order to execute this REST call. Additionally, users can
         change their own data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -193,7 +216,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     patch:
       operationId: updateUserData
       description: |
@@ -201,6 +224,16 @@ paths:
         *Administrate* in order to execute this REST call. Additionally, users can
         change their own data.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -276,7 +309,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     delete:
       operationId: deleteUser
       description: |
@@ -285,6 +318,16 @@ paths:
         You need *Administrate* permissions for the server access level in order to
         execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -333,7 +376,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/user/{user}:
+  /_db/{database-name}/_api/user/{user}:
     get:
       operationId: getUser
       description: |
@@ -341,6 +384,16 @@ paths:
         yourself or you need the *Administrate* server access level in order to
         execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -390,7 +443,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/:
+  /_db/{database-name}/_api/user/:
     get:
       operationId: listUsers
       description: |
@@ -405,6 +458,17 @@ paths:
         - `active`: An optional flag that specifies whether the user is active.
         - `extra`: A JSON object with extra user information. It is used by the web
           interface to store graph viewer settings and saved queries.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -441,7 +505,7 @@ logJsonResponse(response);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     put:
       operationId: setUserDatabasePermissions
       description: |
@@ -463,6 +527,16 @@ paths:
                     - Use "none" to set the database access level to *No access*.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -474,7 +548,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to set the access level for.
           schema:
             type: string
       responses:
@@ -521,7 +595,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     put:
       operationId: setUserCollectionPermissions
       description: |
@@ -545,6 +619,16 @@ paths:
                     Use "none" to set the collection level access to *No access*.
                   type: string
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -556,14 +640,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to set the access level for.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection.
+            The name of the collection to set the access level for.
           schema:
             type: string
       responses:
@@ -614,7 +698,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     delete:
       operationId: deleteUserDatabasePermissions
       description: |
@@ -625,6 +709,16 @@ paths:
         You need write permissions (*Administrate* access level) for the `_system`
         database in order to execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -636,7 +730,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to clear the access level for.
           schema:
             type: string
       responses:
@@ -676,7 +770,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     delete:
       operationId: deleteUserCollectionPermissions
       description: |
@@ -688,6 +782,16 @@ paths:
         You need write permissions (*Administrate* access level) for the `_system`
         database in order to execute this REST call.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -699,14 +803,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database.
+            The name of the database to clear the access level for.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection.
+            The name of the collection to clear the access level for.
           schema:
             type: string
       responses:
@@ -749,7 +853,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/:
+  /_db/{database-name}/_api/user/{user}/database/:
     get:
       operationId: listUserDatabases
       description: |
@@ -766,6 +870,16 @@ paths:
         In case you specified `full`, the result will contain the permissions
         for the databases as well as the permissions for the collections.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -843,12 +957,22 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}:
     get:
       operationId: getUserDatabasePermissions
       description: |
         Fetch the database access level for a specific database
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -860,7 +984,7 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database to query
+            The name of the database to query the access level of.
           schema:
             type: string
       responses:
@@ -906,12 +1030,22 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_api/user/{user}/database/{dbname}/{collection}:
+  /_db/{database-name}/_api/user/{user}/database/{dbname}/{collection}:
     get:
       operationId: getUserCollectionPermissions
       description: |
         Returns the collection access level for a specific collection
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of a database. Which database you use doesn't matter as long
+            as the user account you authenticate with has at least read access
+            to this database and administrate access to the `_system` database.
+          schema:
+            type: string
         - name: user
           in: path
           required: true
@@ -923,14 +1057,14 @@ paths:
           in: path
           required: true
           description: |
-            The name of the database to query
+            The name of the database to query the access level of.
           schema:
             type: string
         - name: collection
           in: path
           required: true
           description: |
-            The name of the collection
+            The name of the collection to query the access level of.
           schema:
             type: string
       responses:

--- a/site/content/3.13/develop/http-api/views/arangosearch-views.md
+++ b/site/content/3.13/develop/http-api/views/arangosearch-views.md
@@ -10,12 +10,21 @@ description: >-
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     post:
       operationId: createView
       description: |
         Creates a new View with a given name and properties if it does not
         already exist.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -680,12 +689,20 @@ db._dropView("products");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     get:
       operationId: getView
       description: |
         Returns the basic information about a specific View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -810,12 +827,20 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     get:
       operationId: getViewProperties
       description: |
         Returns an object containing the definition of the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -1164,12 +1189,21 @@ db._drop("books");
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     get:
       operationId: listViews
       description: |
         Returns an object containing a listing of all Views in the current database,
         regardless of their type.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -1253,12 +1287,20 @@ db._dropView("reviewsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     put:
       operationId: replaceViewProperties
       description: |
         Changes all properties of a View by replacing them, except for immutable properties.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -1719,12 +1761,20 @@ db._dropView(view.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties:
+  /_db/{database-name}/_api/view/{view-name}/properties:
     patch:
       operationId: updateViewProperties
       description: |
         Partially changes the properties of a View by updating the specified attributes.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -2185,8 +2235,9 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/rename:
+  /_db/{database-name}/_api/view/{view-name}/rename:
     put:
+    # The PATCH method can be used as an alias
       operationId: renameView
       description: |
         Renames a View.
@@ -2195,6 +2246,14 @@ paths:
         Renaming Views is not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -2521,12 +2580,20 @@ db._dropView("catalogView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     delete:
       operationId: deleteView
       description: |
         Deletes the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true

--- a/site/content/3.13/develop/http-api/views/search-alias-views.md
+++ b/site/content/3.13/develop/http-api/views/search-alias-views.md
@@ -10,12 +10,21 @@ description: >-
 
 ```openapi
 paths:
-  /_api/view#searchalias:
+  /_db/{database-name}/_api/view#searchalias:
     post:
       operationId: createViewSearchAlias
       description: |
         Creates a new View with a given name and properties if it does not
         already exist.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -200,12 +209,20 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     get:
       operationId: getView
       description: |
         Returns the basic information about a specific View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -331,12 +348,20 @@ db._dropView("productsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     get:
       operationId: getViewPropertiesSearchAlias
       description: |
         Returns an object containing the definition of the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -504,12 +529,21 @@ db._drop("books");
 
 ```openapi
 paths:
-  /_api/view:
+  /_db/{database-name}/_api/view:
     get:
       operationId: listViews
       description: |
         Returns an object containing a listing of all Views in the current database,
         regardless of their type.
+      parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
       responses:
         '200':
           description: |
@@ -593,12 +627,20 @@ db._dropView("reviewsView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     put:
       operationId: replaceViewPropertiesSearchAlias
       description: |
         Replaces the list of indexes of a `search-alias` View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -774,12 +816,20 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/properties#searchalias:
+  /_db/{database-name}/_api/view/{view-name}/properties#searchalias:
     patch:
       operationId: updateViewPropertiesSearchAlias
       description: |
         Updates the list of indexes of a `search-alias` View.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -963,8 +1013,9 @@ db._drop(coll.name());
 
 ```openapi
 paths:
-  /_api/view/{view-name}/rename:
+  /_db/{database-name}/_api/view/{view-name}/rename:
     put:
+    # The PATCH method can be used as an alias
       operationId: renameView
       description: |
         Renames a View.
@@ -973,6 +1024,14 @@ paths:
         Renaming Views is not supported in cluster deployments.
         {{</* /info */>}}
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true
@@ -1116,12 +1175,20 @@ db._dropView("catalogView");
 
 ```openapi
 paths:
-  /_api/view/{view-name}:
+  /_db/{database-name}/_api/view/{view-name}:
     delete:
       operationId: deleteView
       description: |
         Deletes the View identified by `view-name`.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: view-name
           in: path
           required: true

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -1807,8 +1807,17 @@ blockquote p {
     color: #47afe8
 }
 
+.method-head {
+    color: #9012fe;
+}
 .method-post {
     color: #690;
+}
+.method-patch {
+    color: #00997a;
+}
+.method-put {
+    color: #ef8c1b;
 }
 
 .method-delete {


### PR DESCRIPTION
### Description

This makes it possible to use Swagger UI to execute operations in databases other than _system. Some endpoints require the use of the _system database.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
