### PR TITLE
add --enable-microsoft to arangograph authentication providers

### DIFF
--- a/site/content/3.11/arangograph/security-and-access-control/_index.md
+++ b/site/content/3.11/arangograph/security-and-access-control/_index.md
@@ -640,6 +640,7 @@ The following commands are available to configure this option:
   authenticated user has access
   - `--enable-github` - if set, allow access from user accounts authenticated via Github
   - `--enable-google` - if set, allow access from user accounts authenticated via Google
+  - `--enable-microsoft` - if set, allow access from user accounts authenticated via Microsoft
   - `--enable-username-password` - if set, allow access from user accounts
     authenticated via a username/password
 

--- a/site/content/3.12/arangograph/security-and-access-control/_index.md
+++ b/site/content/3.12/arangograph/security-and-access-control/_index.md
@@ -640,6 +640,7 @@ The following commands are available to configure this option:
   authenticated user has access
   - `--enable-github` - if set, allow access from user accounts authenticated via Github
   - `--enable-google` - if set, allow access from user accounts authenticated via Google
+  - `--enable-microsoft` - if set, allow access from user accounts authenticated via Microsoft
   - `--enable-username-password` - if set, allow access from user accounts
     authenticated via a username/password
 

--- a/site/content/3.13/arangograph/security-and-access-control/_index.md
+++ b/site/content/3.13/arangograph/security-and-access-control/_index.md
@@ -640,6 +640,7 @@ The following commands are available to configure this option:
   authenticated user has access
   - `--enable-github` - if set, allow access from user accounts authenticated via Github
   - `--enable-google` - if set, allow access from user accounts authenticated via Google
+  - `--enable-microsoft` - if set, allow access from user accounts authenticated via Microsoft
   - `--enable-username-password` - if set, allow access from user accounts
     authenticated via a username/password
 


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->
Adds Microsoft as an allowed authentication provider. 
Currently this documentation only lists github and google although microsoft is already allowed via oasisctl.
Did not add for version 3.10 since it is no longer available on ArangoGraph

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->
 
- 3.11: 
- 3.12: 
- 3.13: 
