### PR TITLE
add warning that IdP-Initiated SSO is not allowed

### DIFF
--- a/site/content/3.11/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.11/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -22,6 +22,15 @@ SAML SSO works by transferring user authentication data from the identity
 provider (IdP) to the service provider (SP) through an exchange of digitally
 signed XML documents.
 
+## IdP-initiated vs SP-initiated SSO
+
+There are two methods for starting Single Sign-On
+   - Identity Provider Initiated (IdP-initiated): you log into the Identity Provider and are then redirected to ArangoGraph
+   - Service Provider Initiated (SP-initiated): you access the ArangoGraph site which then redirects you to the Identity Provider for authentication
+
+ArangoGraph **only supports SP-initiated SSO** because IdP-Initiated is vulnerable to Man-in-the-Middle attacks.
+In order to initiate the SSO login process, you must start at ArangoGraph.
+
 ## Configure SAML 2.0 using Okta
 
 You can enable SSO for your ArangoGraph organization using Okta as an Identity
@@ -88,7 +97,3 @@ the SSO configuration.
    team via an ArangoGraph Support Ticket in order to complete the SSO
    configuration.
 
-{{< info >}}
-If you would like to enable SCIM provisioning in addition to the SSO SAML
-configuration, please refer to the [SCIM](scim-provisioning.md) documentation.
-{{< /info >}}

--- a/site/content/3.11/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.11/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -22,14 +22,19 @@ SAML SSO works by transferring user authentication data from the identity
 provider (IdP) to the service provider (SP) through an exchange of digitally
 signed XML documents.
 
-## IdP-initiated vs SP-initiated SSO
+## IdP-initiated versus SP-initiated SSO
 
-There are two methods for starting Single Sign-On
-   - Identity Provider Initiated (IdP-initiated): you log into the Identity Provider and are then redirected to ArangoGraph
-   - Service Provider Initiated (SP-initiated): you access the ArangoGraph site which then redirects you to the Identity Provider for authentication
+There are generally two methods for starting Single Sign-On:
 
-ArangoGraph **only supports SP-initiated SSO** because IdP-Initiated is vulnerable to Man-in-the-Middle attacks.
-In order to initiate the SSO login process, you must start at ArangoGraph.
+- **Identity Provider Initiated** (IdP-initiated):
+   You log into the Identity Provider and are then redirected to ArangoGraph.
+- **Service Provider Initiated** (SP-initiated):
+   You access the ArangoGraph site which then redirects you to the
+   Identity Provider for authentication.
+
+**ArangoGraph only supports SP-initiated SSO** because IdP-Initiated SSO is
+vulnerable to Man-in-the-Middle attacks. In order to initiate the SSO login
+process, you must start at ArangoGraph.
 
 ## Configure SAML 2.0 using Okta
 

--- a/site/content/3.12/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.12/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -22,6 +22,15 @@ SAML SSO works by transferring user authentication data from the identity
 provider (IdP) to the service provider (SP) through an exchange of digitally
 signed XML documents.
 
+## IdP-initiated vs SP-initiated SSO
+
+There are two methods for starting Single Sign-On
+   - Identity Provider Initiated (IdP-initiated): you log into the Identity Provider and are then redirected to ArangoGraph
+   - Service Provider Initiated (SP-initiated): you access the ArangoGraph site which then redirects you to the Identity Provider for authentication
+
+ArangoGraph **only supports SP-initiated SSO** because IdP-Initiated is vulnerable to Man-in-the-Middle attacks.
+In order to initiate the SSO login process, you must start at ArangoGraph.
+
 ## Configure SAML 2.0 using Okta
 
 You can enable SSO for your ArangoGraph organization using Okta as an Identity
@@ -88,7 +97,3 @@ the SSO configuration.
    team via an ArangoGraph Support Ticket in order to complete the SSO
    configuration.
 
-{{< info >}}
-If you would like to enable SCIM provisioning in addition to the SSO SAML
-configuration, please refer to the [SCIM](scim-provisioning.md) documentation.
-{{< /info >}}

--- a/site/content/3.12/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.12/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -22,14 +22,19 @@ SAML SSO works by transferring user authentication data from the identity
 provider (IdP) to the service provider (SP) through an exchange of digitally
 signed XML documents.
 
-## IdP-initiated vs SP-initiated SSO
+## IdP-initiated versus SP-initiated SSO
 
-There are two methods for starting Single Sign-On
-   - Identity Provider Initiated (IdP-initiated): you log into the Identity Provider and are then redirected to ArangoGraph
-   - Service Provider Initiated (SP-initiated): you access the ArangoGraph site which then redirects you to the Identity Provider for authentication
+There are generally two methods for starting Single Sign-On:
 
-ArangoGraph **only supports SP-initiated SSO** because IdP-Initiated is vulnerable to Man-in-the-Middle attacks.
-In order to initiate the SSO login process, you must start at ArangoGraph.
+- **Identity Provider Initiated** (IdP-initiated):
+   You log into the Identity Provider and are then redirected to ArangoGraph.
+- **Service Provider Initiated** (SP-initiated):
+   You access the ArangoGraph site which then redirects you to the
+   Identity Provider for authentication.
+
+**ArangoGraph only supports SP-initiated SSO** because IdP-Initiated SSO is
+vulnerable to Man-in-the-Middle attacks. In order to initiate the SSO login
+process, you must start at ArangoGraph.
 
 ## Configure SAML 2.0 using Okta
 

--- a/site/content/3.13/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.13/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -22,6 +22,15 @@ SAML SSO works by transferring user authentication data from the identity
 provider (IdP) to the service provider (SP) through an exchange of digitally
 signed XML documents.
 
+## IdP-initiated vs SP-initiated SSO
+
+There are two methods for starting Single Sign-On
+   - Identity Provider Initiated (IdP-initiated): you log into the Identity Provider and are then redirected to ArangoGraph
+   - Service Provider Initiated (SP-initiated): you access the ArangoGraph site which then redirects you to the Identity Provider for authentication
+
+ArangoGraph **only supports SP-initiated SSO** because IdP-Initiated is vulnerable to Man-in-the-Middle attacks.
+In order to initiate the SSO login process, you must start at ArangoGraph.
+
 ## Configure SAML 2.0 using Okta
 
 You can enable SSO for your ArangoGraph organization using Okta as an Identity
@@ -88,7 +97,3 @@ the SSO configuration.
    team via an ArangoGraph Support Ticket in order to complete the SSO
    configuration.
 
-{{< info >}}
-If you would like to enable SCIM provisioning in addition to the SSO SAML
-configuration, please refer to the [SCIM](scim-provisioning.md) documentation.
-{{< /info >}}

--- a/site/content/3.13/arangograph/security-and-access-control/single-sign-on/_index.md
+++ b/site/content/3.13/arangograph/security-and-access-control/single-sign-on/_index.md
@@ -22,14 +22,19 @@ SAML SSO works by transferring user authentication data from the identity
 provider (IdP) to the service provider (SP) through an exchange of digitally
 signed XML documents.
 
-## IdP-initiated vs SP-initiated SSO
+## IdP-initiated versus SP-initiated SSO
 
-There are two methods for starting Single Sign-On
-   - Identity Provider Initiated (IdP-initiated): you log into the Identity Provider and are then redirected to ArangoGraph
-   - Service Provider Initiated (SP-initiated): you access the ArangoGraph site which then redirects you to the Identity Provider for authentication
+There are generally two methods for starting Single Sign-On:
 
-ArangoGraph **only supports SP-initiated SSO** because IdP-Initiated is vulnerable to Man-in-the-Middle attacks.
-In order to initiate the SSO login process, you must start at ArangoGraph.
+- **Identity Provider Initiated** (IdP-initiated):
+   You log into the Identity Provider and are then redirected to ArangoGraph.
+- **Service Provider Initiated** (SP-initiated):
+   You access the ArangoGraph site which then redirects you to the
+   Identity Provider for authentication.
+
+**ArangoGraph only supports SP-initiated SSO** because IdP-Initiated SSO is
+vulnerable to Man-in-the-Middle attacks. In order to initiate the SSO login
+process, you must start at ArangoGraph.
 
 ## Configure SAML 2.0 using Okta
 


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->
Add clarification that only SP-Initiated SSO is available in ArangoGraph.
Remove comment about SCIM as it is no longer necessary. With current ArangoGraph SSO implementation, individual users do not need to be provisioned. All users from the allowed domain will have an account created in the organization but with no default permissions.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.11: 
- 3.12: 
- 3.13: 
