### PR TITLE
Construct 3.12 CHANGELOG link with shortcode

### DIFF
--- a/site/content/3.12/release-notes/_index.md
+++ b/site/content/3.12/release-notes/_index.md
@@ -31,7 +31,7 @@ For a detailed list of changes to the ArangoDB core programs and tools,
 please refer to the version specific changelogs:
 
 - Changelogs 3.x:
-  [3.12](https://raw.githubusercontent.com/arangodb/arangodb/3.12/CHANGELOG),
+  [3.12](https://raw.githubusercontent.com/arangodb/arangodb/{{< full-version "3.12" >}}/CHANGELOG),
   [3.11](https://raw.githubusercontent.com/arangodb/arangodb/3.11/CHANGELOG),
   [3.10](https://raw.githubusercontent.com/arangodb/arangodb/3.10/CHANGELOG),
   [3.9](https://raw.githubusercontent.com/arangodb/arangodb/3.9/CHANGELOG),

--- a/site/content/3.13/release-notes/_index.md
+++ b/site/content/3.13/release-notes/_index.md
@@ -33,7 +33,7 @@ please refer to the version specific changelogs:
 
 - Changelogs 3.x:
   [3.13](https://raw.githubusercontent.com/arangodb/arangodb/devel/CHANGELOG),
-  [3.12](https://raw.githubusercontent.com/arangodb/arangodb/3.12.0/CHANGELOG),
+  [3.12](https://raw.githubusercontent.com/arangodb/arangodb/{{< full-version "3.12" >}}/CHANGELOG),
   [3.11](https://raw.githubusercontent.com/arangodb/arangodb/3.11/CHANGELOG),
   [3.10](https://raw.githubusercontent.com/arangodb/arangodb/3.10/CHANGELOG),
   [3.9](https://raw.githubusercontent.com/arangodb/arangodb/3.9/CHANGELOG),

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/full-version.html
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/full-version.html
@@ -1,0 +1,7 @@
+{{ $ver := (.Get 0) -}}
+{{- $versions := (where .Site.Data.versions "name" $ver) -}}
+{{ if $versions -}}
+  {{ (index $versions 0).version | htmlEscape -}}
+{{ else -}}
+  {{ errorf "%q: Could not find version info for '%s'" .Page.Path $ver -}}
+{{ end -}}

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/full-version.html
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/full-version.html
@@ -3,5 +3,7 @@
 {{ if $versions -}}
   {{ (index $versions 0).version | htmlEscape -}}
 {{ else -}}
-  {{ errorf "%q: Could not find version info for '%s'" .Page.Path $ver -}}
+  {{ $path := "<non-file source>" -}}
+  {{ with .Page.File }}{{ $path = .Path }}{{ end -}}
+  {{ errorf "%q: Could not find version info for '%s'" $path $ver -}}
 {{ end -}}


### PR DESCRIPTION
### Description

Due to trunk-based development, there is no 3.12 upstream branch but only release branches (3.12.0 etc.). Create this particular link dynamically using the version information to have it update automatically.
#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
