### PR TITLE
DOC-707 | Deprecation of VelocyStream for v3.11

### DIFF
--- a/site/content/3.11/develop/http-api/general-request-handling.md
+++ b/site/content/3.11/develop/http-api/general-request-handling.md
@@ -17,6 +17,14 @@ which can be used for better throughput. HTTP requests are easily mappable
 to VelocyStream and no separate documentation exists as the API is essentially
 the same for both network protocols.
 
+{{< info >}}
+VelocyStream is deprecated in v3.11 and removed in v3.12.0.
+
+While VelocyStream support is still available in v3.11, it is highly recommended
+to already switch to the HTTP(S) protocol because of better performance and
+reliability.
+{{< /info >}}
+
 ArangoDB uses the standard HTTP methods (e.g. `GET`, `POST`, `PUT`, `DELETE`) plus
 the `PATCH` method described in [RFC 5789](http://tools.ietf.org/html/rfc5789).
 

--- a/site/content/3.11/release-notes/deprecated-and-removed-features.md
+++ b/site/content/3.11/release-notes/deprecated-and-removed-features.md
@@ -21,6 +21,11 @@ See the [Release notes](_index.md) of the respective versions for
 detailed information about breaking changes before upgrading.
 {{< /info >}}
 
+- **VelocyStream protocol**:
+  ArangoDB's own bi-directional asynchronous binary protocol VelocyStream (VST)
+  is deprecated in v3.11 and removed in v3.12.0. Use JSON or VelocyPack over the
+  HTTP(S) protocol instead.
+
 - **Little-endian on-disk key format for the RocksDB storage engine**:
 
   The little-endian on-disk key format for the RocksDB storage engine is

--- a/site/content/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -30,6 +30,15 @@ This is only the case if all of the following conditions are true:
 If you are affected, consider using Docker containers, `chroot`, or change
 `nsswitch.conf`.
 
+## VelocyStream protocol deprecation
+
+ArangoDB's own bi-directional asynchronous binary protocol VelocyStream (VST) is
+deprecated in v3.11 and removed in v3.12.0.
+
+While VelocyStream support is still available in v3.11, it is highly recommended
+to already switch to the HTTP(S) protocol because of better performance and
+reliability. ArangoDB supports both VelocyPack and JSON over HTTP(S).
+
 ## Active Failover deployment mode deprecation
 
 Running a single server with asynchronous replication to one or more passive

--- a/site/content/3.12/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/3.12/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -30,6 +30,15 @@ This is only the case if all of the following conditions are true:
 If you are affected, consider using Docker containers, `chroot`, or change
 `nsswitch.conf`.
 
+## VelocyStream protocol deprecation
+
+ArangoDB's own bi-directional asynchronous binary protocol VelocyStream (VST) is
+deprecated in v3.11 and removed in v3.12.0.
+
+While VelocyStream support is still available in v3.11, it is highly recommended
+to already switch to the HTTP(S) protocol because of better performance and
+reliability. ArangoDB supports both VelocyPack and JSON over HTTP(S).
+
 ## Active Failover deployment mode deprecation
 
 Running a single server with asynchronous replication to one or more passive

--- a/site/content/3.13/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/3.13/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -30,6 +30,15 @@ This is only the case if all of the following conditions are true:
 If you are affected, consider using Docker containers, `chroot`, or change
 `nsswitch.conf`.
 
+## VelocyStream protocol deprecation
+
+ArangoDB's own bi-directional asynchronous binary protocol VelocyStream (VST) is
+deprecated in v3.11 and removed in v3.12.0.
+
+While VelocyStream support is still available in v3.11, it is highly recommended
+to already switch to the HTTP(S) protocol because of better performance and
+reliability. ArangoDB supports both VelocyPack and JSON over HTTP(S).
+
 ## Active Failover deployment mode deprecation
 
 Running a single server with asynchronous replication to one or more passive


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
