### PR TITLE
DOC-699 | Individual log levels for log outputs

### DIFF
--- a/site/content/3.12/develop/http-api/monitoring/logs.md
+++ b/site/content/3.12/develop/http-api/monitoring/logs.md
@@ -288,6 +288,43 @@ paths:
             Forwards the request to the specified server.
           schema:
             type: string
+        - name: withAppenders
+          in: query
+          required: false
+          default: false
+          description: |
+            Set this option to `true` to return the individual log level settings
+            of all log outputs (`appenders`) as well as the `global` settings.
+
+            The response structure is as follows:
+
+            ```json
+            {
+              "global": {
+                "agency": "INFO",
+                "agencycomm": "INFO",
+                "agencystore": "WARNING",
+                ...
+              },
+              "appenders": {
+                "-": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                "file:///path/to/file": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                ...
+              }
+            }
+            ```
+          schema:
+            type: boolean
       responses:
         '200':
           description: |
@@ -347,6 +384,45 @@ paths:
             Forwards the request to the specified server.
           schema:
             type: string
+        - name: withAppenders
+          in: query
+          required: false
+          default: false
+          description: |
+            Set this option to `true` to set individual log level settings
+            for log outputs (`appenders`). The request and response structure is
+            as follows:
+
+            ```json
+            {
+              "global": {
+                "agency": "INFO",
+                "agencycomm": "INFO",
+                "agencystore": "WARNING",
+                ...
+              },
+              "appenders": {
+                "-": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                "file:///path/to/file": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                ...
+              }
+            }
+            ```
+
+            Changing the `global` settings affects all outputs and is the same
+            as setting a log level with this option turned off.
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -206,6 +206,58 @@ A new `deprecation` log topic has been added. It warns about deprecated features
 and the usage of options that will not be allowed or have no effect in a future
 version.
 
+The `GET /_admin/log/level` and `PUT /_admin/log/level` endpoints have been
+extended with a `withAppenders` query option to let you query and set log level
+settings for individual log outputs:
+
+```shell
+curl http://localhost:8529/_admin/log/level?withAppenders=true
+```
+
+If enabled, the response structure is as follows:
+
+```json
+{
+  "global": {
+    "agency": "INFO",
+    "agencycomm": "INFO",
+    "agencystore": "WARNING",
+    ...
+  },
+  "appenders": {
+    "-": {
+      "agency": "INFO",
+      "agencycomm": "INFO",
+      "agencystore": "WARNING",
+      ...
+    },
+    "file:///path/to/file": {
+      "agency": "INFO",
+      "agencycomm": "INFO",
+      "agencystore": "WARNING",
+      ...
+    },
+    ...
+  }
+}
+```
+
+The keys under `appenders` correspond to the configured log outputs
+(`--log.output` startup option, `-` stands for the standard output).
+The `global` levels are automatically set to the most verbose log level for that
+topic across all appenders.
+
+To change any of the log levels at runtime, you can send a request following the
+same structure:
+
+```shell
+curl -XPUT -d '{"global":{"queries":"DEBUG"},"appenders":{"-":{"requests":"ERROR"}}}' http://localhost:8529/_admin/log/level?withAppenders=true
+```
+
+Setting a global log level applies the value to all outputs for the specified
+topic. You can only change the log levels for individual log outputs (appenders)
+but not add new outputs at runtime.
+
 #### Error code `12` removed
 
 The unused error `ERROR_OUT_OF_MEMORY_MMAP` with the number `12` has been removed.

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -206,58 +206,6 @@ A new `deprecation` log topic has been added. It warns about deprecated features
 and the usage of options that will not be allowed or have no effect in a future
 version.
 
-The `GET /_admin/log/level` and `PUT /_admin/log/level` endpoints have been
-extended with a `withAppenders` query option to let you query and set log level
-settings for individual log outputs:
-
-```shell
-curl http://localhost:8529/_admin/log/level?withAppenders=true
-```
-
-If enabled, the response structure is as follows:
-
-```json
-{
-  "global": {
-    "agency": "INFO",
-    "agencycomm": "INFO",
-    "agencystore": "WARNING",
-    ...
-  },
-  "appenders": {
-    "-": {
-      "agency": "INFO",
-      "agencycomm": "INFO",
-      "agencystore": "WARNING",
-      ...
-    },
-    "file:///path/to/file": {
-      "agency": "INFO",
-      "agencycomm": "INFO",
-      "agencystore": "WARNING",
-      ...
-    },
-    ...
-  }
-}
-```
-
-The keys under `appenders` correspond to the configured log outputs
-(`--log.output` startup option, `-` stands for the standard output).
-The `global` levels are automatically set to the most verbose log level for that
-topic across all appenders.
-
-To change any of the log levels at runtime, you can send a request following the
-same structure:
-
-```shell
-curl -XPUT -d '{"global":{"queries":"DEBUG"},"appenders":{"-":{"requests":"ERROR"}}}' http://localhost:8529/_admin/log/level?withAppenders=true
-```
-
-Setting a global log level applies the value to all outputs for the specified
-topic. You can only change the log levels for individual log outputs (appenders)
-but not add new outputs at runtime.
-
 #### Error code `12` removed
 
 The unused error `ERROR_OUT_OF_MEMORY_MMAP` with the number `12` has been removed.
@@ -521,6 +469,62 @@ The option defaults to `false` so that fast locking is tried.
 
 See the [HTTP API](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction)
 for details.
+
+#### Log API
+
+<small>Introduced in: v3.12.2</small>
+
+The `GET /_admin/log/level` and `PUT /_admin/log/level` endpoints have been
+extended with a `withAppenders` query option to let you query and set log level
+settings for individual log outputs:
+
+```shell
+curl http://localhost:8529/_admin/log/level?withAppenders=true
+```
+
+If enabled, the response structure is as follows:
+
+```json
+{
+  "global": {
+    "agency": "INFO",
+    "agencycomm": "INFO",
+    "agencystore": "WARNING",
+    ...
+  },
+  "appenders": {
+    "-": {
+      "agency": "INFO",
+      "agencycomm": "INFO",
+      "agencystore": "WARNING",
+      ...
+    },
+    "file:///path/to/file": {
+      "agency": "INFO",
+      "agencycomm": "INFO",
+      "agencystore": "WARNING",
+      ...
+    },
+    ...
+  }
+}
+```
+
+The keys under `appenders` correspond to the configured log outputs
+(`--log.output` startup option, `-` stands for the standard output).
+The `global` levels are automatically set to the most verbose log level for that
+topic across all appenders.
+
+To change any of the log levels at runtime, you can send a request following the
+same structure:
+
+```shell
+curl -XPUT -d '{"global":{"queries":"DEBUG"},"appenders":{"-":{"requests":"ERROR"}}}' http://localhost:8529/_admin/log/level?withAppenders=true
+```
+
+Setting a global log level applies the value to all outputs for the specified
+topic. You can only change the log levels for individual log outputs (appenders)
+but not add new outputs at runtime.
 
 ### Endpoints deprecated
 

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1403,6 +1403,37 @@ See the [JavaScript API](../../develop/transactions/stream-transactions.md#javas
 and the [HTTP API](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction)
 for details.
 
+### Individual log levels per log output
+
+<small>Introduced in: v3.12.2</small>
+
+You can now configure the log level for each log topic per log output. You can
+use this feature to log verbosely to a file but print less information in the
+command-line, for instance.
+
+The repeatable `--log.level` startup option lets you set the log levels for
+log topics as before. You can now additionally specify the levels for individual
+topics in `--log.output` by appending a semicolon and a comma-separated mapping
+of log topics and levels after the destination to override the `--log.level`
+configuration:
+
+```shell
+--log.level memory=warning
+--log.output "file:///path/to/file;queries=trace,requests=info"
+--log.output "-;all=error"
+```
+
+This sets the log level to `warning` for the `memory` topic, which applies to
+all outputs unless overridden. The first output is a file with verbose `trace`
+logging for the `queries` topic, `info`-level logging for `requests`,
+`warning`-level logging for `memory`, and default levels for all other topics.
+The second output is to the standard output (command-line), using the `all`
+pseudo-topic to set the log levels to `error` for all topics. 
+
+Furthermore, the [HTTP API](../../develop/http-api/monitoring/logs.md#get-the-server-log-levels)
+has been extended to let you query and set the log levels for individual outputs
+at runtime.
+
 ## Client tools
 
 ### Protocol aliases for endpoints

--- a/site/content/3.13/develop/http-api/monitoring/logs.md
+++ b/site/content/3.13/develop/http-api/monitoring/logs.md
@@ -288,6 +288,43 @@ paths:
             Forwards the request to the specified server.
           schema:
             type: string
+        - name: withAppenders
+          in: query
+          required: false
+          default: false
+          description: |
+            Set this option to `true` to return the individual log level settings
+            of all log outputs (`appenders`) as well as the `global` settings.
+
+            The response structure is as follows:
+
+            ```json
+            {
+              "global": {
+                "agency": "INFO",
+                "agencycomm": "INFO",
+                "agencystore": "WARNING",
+                ...
+              },
+              "appenders": {
+                "-": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                "file:///path/to/file": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                ...
+              }
+            }
+            ```
+          schema:
+            type: boolean
       responses:
         '200':
           description: |
@@ -347,6 +384,45 @@ paths:
             Forwards the request to the specified server.
           schema:
             type: string
+        - name: withAppenders
+          in: query
+          required: false
+          default: false
+          description: |
+            Set this option to `true` to set individual log level settings
+            for log outputs (`appenders`). The request and response structure is
+            as follows:
+
+            ```json
+            {
+              "global": {
+                "agency": "INFO",
+                "agencycomm": "INFO",
+                "agencystore": "WARNING",
+                ...
+              },
+              "appenders": {
+                "-": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                "file:///path/to/file": {
+                  "agency": "INFO",
+                  "agencycomm": "INFO",
+                  "agencystore": "WARNING",
+                  ...
+                },
+                ...
+              }
+            }
+            ```
+
+            Changing the `global` settings affects all outputs and is the same
+            as setting a log level with this option turned off.
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:

--- a/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
@@ -470,6 +470,62 @@ The option defaults to `false` so that fast locking is tried.
 See the [HTTP API](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction)
 for details.
 
+#### Log API
+
+<small>Introduced in: v3.12.2</small>
+
+The `GET /_admin/log/level` and `PUT /_admin/log/level` endpoints have been
+extended with a `withAppenders` query option to let you query and set log level
+settings for individual log outputs:
+
+```shell
+curl http://localhost:8529/_admin/log/level?withAppenders=true
+```
+
+If enabled, the response structure is as follows:
+
+```json
+{
+  "global": {
+    "agency": "INFO",
+    "agencycomm": "INFO",
+    "agencystore": "WARNING",
+    ...
+  },
+  "appenders": {
+    "-": {
+      "agency": "INFO",
+      "agencycomm": "INFO",
+      "agencystore": "WARNING",
+      ...
+    },
+    "file:///path/to/file": {
+      "agency": "INFO",
+      "agencycomm": "INFO",
+      "agencystore": "WARNING",
+      ...
+    },
+    ...
+  }
+}
+```
+
+The keys under `appenders` correspond to the configured log outputs
+(`--log.output` startup option, `-` stands for the standard output).
+The `global` levels are automatically set to the most verbose log level for that
+topic across all appenders.
+
+To change any of the log levels at runtime, you can send a request following the
+same structure:
+
+```shell
+curl -XPUT -d '{"global":{"queries":"DEBUG"},"appenders":{"-":{"requests":"ERROR"}}}' http://localhost:8529/_admin/log/level?withAppenders=true
+```
+
+Setting a global log level applies the value to all outputs for the specified
+topic. You can only change the log levels for individual log outputs (appenders)
+but not add new outputs at runtime.
+
 ### Endpoints deprecated
 
 #### JavaScript Transactions API

--- a/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1403,6 +1403,37 @@ See the [JavaScript API](../../develop/transactions/stream-transactions.md#javas
 and the [HTTP API](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction)
 for details.
 
+### Individual log levels per log output
+
+<small>Introduced in: v3.12.2</small>
+
+You can now configure the log level for each log topic per log output. You can
+use this feature to log verbosely to a file but print less information in the
+command-line, for instance.
+
+The repeatable `--log.level` startup option lets you set the log levels for
+log topics as before. You can now additionally specify the levels for individual
+topics in `--log.output` by appending a semicolon and a comma-separated mapping
+of log topics and levels after the destination to override the `--log.level`
+configuration:
+
+```shell
+--log.level memory=warning
+--log.output "file:///path/to/file;queries=trace,requests=info"
+--log.output "-;all=error"
+```
+
+This sets the log level to `warning` for the `memory` topic, which applies to
+all outputs unless overridden. The first output is a file with verbose `trace`
+logging for the `queries` topic, `info`-level logging for `requests`,
+`warning`-level logging for `memory`, and default levels for all other topics.
+The second output is to the standard output (command-line), using the `all`
+pseudo-topic to set the log levels to `error` for all topics. 
+
+Furthermore, the [HTTP API](../../develop/http-api/monitoring/logs.md#get-the-server-log-levels)
+has been extended to let you query and set the log levels for individual outputs
+at runtime.
+
 ## Client tools
 
 ### Protocol aliases for endpoints


### PR DESCRIPTION
### Description

https://github.com/arangodb/arangodb/pull/21235

HTTP API Preview: https://deploy-preview-598--docs-hugo.netlify.app/stable/develop/http-api/monitoring/logs/#get-the-server-log-levels_query_withAppenders

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
