### PR TITLE
Fast object enumeration with `ENTRIES()`

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -97,6 +97,8 @@ rule have been added.
 
 A `push-limit-into-index` rule has been added in v3.12.2.
 
+A `replace-entries-with-object-iteration` rule has been added in v3.12.3.
+
 The affected endpoints are `POST /_api/cursor`, `POST /_api/explain`, and
 `GET /_api/query/rules`.
 

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -865,9 +865,44 @@ A new optimization has been implemented to improve the efficiency of the
 [`ENTRIES()` function](../../aql/functions/document-object.md#entries) in AQL.
 
 The new `replace-entries-with-object-iteration` optimizer rule can recognize a
-query pattern like `FOR [key, value] IN ENTRIES(obj) ...` and use a faster code
-path for iterating over the object that avoids copying a lot of key/value pairs
-and storing intermediate results.
+query pattern like `FOR obj IN source FOR [key, value] IN ENTRIES(obj) ...`
+and use a faster code path for iterating over the object that avoids copying a
+lot of key/value pairs and storing intermediate results.
+
+```aql
+LET source = [ { a: 1, b: 2 }, { c: 3 } ]
+
+FOR doc IN source // collection or array of objects
+  FOR [key, value] IN ENTRIES(doc)
+  RETURN CONCAT(key, value)
+```
+
+Without the optimization, the node with ID `6` uses a regular list iteration:
+
+```aql
+Execution plan:
+ Id   NodeType            Par   Est.   Comment
+  1   SingletonNode                1   * ROOT
+  2   CalculationNode       ✓      1     - LET source = [ { "a" : 1, "b" : 2 }, { "c" : 3 } ]   /* json expression */   /* const assignment */
+  4   EnumerateListNode     ✓      2     - FOR doc IN source   /* list iteration */
+  5   CalculationNode       ✓      2       - LET #7 = ENTRIES(doc)   /* simple expression */
+  6   EnumerateListNode     ✓    200       - FOR #4 IN #7   /* list iteration */
+  9   CalculationNode       ✓    200         - LET #8 = CONCAT(#4[0], #4[1])   /* simple expression */
+ 10   ReturnNode                 200         - RETURN #8
+```
+
+With the optimization applied, the faster object iteration is used:
+
+```aql
+Execution plan:
+ Id   NodeType            Par   Est.   Comment
+  1   SingletonNode                1   * ROOT
+  2   CalculationNode       ✓      1     - LET source = [ { "a" : 1, "b" : 2 }, { "c" : 3 } ]   /* json expression */   /* const assignment */
+  4   EnumerateListNode     ✓      2     - FOR doc IN source   /* list iteration */
+  6   EnumerateListNode     ✓    200       - FOR [key, value] OF doc   /* object iteration */
+  9   CalculationNode       ✓    200         - LET #8 = CONCAT(key, value)   /* simple expression */
+ 10   ReturnNode                 200         - RETURN #8
+```
 
 ## Indexing
 

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -857,8 +857,17 @@ FOR { firstName } IN names
 See [Array destructuring](../../aql/operators.md#array-destructuring) and
 [Object destructuring](../../aql/operators.md#object-destructuring) for details.
 
+### Fast object enumeration with `ENTRIES()`
 
+<small>Introduced in: v3.12.3</small>
 
+A new optimization has been implemented to improve the efficiency of the
+[`ENTRIES()` function](../../aql/functions/document-object.md#entries) in AQL.
+
+The new `replace-entries-with-object-iteration` optimizer rule can recognize a
+query pattern like `FOR [key, value] IN ENTRIES(obj) ...` and use a faster code
+path for iterating over the object that avoids copying a lot of key/value pairs
+and storing intermediate results.
 
 ## Indexing
 

--- a/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
@@ -97,6 +97,8 @@ rule have been added.
 
 A `push-limit-into-index` rule has been added in v3.12.2.
 
+A `replace-entries-with-object-iteration` rule has been added in v3.12.3.
+
 The affected endpoints are `POST /_api/cursor`, `POST /_api/explain`, and
 `GET /_api/query/rules`.
 

--- a/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
@@ -865,9 +865,44 @@ A new optimization has been implemented to improve the efficiency of the
 [`ENTRIES()` function](../../aql/functions/document-object.md#entries) in AQL.
 
 The new `replace-entries-with-object-iteration` optimizer rule can recognize a
-query pattern like `FOR [key, value] IN ENTRIES(obj) ...` and use a faster code
-path for iterating over the object that avoids copying a lot of key/value pairs
-and storing intermediate results.
+query pattern like `FOR obj IN source FOR [key, value] IN ENTRIES(obj) ...`
+and use a faster code path for iterating over the object that avoids copying a
+lot of key/value pairs and storing intermediate results.
+
+```aql
+LET source = [ { a: 1, b: 2 }, { c: 3 } ]
+
+FOR doc IN source // collection or array of objects
+  FOR [key, value] IN ENTRIES(doc)
+  RETURN CONCAT(key, value)
+```
+
+Without the optimization, the node with ID `6` uses a regular list iteration:
+
+```aql
+Execution plan:
+ Id   NodeType            Par   Est.   Comment
+  1   SingletonNode                1   * ROOT
+  2   CalculationNode       ✓      1     - LET source = [ { "a" : 1, "b" : 2 }, { "c" : 3 } ]   /* json expression */   /* const assignment */
+  4   EnumerateListNode     ✓      2     - FOR doc IN source   /* list iteration */
+  5   CalculationNode       ✓      2       - LET #7 = ENTRIES(doc)   /* simple expression */
+  6   EnumerateListNode     ✓    200       - FOR #4 IN #7   /* list iteration */
+  9   CalculationNode       ✓    200         - LET #8 = CONCAT(#4[0], #4[1])   /* simple expression */
+ 10   ReturnNode                 200         - RETURN #8
+```
+
+With the optimization applied, the faster object iteration is used:
+
+```aql
+Execution plan:
+ Id   NodeType            Par   Est.   Comment
+  1   SingletonNode                1   * ROOT
+  2   CalculationNode       ✓      1     - LET source = [ { "a" : 1, "b" : 2 }, { "c" : 3 } ]   /* json expression */   /* const assignment */
+  4   EnumerateListNode     ✓      2     - FOR doc IN source   /* list iteration */
+  6   EnumerateListNode     ✓    200       - FOR [key, value] OF doc   /* object iteration */
+  9   CalculationNode       ✓    200         - LET #8 = CONCAT(key, value)   /* simple expression */
+ 10   ReturnNode                 200         - RETURN #8
+```
 
 ## Indexing
 

--- a/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
@@ -857,8 +857,17 @@ FOR { firstName } IN names
 See [Array destructuring](../../aql/operators.md#array-destructuring) and
 [Object destructuring](../../aql/operators.md#object-destructuring) for details.
 
+### Fast object enumeration with `ENTRIES()`
 
+<small>Introduced in: v3.12.3</small>
 
+A new optimization has been implemented to improve the efficiency of the
+[`ENTRIES()` function](../../aql/functions/document-object.md#entries) in AQL.
+
+The new `replace-entries-with-object-iteration` optimizer rule can recognize a
+query pattern like `FOR [key, value] IN ENTRIES(obj) ...` and use a faster code
+path for iterating over the object that avoids copying a lot of key/value pairs
+and storing intermediate results.
 
 ## Indexing
 


### PR DESCRIPTION
### Description

New AQL optimizer rule `replace-entries-with-object-iteration`
https://github.com/arangodb/arangodb/pull/21186

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
