### PR TITLE
[DOC-708] Java Driver: removed mentions to VST in ArangoDB 3.12+

### DIFF
--- a/site/content/3.12/develop/drivers/java/reference-version-6/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-6/driver-setup.md
@@ -16,7 +16,7 @@ ArangoDB arangoDB = new ArangoDB.Builder().build();
 The driver is configured with some default values:
 
 | property-key             | description                             | default value  |
-|--------------------------|-----------------------------------------| -------------- |
+|--------------------------|-----------------------------------------|----------------|
 | arangodb.hosts           | ArangoDB hosts                          | 127.0.0.1:8529 |
 | arangodb.timeout         | connect & request timeout (millisecond) | 0              |
 | arangodb.user            | Basic Authentication User               | root           |
@@ -24,7 +24,7 @@ The driver is configured with some default values:
 | arangodb.jwt             | Authentication JWT                      |                |
 | arangodb.useSsl          | use SSL connection                      | false          |
 | arangodb.chunksize       | VelocyStream Chunk content-size (bytes) | 30000          |
-| arangodb.connections.max | max number of connections               | 1 VST, 20 HTTP |
+| arangodb.connections.max | max number of connections               | 20             |
 | arangodb.protocol        | used network protocol                   | VST            |
 
 To customize the configuration the parameters can be changed in the code...
@@ -157,11 +157,10 @@ ArangoDB arangoDB = new ArangoDB.Builder()
   .build();
 ```
 
-Since version 4.3 the driver support acquiring a list of known hosts in a
-cluster setup or a single server setup with followers. For this the driver has
+The driver is also able to acquire a list of known hosts in a cluster. For this the driver has
 to be able to successfully open a connection to at least one host to get the
-list of hosts. Then it can use this list when fallback is needed. To use this
-feature just pass `true` to the method `acquireHostList(boolean)`.
+list of hosts. Then it can use this list when fallback is needed. To enable this
+feature:
 
 ```java
 ArangoDB arangoDB = new ArangoDB.Builder()
@@ -233,23 +232,3 @@ Connection TTL can be disabled setting it to `null`:
 ```
 
 The default TTL is `null` (no automatic connection closure).
-
-## VST Keep-Alive
-
-Since version 6.8, the driver supports setting keep-alive interval (in seconds)
-for VST connections (but VST is not supported from ArangoDB v3.12.0 onward).
-If set, every VST connection will perform a no-op request
-at the specified intervals, to avoid to be closed due to inactivity by the
-server (or by the external environment, e.g. firewall, intermediate routers,
-operating system, ... ).
-
-This option can be set using the key `arangodb.connections.keepAlive.interval`
-in the properties file or programmatically from the driver builder:
-
-```java
-ArangoDB arangoDB = new ArangoDB.Builder()
-  .keepAliveInterval(1800) // 30 minutes
-  .build();
-```
-
-If not set or set to `null` (default), no keep-alive probes will be sent.

--- a/site/content/3.12/develop/drivers/java/reference-version-6/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-6/driver-setup.md
@@ -24,7 +24,7 @@ The driver is configured with some default values:
 | arangodb.jwt             | Authentication JWT                      |                |
 | arangodb.useSsl          | use SSL connection                      | false          |
 | arangodb.chunksize       | VelocyStream Chunk content-size (bytes) | 30000          |
-| arangodb.connections.max | max number of connections               | 20             |
+| arangodb.connections.max | max number of connections               | 1 VST, 20 HTTP |
 | arangodb.protocol        | used network protocol                   | VST            |
 
 To customize the configuration the parameters can be changed in the code...
@@ -157,10 +157,10 @@ ArangoDB arangoDB = new ArangoDB.Builder()
   .build();
 ```
 
-The driver is also able to acquire a list of known hosts in a cluster. For this the driver has
-to be able to successfully open a connection to at least one host to get the
-list of hosts. Then it can use this list when fallback is needed. To enable this
-feature:
+The driver is also able to acquire a list of known hosts in a cluster.
+For this the driver has to be able to successfully open a connection to at least
+one host to get the list of hosts. Then it can use this list when fallback is
+needed. You can enable this feature as follows:
 
 ```java
 ArangoDB arangoDB = new ArangoDB.Builder()

--- a/site/content/3.12/develop/drivers/java/reference-version-7/changes-in-version-7.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/changes-in-version-7.md
@@ -94,7 +94,7 @@ The main driver artifact `com.arangodb:arangodb-java-driver` has transitive depe
 - `com.arangodb:http-protocol`: `HTTP` communication protocol (HTTP/1.1 and HTTP/2)
 - `com.arangodb:jackson-serde-json`: `JSON` user-data serde module based on Jackson Databind
 
-Alternative user-data serde module is:
+Alternative module for user-data serde:
 - `com.arangodb:jackson-serde-vpack`: `VPACK` user-data serde module based on Jackson Databind
 
 The modules above are discovered and loaded using SPI (Service Provider Interface).
@@ -165,9 +165,8 @@ to use the [shaded version](#arangodb-java-driver-shaded) of this driver, which
 bundles all modules together with relocated external dependencies.
 
 The dependency on `com.arangodb:velocypack` has been removed from core module and
-is now only used as internal dependency by
-`com.arangodb:jackson-serde-vpack`, thus transitively imported only when using 
-`VPACK` content type.
+is now only used as internal dependency by `com.arangodb:jackson-serde-vpack`,
+thus transitively imported only when using `VPACK` content type.
 
 ## User Data
 

--- a/site/content/3.12/develop/drivers/java/reference-version-7/changes-in-version-7.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/changes-in-version-7.md
@@ -94,8 +94,7 @@ The main driver artifact `com.arangodb:arangodb-java-driver` has transitive depe
 - `com.arangodb:http-protocol`: `HTTP` communication protocol (HTTP/1.1 and HTTP/2)
 - `com.arangodb:jackson-serde-json`: `JSON` user-data serde module based on Jackson Databind
 
-Alternative modules are respectively:
-- `com.arangodb:vst-protocol`: `VST` communication protocol (no longer supported from ArangoDB v3.12.0 onward)
+Alternative user-data serde module is:
 - `com.arangodb:jackson-serde-vpack`: `VPACK` user-data serde module based on Jackson Databind
 
 The modules above are discovered and loaded using SPI (Service Provider Interface).
@@ -109,8 +108,6 @@ For example, to use the driver with `VPACK` over `HTTP`:
 - You can exclude `com.arangodb:jackson-serde-json`
 - You don't need to include `com.arangodb:http-protocol` because the driver
   includes it automatically
-- You don't need to exclude `com.arangodb:vst-protocol` because it is not
-  included automatically
 
 For example in Maven:
 
@@ -168,9 +165,9 @@ to use the [shaded version](#arangodb-java-driver-shaded) of this driver, which
 bundles all modules together with relocated external dependencies.
 
 The dependency on `com.arangodb:velocypack` has been removed from core module and
-is now only used as internal dependency by `com.arangodb:vst-protocol` and
-`com.arangodb:jackson-serde-vpack`, thus transitively imported only when using
-`VST` protocol or `VPACK` content type.
+is now only used as internal dependency by
+`com.arangodb:jackson-serde-vpack`, thus transitively imported only when using 
+`VPACK` content type.
 
 ## User Data
 

--- a/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
@@ -73,7 +73,7 @@ Here are examples to integrate configuration properties from different sources:
 `ArangoDB.Builder` has the following configuration methods:
 
 - `host(String, int)`:           adds a host (hostname and port) to connect to, multiple hosts can be added
-- `protocol(Protocol)`:          communication protocol, possible values are: `VST` (unsupported since ArangoDB 3.12), `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, (default: `HTTP2_JSON`)
+- `protocol(Protocol)`:          communication protocol, possible values are: `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, `VST` (unsupported from ArangoDB v3.12 onward), (default: `HTTP2_JSON`)
 - `timeout(Integer)`:            connection and request timeout (ms), (default `0`, no timeout)
 - `user(String)`:                username for authentication, (default: `root`)
 - `password(String)`:            password for authentication
@@ -127,7 +127,7 @@ file name can be specified using its overloaded variants.
 
 The properties read are:
 - `hosts`: comma-separated list of `<hostname>:<port>` entries
-- `protocol`: `VST` (unsupported since ArangoDB 3.12), `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON` or `HTTP2_VPACK`
+- `protocol`: `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, or `VST` (unsupported from ArangoDB v3.12 onward)
 - `timeout`
 - `user`
 - `password`
@@ -252,4 +252,3 @@ In this example, inactive connections are closed after 5 minutes.
 The default connection TTL is `30` seconds.
 
 If set to `null`, no automatic connection closure is performed.
-

--- a/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.12/develop/drivers/java/reference-version-7/driver-setup.md
@@ -73,7 +73,7 @@ Here are examples to integrate configuration properties from different sources:
 `ArangoDB.Builder` has the following configuration methods:
 
 - `host(String, int)`:           adds a host (hostname and port) to connect to, multiple hosts can be added
-- `protocol(Protocol)`:          communication protocol, possible values are: `VST`, `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, (default: `HTTP2_JSON`)
+- `protocol(Protocol)`:          communication protocol, possible values are: `VST` (unsupported since ArangoDB 3.12), `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, (default: `HTTP2_JSON`)
 - `timeout(Integer)`:            connection and request timeout (ms), (default `0`, no timeout)
 - `user(String)`:                username for authentication, (default: `root`)
 - `password(String)`:            password for authentication
@@ -81,10 +81,8 @@ Here are examples to integrate configuration properties from different sources:
 - `useSsl(Boolean)`:             use SSL connection, (default: `false`)
 - `sslContext(SSLContext)`:      SSL context
 - `verifyHost(Boolean)`:         enable hostname verification, (HTTP only, default: `true`)
-- `chunkSize(Integer)`:          VST chunk size in bytes, (default: `30000`)
-- `maxConnections(Integer)`:     max number of connections per host, (default: 1 VST, 1 HTTP/2, 20 HTTP/1.1)
-- `connectionTtl(Long)`:         time to live of an inactive connection (ms), (default: `30_000` for HTTP, no TTL for VST)
-- `keepAliveInterval(Integer)`:  VST keep-alive interval (s), (default: no keep-alive probes will be sent)
+- `maxConnections(Integer)`:     max number of connections per host, (default: `1` for `HTTP/2`, `20` for `HTTP/1.1`)
+- `connectionTtl(Long)`:         time to live of an inactive connection (ms), (default: `30_000`)
 - `acquireHostList(Boolean)`:    acquire the list of available hosts, (default: `false`)
 - `acquireHostListInterval(Integer)`:             acquireHostList interval (ms), (default: `3_600_000`, 1 hour)
 - `loadBalancingStrategy(LoadBalancingStrategy)`: load balancing strategy, possible values are: `NONE`, `ROUND_ROBIN`, `ONE_RANDOM`, (default: `NONE`)
@@ -129,7 +127,7 @@ file name can be specified using its overloaded variants.
 
 The properties read are:
 - `hosts`: comma-separated list of `<hostname>:<port>` entries
-- `protocol`: `VST`, `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON` or `HTTP2_VPACK`
+- `protocol`: `VST` (unsupported since ArangoDB 3.12), `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON` or `HTTP2_VPACK`
 - `timeout`
 - `user`
 - `password`
@@ -251,23 +249,7 @@ ArangoDB arango = new ArangoDB.Builder()
 
 In this example, inactive connections are closed after 5 minutes.
 
-The default TTL for HTTP connections is 30 seconds, while it is `null` for VST connections.
+The default connection TTL is `30` seconds.
 
 If set to `null`, no automatic connection closure is performed.
 
-## VST Keep-Alive
-
-The driver supports setting keep-alive interval (in seconds)
-for VST connections (but VST is not supported from ArangoDB v3.12.0 onward).
-If set, every VST connection performs a no-op request
-at the specified intervals, to avoid to be closed due to inactivity by the
-server (or by the external environment, e.g. firewall, intermediate routers,
-operating system, ... ).
-
-```java
-ArangoDB arangoDB = new ArangoDB.Builder()
-        .keepAliveInterval(1_800) // 30 minutes
-        .build();
-```
-
-If not set or set to `null` (default), no keep-alive probes will be sent.

--- a/site/content/3.13/develop/drivers/java/reference-version-6/driver-setup.md
+++ b/site/content/3.13/develop/drivers/java/reference-version-6/driver-setup.md
@@ -16,7 +16,7 @@ ArangoDB arangoDB = new ArangoDB.Builder().build();
 The driver is configured with some default values:
 
 | property-key             | description                             | default value  |
-|--------------------------|-----------------------------------------| -------------- |
+|--------------------------|-----------------------------------------|----------------|
 | arangodb.hosts           | ArangoDB hosts                          | 127.0.0.1:8529 |
 | arangodb.timeout         | connect & request timeout (millisecond) | 0              |
 | arangodb.user            | Basic Authentication User               | root           |
@@ -157,11 +157,10 @@ ArangoDB arangoDB = new ArangoDB.Builder()
   .build();
 ```
 
-Since version 4.3 the driver support acquiring a list of known hosts in a
-cluster setup or a single server setup with followers. For this the driver has
-to be able to successfully open a connection to at least one host to get the
-list of hosts. Then it can use this list when fallback is needed. To use this
-feature just pass `true` to the method `acquireHostList(boolean)`.
+The driver is also able to acquire a list of known hosts in a cluster.
+For this the driver has to be able to successfully open a connection to at least
+one host to get the list of hosts. Then it can use this list when fallback is
+needed. You can enable this feature as follows:
 
 ```java
 ArangoDB arangoDB = new ArangoDB.Builder()
@@ -233,23 +232,3 @@ Connection TTL can be disabled setting it to `null`:
 ```
 
 The default TTL is `null` (no automatic connection closure).
-
-## VST Keep-Alive
-
-Since version 6.8, the driver supports setting keep-alive interval (in seconds)
-for VST connections (but VST is not supported from ArangoDB v3.12.0 onward).
-If set, every VST connection will perform a no-op request
-at the specified intervals, to avoid to be closed due to inactivity by the
-server (or by the external environment, e.g. firewall, intermediate routers,
-operating system, ... ).
-
-This option can be set using the key `arangodb.connections.keepAlive.interval`
-in the properties file or programmatically from the driver builder:
-
-```java
-ArangoDB arangoDB = new ArangoDB.Builder()
-  .keepAliveInterval(1800) // 30 minutes
-  .build();
-```
-
-If not set or set to `null` (default), no keep-alive probes will be sent.

--- a/site/content/3.13/develop/drivers/java/reference-version-7/changes-in-version-7.md
+++ b/site/content/3.13/develop/drivers/java/reference-version-7/changes-in-version-7.md
@@ -94,8 +94,7 @@ The main driver artifact `com.arangodb:arangodb-java-driver` has transitive depe
 - `com.arangodb:http-protocol`: `HTTP` communication protocol (HTTP/1.1 and HTTP/2)
 - `com.arangodb:jackson-serde-json`: `JSON` user-data serde module based on Jackson Databind
 
-Alternative modules are respectively:
-- `com.arangodb:vst-protocol`: `VST` communication protocol (no longer supported from ArangoDB v3.12.0 onward)
+Alternative module for user-data serde:
 - `com.arangodb:jackson-serde-vpack`: `VPACK` user-data serde module based on Jackson Databind
 
 The modules above are discovered and loaded using SPI (Service Provider Interface).
@@ -109,8 +108,6 @@ For example, to use the driver with `VPACK` over `HTTP`:
 - You can exclude `com.arangodb:jackson-serde-json`
 - You don't need to include `com.arangodb:http-protocol` because the driver
   includes it automatically
-- You don't need to exclude `com.arangodb:vst-protocol` because it is not
-  included automatically
 
 For example in Maven:
 
@@ -168,9 +165,8 @@ to use the [shaded version](#arangodb-java-driver-shaded) of this driver, which
 bundles all modules together with relocated external dependencies.
 
 The dependency on `com.arangodb:velocypack` has been removed from core module and
-is now only used as internal dependency by `com.arangodb:vst-protocol` and
-`com.arangodb:jackson-serde-vpack`, thus transitively imported only when using
-`VST` protocol or `VPACK` content type.
+is now only used as internal dependency by `com.arangodb:jackson-serde-vpack`,
+thus transitively imported only when using `VPACK` content type.
 
 ## User Data
 

--- a/site/content/3.13/develop/drivers/java/reference-version-7/driver-setup.md
+++ b/site/content/3.13/develop/drivers/java/reference-version-7/driver-setup.md
@@ -73,7 +73,7 @@ Here are examples to integrate configuration properties from different sources:
 `ArangoDB.Builder` has the following configuration methods:
 
 - `host(String, int)`:           adds a host (hostname and port) to connect to, multiple hosts can be added
-- `protocol(Protocol)`:          communication protocol, possible values are: `VST`, `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, (default: `HTTP2_JSON`)
+- `protocol(Protocol)`:          communication protocol, possible values are: `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, `VST` (unsupported from ArangoDB v3.12 onward), (default: `HTTP2_JSON`)
 - `timeout(Integer)`:            connection and request timeout (ms), (default `0`, no timeout)
 - `user(String)`:                username for authentication, (default: `root`)
 - `password(String)`:            password for authentication
@@ -81,10 +81,8 @@ Here are examples to integrate configuration properties from different sources:
 - `useSsl(Boolean)`:             use SSL connection, (default: `false`)
 - `sslContext(SSLContext)`:      SSL context
 - `verifyHost(Boolean)`:         enable hostname verification, (HTTP only, default: `true`)
-- `chunkSize(Integer)`:          VST chunk size in bytes, (default: `30000`)
-- `maxConnections(Integer)`:     max number of connections per host, (default: 1 VST, 1 HTTP/2, 20 HTTP/1.1)
-- `connectionTtl(Long)`:         time to live of an inactive connection (ms), (default: `30_000` for HTTP, no TTL for VST)
-- `keepAliveInterval(Integer)`:  VST keep-alive interval (s), (default: no keep-alive probes will be sent)
+- `maxConnections(Integer)`:     max number of connections per host, (default: `1` for `HTTP/2`, `20` for `HTTP/1.1`)
+- `connectionTtl(Long)`:         time to live of an inactive connection (ms), (default: `30_000`)
 - `acquireHostList(Boolean)`:    acquire the list of available hosts, (default: `false`)
 - `acquireHostListInterval(Integer)`:             acquireHostList interval (ms), (default: `3_600_000`, 1 hour)
 - `loadBalancingStrategy(LoadBalancingStrategy)`: load balancing strategy, possible values are: `NONE`, `ROUND_ROBIN`, `ONE_RANDOM`, (default: `NONE`)
@@ -129,7 +127,7 @@ file name can be specified using its overloaded variants.
 
 The properties read are:
 - `hosts`: comma-separated list of `<hostname>:<port>` entries
-- `protocol`: `VST`, `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON` or `HTTP2_VPACK`
+- `protocol`: `HTTP_JSON`, `HTTP_VPACK`, `HTTP2_JSON`, `HTTP2_VPACK`, or `VST` (unsupported from ArangoDB v3.12 onward)
 - `timeout`
 - `user`
 - `password`
@@ -251,23 +249,6 @@ ArangoDB arango = new ArangoDB.Builder()
 
 In this example, inactive connections are closed after 5 minutes.
 
-The default TTL for HTTP connections is 30 seconds, while it is `null` for VST connections.
+The default connection TTL is `30` seconds.
 
 If set to `null`, no automatic connection closure is performed.
-
-## VST Keep-Alive
-
-The driver supports setting keep-alive interval (in seconds)
-for VST connections (but VST is not supported from ArangoDB v3.12.0 onward).
-If set, every VST connection performs a no-op request
-at the specified intervals, to avoid to be closed due to inactivity by the
-server (or by the external environment, e.g. firewall, intermediate routers,
-operating system, ... ).
-
-```java
-ArangoDB arangoDB = new ArangoDB.Builder()
-        .keepAliveInterval(1_800) // 30 minutes
-        .build();
-```
-
-If not set or set to `null` (default), no keep-alive probes will be sent.


### PR DESCRIPTION
Java Driver: removed mentions to VST in ArangoDB 3.12+