### PR TITLE
Use Hugo instead of CSS to capitalize HTTP API methods

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-openapi.html
@@ -34,7 +34,7 @@
   {{- range $path, $methods := .paths }}
     {{- range $method, $items := $methods }}
       <div class="endpoint">
-        <span class="endpoint-method regular-font upper bold-text method-{{ $method }}">{{ $method }}</span>
+        <span class="endpoint-method regular-font bold-text method-{{ $method }}">{{ upper $method }}</span>
         <span class="endpoint-path">{{ replaceRE "#.*" "" $path }}</span>
       </div>
       <div class="openapi-description regular-font">

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -1795,10 +1795,6 @@ blockquote p {
     font-family: var(--font-regular);
 }
 
-.upper {
-    text-transform: uppercase;
-}
-
 .bold-text {
     font-weight: bold;
 }


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
