### PR TITLE
DOC-715 | Add Java driver tutorial back again

### DIFF
--- a/site/content/3.11/develop/drivers/java/_index.md
+++ b/site/content/3.11/develop/drivers/java/_index.md
@@ -6,7 +6,6 @@ description: ''
 ---
 The official ArangoDB [Java Driver](https://github.com/arangodb/arangodb-java-driver).
 
-- [Tutorial](https://university.arangodb.com/courses/java-driver-tutorial-v7/)
 - [Code examples](https://github.com/arangodb/arangodb-java-driver/tree/main/driver/src/test/java/com/arangodb/example)
 - [Reference](reference-version-7/_index.md)
 - [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
@@ -26,7 +25,13 @@ Both versions are compatible with all supported stable versions of ArangoDB serv
 
 They are compatible with JDK 8 and higher versions.
 
-## Maven
+## Project configuration
+
+To use the ArangoDB Java driver, you need to import `arangodb-java-driver` as a
+library into your project. This is described below for the popular Java build
+automation systems Maven and Gradle.
+
+### Maven
 
 To add the driver to your project with Maven, add the following code to your
 `pom.xml` (substitute `7.x.x` with the latest driver version):
@@ -41,7 +46,7 @@ To add the driver to your project with Maven, add the following code to your
 </dependencies>
 ```
 
-## Gradle
+### Gradle
 
 To add the driver to your project with Gradle, add the following code to your
 `build.gradle` (substitute `7.x.x` with the latest driver version):
@@ -55,6 +60,287 @@ dependencies {
     implementation 'com.arangodb:arangodb-java-driver:7.x.x'
 }
 ```
+
+## Tutorial
+
+### Connect to ArangoDB
+
+Let's configure and open a connection to ArangoDB. The default connection is to
+`127.0.0.1:8529`. Change the connection details to point to your specific instance.
+
+```java
+ArangoDB arangoDB = new ArangoDB.Builder()
+        .host("localhost", 8529)
+        .user("root")
+        .password("")
+        .build();
+```
+
+For more connections options and details, see
+[Driver setup](reference-version-7/driver-setup.md).
+
+### Create a database
+
+Let's create a new database:
+
+```java
+ArangoDatabase db = arangoDB.db("mydb");
+System.out.println("Creating database...");
+db.create();
+```
+
+### Create a collection
+
+Now let's create our first collection:
+
+```java
+ArangoCollection collection = db.collection("firstCollection");
+System.out.println("Creating collection...");
+collection.create();
+```
+
+### Create a document
+
+Let's create a document in the collection. Any object can be added as a document
+to the database and be retrieved from the database as an object.
+
+This example uses the `BaseDocument` class, provided with the driver. The
+attributes of the document are stored in a map as `key<String>`/`value<Object>` pair:
+
+```java
+String key = "myKey";
+BaseDocument doc = new BaseDocument(key);
+doc.addAttribute("a", "Foo");
+doc.addAttribute("b", 42);
+System.out.println("Inserting document...");
+collection.insertDocument(doc);
+```
+
+Some details you should know about the code:
+
+- The document key is passed to the `BaseDocument` constructor
+- The `addAttribute()` method puts a new key/value pair into the document
+- Each attribute is stored as a single key value pair in the document root
+
+### Read a document
+
+Read the created document:
+
+```java
+System.out.println("Reading document...");
+BaseDocument readDocument = collection.getDocument(key, BaseDocument.class);
+System.out.println("Key: " + readDocument.getKey());
+System.out.println("Attribute a: " + readDocument.getAttribute("a"));
+System.out.println("Attribute b: " + readDocument.getAttribute("b"));
+```
+
+After executing this program, the console output should be:
+
+```text
+Key: myKey
+Attribute a: Foo
+Attribute b: 42
+```
+
+Some details you should know about the code:
+
+- The `getDocument()` method reads the stored document data and deserializes it
+  into the given class (`BaseDocument`)
+
+### Create a document from Jackson JsonNode
+
+You can also create a document from a Jackson
+[JsonNode](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/JsonNode.html)
+object:
+
+```java
+System.out.println("Creating a document from Jackson JsonNode...");
+String keyJackson = "myJacksonKey";
+JsonNode jsonNode = JsonNodeFactory.instance.objectNode()
+        .put("_key", keyJackson)
+        .put("a", "Bar")
+        .put("b", 53);
+System.out.println("Inserting document from Jackson JsonNode...");
+collection.insertDocument(jsonNode);
+```
+
+### Read a document as Jackson JsonNode
+
+You can also read a document as a Jackson
+[JsonNode](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/JsonNode.html):
+
+```java
+System.out.println("Reading document as Jackson JsonNode...");
+JsonNode readJsonNode = collection.getDocument(keyJackson, JsonNode.class);
+System.out.println("Key: " + readJsonNode.get("_key").textValue());
+System.out.println("Attribute a: " + readJsonNode.get("a").textValue());
+System.out.println("Attribute b: " + readJsonNode.get("b").intValue());
+```
+
+After executing this program, the console output should be:
+
+```text
+Key: myKey
+Attribute a: Bar
+Attribute b: 53
+```
+
+Some details you should know about the code:
+
+- The `getDocument()` method returns the stored document as instance of
+  `com.fasterxml.jackson.databind.JsonNode`.
+
+### Create a document from JSON String
+
+You can also create a document from raw JSON string:
+
+```java
+System.out.println("Creating a document from JSON String...");
+String keyJson = "myJsonKey";
+RawJson json = RawJson.of("{\"_key\":\"" + keyJson + "\",\"a\":\"Baz\",\"b\":64}");
+System.out.println("Inserting document from JSON String...");
+collection.insertDocument(json);
+```
+
+### Read a document as JSON String
+
+You can also read a document as raw JSON string:
+
+```java
+System.out.println("Reading document as JSON String...");
+RawJson readJson = collection.getDocument(keyJson, RawJson.class);
+System.out.println(readJson.get());
+```
+
+After executing this program, the console output should be:
+
+```text
+{"_key":"myJsonKey","_id":"firstCollection/myJsonKey","_rev":"_e0nEe2y---","a":"Baz","b":64}
+```
+
+### Update a document
+
+Let's update the document:
+
+```java
+doc.addAttribute("c", "Bar");
+System.out.println("Updating document ...");
+collection.updateDocument(key, doc);
+```
+
+### Read the document again
+
+Let's read the document again:
+
+```java
+System.out.println("Reading updated document ...");
+BaseDocument updatedDocument = collection.getDocument(key, BaseDocument.class);
+System.out.println("Key: " + updatedDocument.getKey());
+System.out.println("Attribute a: " + updatedDocument.getAttribute("a"));
+System.out.println("Attribute b: " + updatedDocument.getAttribute("b"));
+System.out.println("Attribute c: " + updatedDocument.getAttribute("c"));
+```
+
+After executing this program, the console output should look like this:
+
+```text
+Key: myKey
+Attribute a: Foo
+Attribute b: 42
+Attribute c: Bar
+```
+
+### Delete a document
+
+Let's delete a document:
+
+```java
+System.out.println("Deleting document ...");
+collection.deleteDocument(key);
+```
+
+### Execute AQL queries
+
+First, you need to create some documents with the name `Homer` in the
+collection called `firstCollection`:
+
+```java
+for (int i = 0; i < 10; i++) {
+    BaseDocument value = new BaseDocument(String.valueOf(i));
+    value.addAttribute("name", "Homer");
+    collection.insertDocument(value);
+}
+```
+
+Get all documents with the name `Homer` from the collection using an AQL query
+and iterate over the results:
+
+```java
+String query = "FOR t IN firstCollection FILTER t.name == @name RETURN t";
+Map<String, Object> bindVars = Collections.singletonMap("name", "Homer");
+System.out.println("Executing read query ...");
+ArangoCursor<BaseDocument> cursor = db.query(query, bindVars, null, BaseDocument.class);
+cursor.forEach(aDocument -> System.out.println("Key: " + aDocument.getKey()));
+```
+
+After executing this program, the console output should look something like this:
+
+```text
+Key: 1
+Key: 0
+Key: 5
+Key: 3
+Key: 4
+Key: 9
+Key: 2
+Key: 7
+Key: 8
+Key: 6
+```
+
+Some details you should know about the code:
+
+- The AQL query uses the placeholder `@name` that has to be bound to a value
+- The `query()` method executes the defined query and returns an `ArangoCursor`
+  with the given class (here: `BaseDocument`)
+- The order of is not guaranteed
+
+### Delete documents with AQL
+
+Delete previously created documents:
+
+```java
+String query = "FOR t IN firstCollection FILTER t.name == @name "
+    + "REMOVE t IN firstCollection LET removed = OLD RETURN removed";
+Map<String, Object> bindVars = Collections.singletonMap("name", "Homer");
+System.out.println("Executing delete query ...");
+ArangoCursor<BaseDocument> cursor = db.query(query, bindVars, null, BaseDocument.class);
+cursor.forEach(aDocument -> System.out.println("Removed document " + aDocument.getKey()));
+```
+
+After executing this program, the console output should look something like this:
+
+```text
+Removed document: 1
+Removed document: 0
+Removed document: 5
+Removed document: 3
+Removed document: 4
+Removed document: 9
+Removed document: 2
+Removed document: 7
+Removed document: 8
+Removed document: 6
+```
+
+### Learn more
+
+- Have a look at the [AQL documentation](../../../aql/) to lear about the
+  query language
+- See [Serialization](reference-version-7/serialization.md) for details about
+  user-data serde
+- For the full reference documentation, see
+  [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
 
 ## GraalVM Native Image
 

--- a/site/content/3.12/develop/drivers/java/_index.md
+++ b/site/content/3.12/develop/drivers/java/_index.md
@@ -6,7 +6,6 @@ description: ''
 ---
 The official ArangoDB [Java Driver](https://github.com/arangodb/arangodb-java-driver).
 
-- [Tutorial](https://university.arangodb.com/courses/java-driver-tutorial-v7/)
 - [Code examples](https://github.com/arangodb/arangodb-java-driver/tree/main/driver/src/test/java/com/arangodb/example)
 - [Reference](reference-version-7/_index.md)
 - [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
@@ -26,7 +25,13 @@ Both versions are compatible with all supported stable versions of ArangoDB serv
 
 They are compatible with JDK 8 and higher versions.
 
-## Maven
+## Project configuration
+
+To use the ArangoDB Java driver, you need to import `arangodb-java-driver` as a
+library into your project. This is described below for the popular Java build
+automation systems Maven and Gradle.
+
+### Maven
 
 To add the driver to your project with Maven, add the following code to your
 `pom.xml` (substitute `7.x.x` with the latest driver version):
@@ -41,7 +46,7 @@ To add the driver to your project with Maven, add the following code to your
 </dependencies>
 ```
 
-## Gradle
+### Gradle
 
 To add the driver to your project with Gradle, add the following code to your
 `build.gradle` (substitute `7.x.x` with the latest driver version):
@@ -55,6 +60,287 @@ dependencies {
     implementation 'com.arangodb:arangodb-java-driver:7.x.x'
 }
 ```
+
+## Tutorial
+
+### Connect to ArangoDB
+
+Let's configure and open a connection to ArangoDB. The default connection is to
+`127.0.0.1:8529`. Change the connection details to point to your specific instance.
+
+```java
+ArangoDB arangoDB = new ArangoDB.Builder()
+        .host("localhost", 8529)
+        .user("root")
+        .password("")
+        .build();
+```
+
+For more connections options and details, see
+[Driver setup](reference-version-7/driver-setup.md).
+
+### Create a database
+
+Let's create a new database:
+
+```java
+ArangoDatabase db = arangoDB.db("mydb");
+System.out.println("Creating database...");
+db.create();
+```
+
+### Create a collection
+
+Now let's create our first collection:
+
+```java
+ArangoCollection collection = db.collection("firstCollection");
+System.out.println("Creating collection...");
+collection.create();
+```
+
+### Create a document
+
+Let's create a document in the collection. Any object can be added as a document
+to the database and be retrieved from the database as an object.
+
+This example uses the `BaseDocument` class, provided with the driver. The
+attributes of the document are stored in a map as `key<String>`/`value<Object>` pair:
+
+```java
+String key = "myKey";
+BaseDocument doc = new BaseDocument(key);
+doc.addAttribute("a", "Foo");
+doc.addAttribute("b", 42);
+System.out.println("Inserting document...");
+collection.insertDocument(doc);
+```
+
+Some details you should know about the code:
+
+- The document key is passed to the `BaseDocument` constructor
+- The `addAttribute()` method puts a new key/value pair into the document
+- Each attribute is stored as a single key value pair in the document root
+
+### Read a document
+
+Read the created document:
+
+```java
+System.out.println("Reading document...");
+BaseDocument readDocument = collection.getDocument(key, BaseDocument.class);
+System.out.println("Key: " + readDocument.getKey());
+System.out.println("Attribute a: " + readDocument.getAttribute("a"));
+System.out.println("Attribute b: " + readDocument.getAttribute("b"));
+```
+
+After executing this program, the console output should be:
+
+```text
+Key: myKey
+Attribute a: Foo
+Attribute b: 42
+```
+
+Some details you should know about the code:
+
+- The `getDocument()` method reads the stored document data and deserializes it
+  into the given class (`BaseDocument`)
+
+### Create a document from Jackson JsonNode
+
+You can also create a document from a Jackson
+[JsonNode](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/JsonNode.html)
+object:
+
+```java
+System.out.println("Creating a document from Jackson JsonNode...");
+String keyJackson = "myJacksonKey";
+JsonNode jsonNode = JsonNodeFactory.instance.objectNode()
+        .put("_key", keyJackson)
+        .put("a", "Bar")
+        .put("b", 53);
+System.out.println("Inserting document from Jackson JsonNode...");
+collection.insertDocument(jsonNode);
+```
+
+### Read a document as Jackson JsonNode
+
+You can also read a document as a Jackson
+[JsonNode](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/JsonNode.html):
+
+```java
+System.out.println("Reading document as Jackson JsonNode...");
+JsonNode readJsonNode = collection.getDocument(keyJackson, JsonNode.class);
+System.out.println("Key: " + readJsonNode.get("_key").textValue());
+System.out.println("Attribute a: " + readJsonNode.get("a").textValue());
+System.out.println("Attribute b: " + readJsonNode.get("b").intValue());
+```
+
+After executing this program, the console output should be:
+
+```text
+Key: myKey
+Attribute a: Bar
+Attribute b: 53
+```
+
+Some details you should know about the code:
+
+- The `getDocument()` method returns the stored document as instance of
+  `com.fasterxml.jackson.databind.JsonNode`.
+
+### Create a document from JSON String
+
+You can also create a document from raw JSON string:
+
+```java
+System.out.println("Creating a document from JSON String...");
+String keyJson = "myJsonKey";
+RawJson json = RawJson.of("{\"_key\":\"" + keyJson + "\",\"a\":\"Baz\",\"b\":64}");
+System.out.println("Inserting document from JSON String...");
+collection.insertDocument(json);
+```
+
+### Read a document as JSON String
+
+You can also read a document as raw JSON string:
+
+```java
+System.out.println("Reading document as JSON String...");
+RawJson readJson = collection.getDocument(keyJson, RawJson.class);
+System.out.println(readJson.get());
+```
+
+After executing this program, the console output should be:
+
+```text
+{"_key":"myJsonKey","_id":"firstCollection/myJsonKey","_rev":"_e0nEe2y---","a":"Baz","b":64}
+```
+
+### Update a document
+
+Let's update the document:
+
+```java
+doc.addAttribute("c", "Bar");
+System.out.println("Updating document ...");
+collection.updateDocument(key, doc);
+```
+
+### Read the document again
+
+Let's read the document again:
+
+```java
+System.out.println("Reading updated document ...");
+BaseDocument updatedDocument = collection.getDocument(key, BaseDocument.class);
+System.out.println("Key: " + updatedDocument.getKey());
+System.out.println("Attribute a: " + updatedDocument.getAttribute("a"));
+System.out.println("Attribute b: " + updatedDocument.getAttribute("b"));
+System.out.println("Attribute c: " + updatedDocument.getAttribute("c"));
+```
+
+After executing this program, the console output should look like this:
+
+```text
+Key: myKey
+Attribute a: Foo
+Attribute b: 42
+Attribute c: Bar
+```
+
+### Delete a document
+
+Let's delete a document:
+
+```java
+System.out.println("Deleting document ...");
+collection.deleteDocument(key);
+```
+
+### Execute AQL queries
+
+First, you need to create some documents with the name `Homer` in the
+collection called `firstCollection`:
+
+```java
+for (int i = 0; i < 10; i++) {
+    BaseDocument value = new BaseDocument(String.valueOf(i));
+    value.addAttribute("name", "Homer");
+    collection.insertDocument(value);
+}
+```
+
+Get all documents with the name `Homer` from the collection using an AQL query
+and iterate over the results:
+
+```java
+String query = "FOR t IN firstCollection FILTER t.name == @name RETURN t";
+Map<String, Object> bindVars = Collections.singletonMap("name", "Homer");
+System.out.println("Executing read query ...");
+ArangoCursor<BaseDocument> cursor = db.query(query, bindVars, null, BaseDocument.class);
+cursor.forEach(aDocument -> System.out.println("Key: " + aDocument.getKey()));
+```
+
+After executing this program, the console output should look something like this:
+
+```text
+Key: 1
+Key: 0
+Key: 5
+Key: 3
+Key: 4
+Key: 9
+Key: 2
+Key: 7
+Key: 8
+Key: 6
+```
+
+Some details you should know about the code:
+
+- The AQL query uses the placeholder `@name` that has to be bound to a value
+- The `query()` method executes the defined query and returns an `ArangoCursor`
+  with the given class (here: `BaseDocument`)
+- The order of is not guaranteed
+
+### Delete documents with AQL
+
+Delete previously created documents:
+
+```java
+String query = "FOR t IN firstCollection FILTER t.name == @name "
+    + "REMOVE t IN firstCollection LET removed = OLD RETURN removed";
+Map<String, Object> bindVars = Collections.singletonMap("name", "Homer");
+System.out.println("Executing delete query ...");
+ArangoCursor<BaseDocument> cursor = db.query(query, bindVars, null, BaseDocument.class);
+cursor.forEach(aDocument -> System.out.println("Removed document " + aDocument.getKey()));
+```
+
+After executing this program, the console output should look something like this:
+
+```text
+Removed document: 1
+Removed document: 0
+Removed document: 5
+Removed document: 3
+Removed document: 4
+Removed document: 9
+Removed document: 2
+Removed document: 7
+Removed document: 8
+Removed document: 6
+```
+
+### Learn more
+
+- Have a look at the [AQL documentation](../../../aql/) to lear about the
+  query language
+- See [Serialization](reference-version-7/serialization.md) for details about
+  user-data serde
+- For the full reference documentation, see
+  [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
 
 ## GraalVM Native Image
 

--- a/site/content/3.13/develop/drivers/java/_index.md
+++ b/site/content/3.13/develop/drivers/java/_index.md
@@ -6,7 +6,6 @@ description: ''
 ---
 The official ArangoDB [Java Driver](https://github.com/arangodb/arangodb-java-driver).
 
-- [Tutorial](https://university.arangodb.com/courses/java-driver-tutorial-v7/)
 - [Code examples](https://github.com/arangodb/arangodb-java-driver/tree/main/driver/src/test/java/com/arangodb/example)
 - [Reference](reference-version-7/_index.md)
 - [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
@@ -26,7 +25,13 @@ Both versions are compatible with all supported stable versions of ArangoDB serv
 
 They are compatible with JDK 8 and higher versions.
 
-## Maven
+## Project configuration
+
+To use the ArangoDB Java driver, you need to import `arangodb-java-driver` as a
+library into your project. This is described below for the popular Java build
+automation systems Maven and Gradle.
+
+### Maven
 
 To add the driver to your project with Maven, add the following code to your
 `pom.xml` (substitute `7.x.x` with the latest driver version):
@@ -41,7 +46,7 @@ To add the driver to your project with Maven, add the following code to your
 </dependencies>
 ```
 
-## Gradle
+### Gradle
 
 To add the driver to your project with Gradle, add the following code to your
 `build.gradle` (substitute `7.x.x` with the latest driver version):
@@ -55,6 +60,287 @@ dependencies {
     implementation 'com.arangodb:arangodb-java-driver:7.x.x'
 }
 ```
+
+## Tutorial
+
+### Connect to ArangoDB
+
+Let's configure and open a connection to ArangoDB. The default connection is to
+`127.0.0.1:8529`. Change the connection details to point to your specific instance.
+
+```java
+ArangoDB arangoDB = new ArangoDB.Builder()
+        .host("localhost", 8529)
+        .user("root")
+        .password("")
+        .build();
+```
+
+For more connections options and details, see
+[Driver setup](reference-version-7/driver-setup.md).
+
+### Create a database
+
+Let's create a new database:
+
+```java
+ArangoDatabase db = arangoDB.db("mydb");
+System.out.println("Creating database...");
+db.create();
+```
+
+### Create a collection
+
+Now let's create our first collection:
+
+```java
+ArangoCollection collection = db.collection("firstCollection");
+System.out.println("Creating collection...");
+collection.create();
+```
+
+### Create a document
+
+Let's create a document in the collection. Any object can be added as a document
+to the database and be retrieved from the database as an object.
+
+This example uses the `BaseDocument` class, provided with the driver. The
+attributes of the document are stored in a map as `key<String>`/`value<Object>` pair:
+
+```java
+String key = "myKey";
+BaseDocument doc = new BaseDocument(key);
+doc.addAttribute("a", "Foo");
+doc.addAttribute("b", 42);
+System.out.println("Inserting document...");
+collection.insertDocument(doc);
+```
+
+Some details you should know about the code:
+
+- The document key is passed to the `BaseDocument` constructor
+- The `addAttribute()` method puts a new key/value pair into the document
+- Each attribute is stored as a single key value pair in the document root
+
+### Read a document
+
+Read the created document:
+
+```java
+System.out.println("Reading document...");
+BaseDocument readDocument = collection.getDocument(key, BaseDocument.class);
+System.out.println("Key: " + readDocument.getKey());
+System.out.println("Attribute a: " + readDocument.getAttribute("a"));
+System.out.println("Attribute b: " + readDocument.getAttribute("b"));
+```
+
+After executing this program, the console output should be:
+
+```text
+Key: myKey
+Attribute a: Foo
+Attribute b: 42
+```
+
+Some details you should know about the code:
+
+- The `getDocument()` method reads the stored document data and deserializes it
+  into the given class (`BaseDocument`)
+
+### Create a document from Jackson JsonNode
+
+You can also create a document from a Jackson
+[JsonNode](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/JsonNode.html)
+object:
+
+```java
+System.out.println("Creating a document from Jackson JsonNode...");
+String keyJackson = "myJacksonKey";
+JsonNode jsonNode = JsonNodeFactory.instance.objectNode()
+        .put("_key", keyJackson)
+        .put("a", "Bar")
+        .put("b", 53);
+System.out.println("Inserting document from Jackson JsonNode...");
+collection.insertDocument(jsonNode);
+```
+
+### Read a document as Jackson JsonNode
+
+You can also read a document as a Jackson
+[JsonNode](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/JsonNode.html):
+
+```java
+System.out.println("Reading document as Jackson JsonNode...");
+JsonNode readJsonNode = collection.getDocument(keyJackson, JsonNode.class);
+System.out.println("Key: " + readJsonNode.get("_key").textValue());
+System.out.println("Attribute a: " + readJsonNode.get("a").textValue());
+System.out.println("Attribute b: " + readJsonNode.get("b").intValue());
+```
+
+After executing this program, the console output should be:
+
+```text
+Key: myKey
+Attribute a: Bar
+Attribute b: 53
+```
+
+Some details you should know about the code:
+
+- The `getDocument()` method returns the stored document as instance of
+  `com.fasterxml.jackson.databind.JsonNode`.
+
+### Create a document from JSON String
+
+You can also create a document from raw JSON string:
+
+```java
+System.out.println("Creating a document from JSON String...");
+String keyJson = "myJsonKey";
+RawJson json = RawJson.of("{\"_key\":\"" + keyJson + "\",\"a\":\"Baz\",\"b\":64}");
+System.out.println("Inserting document from JSON String...");
+collection.insertDocument(json);
+```
+
+### Read a document as JSON String
+
+You can also read a document as raw JSON string:
+
+```java
+System.out.println("Reading document as JSON String...");
+RawJson readJson = collection.getDocument(keyJson, RawJson.class);
+System.out.println(readJson.get());
+```
+
+After executing this program, the console output should be:
+
+```text
+{"_key":"myJsonKey","_id":"firstCollection/myJsonKey","_rev":"_e0nEe2y---","a":"Baz","b":64}
+```
+
+### Update a document
+
+Let's update the document:
+
+```java
+doc.addAttribute("c", "Bar");
+System.out.println("Updating document ...");
+collection.updateDocument(key, doc);
+```
+
+### Read the document again
+
+Let's read the document again:
+
+```java
+System.out.println("Reading updated document ...");
+BaseDocument updatedDocument = collection.getDocument(key, BaseDocument.class);
+System.out.println("Key: " + updatedDocument.getKey());
+System.out.println("Attribute a: " + updatedDocument.getAttribute("a"));
+System.out.println("Attribute b: " + updatedDocument.getAttribute("b"));
+System.out.println("Attribute c: " + updatedDocument.getAttribute("c"));
+```
+
+After executing this program, the console output should look like this:
+
+```text
+Key: myKey
+Attribute a: Foo
+Attribute b: 42
+Attribute c: Bar
+```
+
+### Delete a document
+
+Let's delete a document:
+
+```java
+System.out.println("Deleting document ...");
+collection.deleteDocument(key);
+```
+
+### Execute AQL queries
+
+First, you need to create some documents with the name `Homer` in the
+collection called `firstCollection`:
+
+```java
+for (int i = 0; i < 10; i++) {
+    BaseDocument value = new BaseDocument(String.valueOf(i));
+    value.addAttribute("name", "Homer");
+    collection.insertDocument(value);
+}
+```
+
+Get all documents with the name `Homer` from the collection using an AQL query
+and iterate over the results:
+
+```java
+String query = "FOR t IN firstCollection FILTER t.name == @name RETURN t";
+Map<String, Object> bindVars = Collections.singletonMap("name", "Homer");
+System.out.println("Executing read query ...");
+ArangoCursor<BaseDocument> cursor = db.query(query, bindVars, null, BaseDocument.class);
+cursor.forEach(aDocument -> System.out.println("Key: " + aDocument.getKey()));
+```
+
+After executing this program, the console output should look something like this:
+
+```text
+Key: 1
+Key: 0
+Key: 5
+Key: 3
+Key: 4
+Key: 9
+Key: 2
+Key: 7
+Key: 8
+Key: 6
+```
+
+Some details you should know about the code:
+
+- The AQL query uses the placeholder `@name` that has to be bound to a value
+- The `query()` method executes the defined query and returns an `ArangoCursor`
+  with the given class (here: `BaseDocument`)
+- The order of is not guaranteed
+
+### Delete documents with AQL
+
+Delete previously created documents:
+
+```java
+String query = "FOR t IN firstCollection FILTER t.name == @name "
+    + "REMOVE t IN firstCollection LET removed = OLD RETURN removed";
+Map<String, Object> bindVars = Collections.singletonMap("name", "Homer");
+System.out.println("Executing delete query ...");
+ArangoCursor<BaseDocument> cursor = db.query(query, bindVars, null, BaseDocument.class);
+cursor.forEach(aDocument -> System.out.println("Removed document " + aDocument.getKey()));
+```
+
+After executing this program, the console output should look something like this:
+
+```text
+Removed document: 1
+Removed document: 0
+Removed document: 5
+Removed document: 3
+Removed document: 4
+Removed document: 9
+Removed document: 2
+Removed document: 7
+Removed document: 8
+Removed document: 6
+```
+
+### Learn more
+
+- Have a look at the [AQL documentation](../../../aql/) to lear about the
+  query language
+- See [Serialization](reference-version-7/serialization.md) for details about
+  user-data serde
+- For the full reference documentation, see
+  [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
 
 ## GraalVM Native Image
 


### PR DESCRIPTION
### Description

Omitted from the developer hub at the moment:
- [Untyped data structures](https://developer.arangodb.com/docs/develop/develop%20java/java%20untyped%20data%20structures): this seems largely redundant but should we add something beginner-friendly about the `BaseDocument` class? Maybe just link to JavaDoc or the source code?
- [Importing graph data with Stream Transactions](https://developer.arangodb.com/docs/develop/develop%20java/java%20importing%20graph%20data%20with%20stream%20transactions): The content seems incomplete and unpolished. Showing how Stream Transactions work can be added later, in the respective chapter. Should we add something about bulk inserting though? Is there a specific reason for inserting graph vertices and edges transactionally with the Stream Transaction API? What motivated this example?

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
