### PR TITLE
Fixing typo in collections API

### DIFF
--- a/site/content/3.10/develop/http-api/collections.md
+++ b/site/content/3.10/develop/http-api/collections.md
@@ -1106,7 +1106,7 @@ paths:
                       description: |
                         If set to `true`, then you are allowed to supply own key values in the
                         `_key` attribute of documents. If set to `false`, then the key generator
-                        is solely be responsible for generating keys and an error is raised if you
+                        is solely responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
 
 

--- a/site/content/3.10/develop/http-api/collections.md
+++ b/site/content/3.10/develop/http-api/collections.md
@@ -1106,7 +1106,7 @@ paths:
                       description: |
                         If set to `true`, then you are allowed to supply own key values in the
                         `_key` attribute of documents. If set to `false`, then the key generator
-                        is solely responsible for generating keys and an error is raised if you
+                        is solely be responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
 
 

--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -2457,7 +2457,7 @@ paths:
                       description: |
                         If set to `true`, then you are allowed to supply own key values in the
                         `_key` attribute of documents. If set to `false`, then the key generator
-                        is solely be responsible for generating keys and an error is raised if you
+                        is solely responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
 
 

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -2519,7 +2519,7 @@ paths:
                       description: |
                         If set to `true`, then you are allowed to supply own key values in the
                         `_key` attribute of documents. If set to `false`, then the key generator
-                        is solely be responsible for generating keys and an error is raised if you
+                        is solely responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
 
 

--- a/site/content/3.13/develop/http-api/collections.md
+++ b/site/content/3.13/develop/http-api/collections.md
@@ -2519,7 +2519,7 @@ paths:
                       description: |
                         If set to `true`, then you are allowed to supply own key values in the
                         `_key` attribute of documents. If set to `false`, then the key generator
-                        is solely be responsible for generating keys and an error is raised if you
+                        is solely responsible for generating keys and an error is raised if you
                         supply own key values in the `_key` attribute of documents.
 
 


### PR DESCRIPTION
### Description

Simple fix. The expression does not need a "be" verb.