### PR TITLE
Add cursor statistics `documentLookups` and `seeks`

### DIFF
--- a/site/content/3.11/deploy/cluster/administration.md
+++ b/site/content/3.11/deploy/cluster/administration.md
@@ -291,22 +291,22 @@ console.log("Checking shard distribution every %d seconds...", sleep);
 
 var count;
 do {
-    count = 0;
-    for (dbase in dblist) {
-        var sd = arango.GET("/_db/" + dblist[dbase] + "/_admin/cluster/shardDistribution");
-        var collections = sd.results;
-        for (collection in collections) {
-        var current = collections[collection].Current;
-        for (shard in current) {
-            if (current[shard].leader == server) {
-            ++count;
-            }
+  count = 0;
+  for (dbase in dblist) {
+    var sd = arango.GET("/_db/" + dblist[dbase] + "/_admin/cluster/shardDistribution");
+    var collections = sd.results;
+    for (collection in collections) {
+      var current = collections[collection].Current;
+      for (shard in current) {
+        if (current[shard].leader == server) {
+          ++count;
         }
-        }
+      }
     }
-    console.log("Shards to be moved away from node %s: %d", server, count);
-    if (count == 0) break;
-    internal.wait(sleep);
+  }
+  console.log("Shards to be moved away from node %s: %d", server, count);
+  if (count == 0) break;
+  internal.wait(sleep);
 } while (count > 0);
 ```
 

--- a/site/content/3.11/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.11/develop/http-api/queries/aql-queries.md
@@ -729,6 +729,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -1419,8 +1420,6 @@ paths:
                     required:
                       - warnings
                       - stats
-                      - warnings
-                      - stats
                     properties:
                       warnings:
                         description: |
@@ -1429,8 +1428,6 @@ paths:
                         items:
                           type: object
                           required:
-                            - code
-                            - message
                             - code
                             - message
                           properties:
@@ -1459,18 +1456,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -1576,10 +1562,6 @@ paths:
                                 - calls
                                 - items
                                 - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
                               properties:
                                 id:
                                   description: |
@@ -1604,15 +1586,6 @@ paths:
                           The duration of the different query execution phases in seconds.
                         type: object
                         required:
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
                           - initializing
                           - parsing
                           - optimizing ast
@@ -1662,13 +1635,6 @@ paths:
                           - estimatedCost
                           - estimatedNrItems
                           - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
                         properties:
                           nodes:
                             description: |
@@ -1690,8 +1656,6 @@ paths:
                             items:
                               type: object
                               required:
-                                - name
-                                - type
                                 - name
                                 - type
                               properties:
@@ -2074,10 +2038,6 @@ paths:
                     required:
                       - warnings
                       - stats
-                      - warnings
-                      - stats
-                      - warnings
-                      - stats
                     properties:
                       warnings:
                         description: |
@@ -2086,10 +2046,6 @@ paths:
                         items:
                           type: object
                           required:
-                            - code
-                            - message
-                            - code
-                            - message
                             - code
                             - message
                           properties:
@@ -2118,30 +2074,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -2247,14 +2180,6 @@ paths:
                                 - calls
                                 - items
                                 - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
                               properties:
                                 id:
                                   description: |
@@ -2279,24 +2204,6 @@ paths:
                           The duration of the different query execution phases in seconds.
                         type: object
                         required:
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
                           - initializing
                           - parsing
                           - optimizing ast
@@ -2346,20 +2253,6 @@ paths:
                           - estimatedCost
                           - estimatedNrItems
                           - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
                         properties:
                           nodes:
                             description: |
@@ -2381,10 +2274,6 @@ paths:
                             items:
                               type: object
                               required:
-                                - name
-                                - type
-                                - name
-                                - type
                                 - name
                                 - type
                               properties:

--- a/site/content/3.11/index-and-search/indexing/basics.md
+++ b/site/content/3.11/index-and-search/indexing/basics.md
@@ -610,12 +610,12 @@ To create an index in the background in *arangosh* just specify `inBackground: t
 like in the following examples:
 
 ```js
-// create the persistent index in the background
+// create the persistent indexes in the background
 db.collection.ensureIndex({ type: "persistent", fields: [ "value" ], unique: false, inBackground: true });
 db.collection.ensureIndex({ type: "persistent", fields: [ "email" ], unique: true, inBackground: true });
 
 // also supported for geo and fulltext indexes
-db.collection.ensureIndex({ type: "geo", fields: [ "latitude", "longitude"], inBackground: true });
+db.collection.ensureIndex({ type: "geo", fields: [ "location"], inBackground: true });
 db.collection.ensureIndex({ type: "geo", fields: [ "latitude", "longitude"], inBackground: true });
 db.collection.ensureIndex({ type: "fulltext", fields: [ "text" ], minLength: 4, inBackground: true })
 ```

--- a/site/content/3.11/operations/security/security-options.md
+++ b/site/content/3.11/operations/security/security-options.md
@@ -227,12 +227,8 @@ ensure that no other than the intended URLs are matched.
 
 Specifying `arangodb.org` will match:
 - `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
+- `http://arangodb.org/`
+- `http://arangodb.org/folder/file.html`
 - `https://arangodb.org`
 - `https://arangodb.org:12345`
 - `https://subdomain.arangodb.organic` **(!)**
@@ -242,12 +238,6 @@ Specifying `arangodb.org` will match:
 An unescaped `.` represents any character. For a literal dot use `\.`.
 
 Specifying `http://arangodb\.org` will match:
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
 - `http://arangodb.org`
 - `http://arangodb.org:12345`
 - `http://arangodb.organic` **(!)**

--- a/site/content/3.12/aql/execution-and-performance/query-statistics.md
+++ b/site/content/3.12/aql/execution-and-performance/query-statistics.md
@@ -38,6 +38,11 @@ The meaning of the statistics attributes is as follows:
   `UPDATE`, `REPLACE`, `REMOVE`, or `UPSERT` operations.
 - **writesIgnored**: The total number of data-modification operations that were unsuccessful,
   but have been ignored because of the `ignoreErrors` query option.
+- **documentLookups**: The number of real document lookups caused by late materialization.
+  This is how many documents had to fetched from storage after an index scan
+  that initially covered the attribute access for these documents.
+- **seeks**: The number of seek calls done by RocksDB iterators for merge joins
+  (`JoinNode` in the execution plan).
 - **scannedFull**: The total number of documents iterated over when scanning a collection 
   without an index. Documents scanned by subqueries are included in the result, but
   operations triggered by built-in or user-defined AQL functions are not.

--- a/site/content/3.12/aql/fundamentals/limitations.md
+++ b/site/content/3.12/aql/fundamentals/limitations.md
@@ -47,9 +47,9 @@ The following design limitations are known for AQL queries:
   participate in lazy evaluation of operands, for example in the
   [ternary operator](../operators.md#ternary-operator) or when used as
   sub-expressions that are combined with logical `AND` or `OR`.
-  
+
   From v3.12.1 onward, short-circuiting is applied.
-  
+
   Also see [evaluation of subqueries](subqueries.md#evaluation-of-subqueries).
 
 - It is not possible to use a collection in a read operation after

--- a/site/content/3.12/aql/operators.md
+++ b/site/content/3.12/aql/operators.md
@@ -313,9 +313,9 @@ in case of `u.value ? u.value : 'value is null'`.
 Up to v3.12.0, subqueries used inside expressions are pulled out of these
 expressions and executed beforehand. That means that subqueries do not
 participate in lazy evaluation of operands.
-  
+
 From v3.12.1 onward, short-circuiting is applied.
-  
+
 Also see [evaluation of subqueries](fundamentals/subqueries.md#evaluation-of-subqueries).
 {{< /info >}}
 

--- a/site/content/3.12/deploy/cluster/administration.md
+++ b/site/content/3.12/deploy/cluster/administration.md
@@ -291,22 +291,22 @@ console.log("Checking shard distribution every %d seconds...", sleep);
 
 var count;
 do {
-    count = 0;
-    for (dbase in dblist) {
-        var sd = arango.GET("/_db/" + dblist[dbase] + "/_admin/cluster/shardDistribution");
-        var collections = sd.results;
-        for (collection in collections) {
-        var current = collections[collection].Current;
-        for (shard in current) {
-            if (current[shard].leader == server) {
-            ++count;
-            }
+  count = 0;
+  for (dbase in dblist) {
+    var sd = arango.GET("/_db/" + dblist[dbase] + "/_admin/cluster/shardDistribution");
+    var collections = sd.results;
+    for (collection in collections) {
+      var current = collections[collection].Current;
+      for (shard in current) {
+        if (current[shard].leader == server) {
+          ++count;
         }
-        }
+      }
     }
-    console.log("Shards to be moved away from node %s: %d", server, count);
-    if (count == 0) break;
-    internal.wait(sleep);
+  }
+  console.log("Shards to be moved away from node %s: %d", server, count);
+  if (count == 0) break;
+  internal.wait(sleep);
 } while (count > 0);
 ```
 

--- a/site/content/3.12/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.12/develop/http-api/queries/aql-queries.md
@@ -720,6 +720,8 @@ paths:
                         required:
                           - writesExecuted
                           - writesIgnored
+                          - documentLookups
+                          - seeks
                           - scannedFull
                           - scannedIndex
                           - cursorsCreated
@@ -730,6 +732,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -739,6 +742,17 @@ paths:
                             description: |
                               The total number of data-modification operations that were unsuccessful,
                               but have been ignored because of the `ignoreErrors` query option.
+                            type: integer
+                          documentLookups:
+                            description: |
+                              The number of real document lookups caused by late materialization.
+                              This is how many documents had to fetched from storage after an index scan
+                              that initially covered the attribute access for these documents.
+                            type: integer
+                          seeks:
+                            description: |
+                              The number of seek calls done by RocksDB iterators for merge joins
+                              (`JoinNode` in the execution plan).
                             type: integer
                           scannedFull:
                             description: |
@@ -1423,8 +1437,6 @@ paths:
                     required:
                       - warnings
                       - stats
-                      - warnings
-                      - stats
                     properties:
                       warnings:
                         description: |
@@ -1433,8 +1445,6 @@ paths:
                         items:
                           type: object
                           required:
-                            - code
-                            - message
                             - code
                             - message
                           properties:
@@ -1453,6 +1463,8 @@ paths:
                         required:
                           - writesExecuted
                           - writesIgnored
+                          - documentLookups
+                          - seeks
                           - scannedFull
                           - scannedIndex
                           - cursorsCreated
@@ -1463,18 +1475,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -1484,6 +1485,17 @@ paths:
                             description: |
                               The total number of data-modification operations that were unsuccessful,
                               but have been ignored because of the `ignoreErrors` query option.
+                            type: integer
+                          documentLookups:
+                            description: |
+                              The number of real document lookups caused by late materialization.
+                              This is how many documents had to fetched from storage after an index scan
+                              that initially covered the attribute access for these documents.
+                            type: integer
+                          seeks:
+                            description: |
+                              The number of seek calls done by RocksDB iterators for merge joins
+                              (`JoinNode` in the execution plan).
                             type: integer
                           scannedFull:
                             description: |
@@ -1580,10 +1592,6 @@ paths:
                                 - calls
                                 - items
                                 - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
                               properties:
                                 id:
                                   description: |
@@ -1608,15 +1616,6 @@ paths:
                           The duration of the different query execution phases in seconds.
                         type: object
                         required:
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
                           - initializing
                           - parsing
                           - optimizing ast
@@ -1666,13 +1665,6 @@ paths:
                           - estimatedCost
                           - estimatedNrItems
                           - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
                         properties:
                           nodes:
                             description: |
@@ -1694,8 +1686,6 @@ paths:
                             items:
                               type: object
                               required:
-                                - name
-                                - type
                                 - name
                                 - type
                               properties:
@@ -2083,10 +2073,6 @@ paths:
                     required:
                       - warnings
                       - stats
-                      - warnings
-                      - stats
-                      - warnings
-                      - stats
                     properties:
                       warnings:
                         description: |
@@ -2095,10 +2081,6 @@ paths:
                         items:
                           type: object
                           required:
-                            - code
-                            - message
-                            - code
-                            - message
                             - code
                             - message
                           properties:
@@ -2117,6 +2099,8 @@ paths:
                         required:
                           - writesExecuted
                           - writesIgnored
+                          - documentLookups
+                          - seeks
                           - scannedFull
                           - scannedIndex
                           - cursorsCreated
@@ -2127,30 +2111,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -2160,6 +2121,17 @@ paths:
                             description: |
                               The total number of data-modification operations that were unsuccessful,
                               but have been ignored because of the `ignoreErrors` query option.
+                            type: integer
+                          documentLookups:
+                            description: |
+                              The number of real document lookups caused by late materialization.
+                              This is how many documents had to fetched from storage after an index scan
+                              that initially covered the attribute access for these documents.
+                            type: integer
+                          seeks:
+                            description: |
+                              The number of seek calls done by RocksDB iterators for merge joins
+                              (`JoinNode` in the execution plan).
                             type: integer
                           scannedFull:
                             description: |
@@ -2256,14 +2228,6 @@ paths:
                                 - calls
                                 - items
                                 - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
                               properties:
                                 id:
                                   description: |
@@ -2288,24 +2252,6 @@ paths:
                           The duration of the different query execution phases in seconds.
                         type: object
                         required:
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
                           - initializing
                           - parsing
                           - optimizing ast
@@ -2355,20 +2301,6 @@ paths:
                           - estimatedCost
                           - estimatedNrItems
                           - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
                         properties:
                           nodes:
                             description: |
@@ -2390,10 +2322,6 @@ paths:
                             items:
                               type: object
                               required:
-                                - name
-                                - type
-                                - name
-                                - type
                                 - name
                                 - type
                               properties:

--- a/site/content/3.12/index-and-search/indexing/basics.md
+++ b/site/content/3.12/index-and-search/indexing/basics.md
@@ -622,12 +622,12 @@ To create an index in the background in *arangosh* just specify `inBackground: t
 like in the following examples:
 
 ```js
-// create the persistent index in the background
+// create the persistent indexes in the background
 db.collection.ensureIndex({ type: "persistent", fields: [ "value" ], unique: false, inBackground: true });
 db.collection.ensureIndex({ type: "persistent", fields: [ "email" ], unique: true, inBackground: true });
 
 // also supported for geo and fulltext indexes
-db.collection.ensureIndex({ type: "geo", fields: [ "latitude", "longitude"], inBackground: true });
+db.collection.ensureIndex({ type: "geo", fields: [ "location"], inBackground: true });
 db.collection.ensureIndex({ type: "geo", fields: [ "latitude", "longitude"], inBackground: true });
 db.collection.ensureIndex({ type: "fulltext", fields: [ "text" ], minLength: 4, inBackground: true })
 ```

--- a/site/content/3.12/operations/security/security-options.md
+++ b/site/content/3.12/operations/security/security-options.md
@@ -227,12 +227,8 @@ ensure that no other than the intended URLs are matched.
 
 Specifying `arangodb.org` will match:
 - `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
+- `http://arangodb.org/`
+- `http://arangodb.org/folder/file.html`
 - `https://arangodb.org`
 - `https://arangodb.org:12345`
 - `https://subdomain.arangodb.organic` **(!)**
@@ -242,12 +238,6 @@ Specifying `arangodb.org` will match:
 An unescaped `.` represents any character. For a literal dot use `\.`.
 
 Specifying `http://arangodb\.org` will match:
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
 - `http://arangodb.org`
 - `http://arangodb.org:12345`
 - `http://arangodb.organic` **(!)**

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -309,6 +309,34 @@ the versioning attribute in the supplied document that is supposed to update/rep
 The document is only changed if the new number is higher. See the
 [Document API](../../develop/http-api/documents.md#create-a-document) for details.
 
+#### Cursor API
+
+##### `documentLookups` and `seeks` statistics
+
+Two new statistics are included in the response when you execute an AQL query:
+
+- `documentLookups`: The number of real document lookups caused by late materialization.
+  This is how many documents had to fetched from storage after an index scan
+  that initially covered the attribute access for these documents.
+- `seeks`: The number of seek calls done by RocksDB iterators for merge joins
+  (`JoinNode` in the execution plan).
+
+```js
+{
+  "result": [
+    // ...
+  ],
+  // ...
+  "extra": {
+    "stats": {
+      "documentLookups": 10,
+      "seeks": 0,
+      // ...
+    }
+  }
+}
+```
+
 #### Index API
 
 ##### `optimizeTopK` for inverted indexes

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -503,6 +503,16 @@ Optimization rules applied:
   4   move-filters-up-2                          8   reduce-extraction-to-projection  
 ```
 
+The number of document lookups caused by late materialization is now reported
+under `extra.stats.documentLookups` by the Cursor HTTP API and shown in a column
+of the query profile output:
+
+```aql
+Query Statistics:
+ Writes Exec      Writes Ign      Doc. Lookups      Scan Full      Scan Index      Cache Hits/Misses      Filtered      Peak Mem [b]      Exec Time [s]
+           0               0               290              0            3708                  0 / 0          3418             32768            0.01247
+```
+
 ---
 
 <small>Introduced in: v3.12.1</small>

--- a/site/content/3.13/aql/execution-and-performance/query-statistics.md
+++ b/site/content/3.13/aql/execution-and-performance/query-statistics.md
@@ -38,6 +38,11 @@ The meaning of the statistics attributes is as follows:
   `UPDATE`, `REPLACE`, `REMOVE`, or `UPSERT` operations.
 - **writesIgnored**: The total number of data-modification operations that were unsuccessful,
   but have been ignored because of the `ignoreErrors` query option.
+- **documentLookups**: The number of real document lookups caused by late materialization.
+  This is how many documents had to fetched from storage after an index scan
+  that initially covered the attribute access for these documents.
+- **seeks**: The number of seek calls done by RocksDB iterators for merge joins
+  (`JoinNode` in the execution plan).
 - **scannedFull**: The total number of documents iterated over when scanning a collection 
   without an index. Documents scanned by subqueries are included in the result, but
   operations triggered by built-in or user-defined AQL functions are not.

--- a/site/content/3.13/aql/fundamentals/limitations.md
+++ b/site/content/3.13/aql/fundamentals/limitations.md
@@ -47,9 +47,9 @@ The following design limitations are known for AQL queries:
   participate in lazy evaluation of operands, for example in the
   [ternary operator](../operators.md#ternary-operator) or when used as
   sub-expressions that are combined with logical `AND` or `OR`.
-  
+
   From v3.12.1 onward, short-circuiting is applied.
-  
+
   Also see [evaluation of subqueries](subqueries.md#evaluation-of-subqueries).
 
 - It is not possible to use a collection in a read operation after

--- a/site/content/3.13/aql/operators.md
+++ b/site/content/3.13/aql/operators.md
@@ -313,9 +313,9 @@ in case of `u.value ? u.value : 'value is null'`.
 Up to v3.12.0, subqueries used inside expressions are pulled out of these
 expressions and executed beforehand. That means that subqueries do not
 participate in lazy evaluation of operands.
-  
+
 From v3.12.1 onward, short-circuiting is applied.
-  
+
 Also see [evaluation of subqueries](fundamentals/subqueries.md#evaluation-of-subqueries).
 {{< /info >}}
 

--- a/site/content/3.13/deploy/cluster/administration.md
+++ b/site/content/3.13/deploy/cluster/administration.md
@@ -291,22 +291,22 @@ console.log("Checking shard distribution every %d seconds...", sleep);
 
 var count;
 do {
-    count = 0;
-    for (dbase in dblist) {
-        var sd = arango.GET("/_db/" + dblist[dbase] + "/_admin/cluster/shardDistribution");
-        var collections = sd.results;
-        for (collection in collections) {
-        var current = collections[collection].Current;
-        for (shard in current) {
-            if (current[shard].leader == server) {
-            ++count;
-            }
+  count = 0;
+  for (dbase in dblist) {
+    var sd = arango.GET("/_db/" + dblist[dbase] + "/_admin/cluster/shardDistribution");
+    var collections = sd.results;
+    for (collection in collections) {
+      var current = collections[collection].Current;
+      for (shard in current) {
+        if (current[shard].leader == server) {
+          ++count;
         }
-        }
+      }
     }
-    console.log("Shards to be moved away from node %s: %d", server, count);
-    if (count == 0) break;
-    internal.wait(sleep);
+  }
+  console.log("Shards to be moved away from node %s: %d", server, count);
+  if (count == 0) break;
+  internal.wait(sleep);
 } while (count > 0);
 ```
 

--- a/site/content/3.13/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.13/develop/http-api/queries/aql-queries.md
@@ -720,6 +720,8 @@ paths:
                         required:
                           - writesExecuted
                           - writesIgnored
+                          - documentLookups
+                          - seeks
                           - scannedFull
                           - scannedIndex
                           - cursorsCreated
@@ -730,6 +732,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -739,6 +742,17 @@ paths:
                             description: |
                               The total number of data-modification operations that were unsuccessful,
                               but have been ignored because of the `ignoreErrors` query option.
+                            type: integer
+                          documentLookups:
+                            description: |
+                              The number of real document lookups caused by late materialization.
+                              This is how many documents had to fetched from storage after an index scan
+                              that initially covered the attribute access for these documents.
+                            type: integer
+                          seeks:
+                            description: |
+                              The number of seek calls done by RocksDB iterators for merge joins
+                              (`JoinNode` in the execution plan).
                             type: integer
                           scannedFull:
                             description: |
@@ -1423,8 +1437,6 @@ paths:
                     required:
                       - warnings
                       - stats
-                      - warnings
-                      - stats
                     properties:
                       warnings:
                         description: |
@@ -1433,8 +1445,6 @@ paths:
                         items:
                           type: object
                           required:
-                            - code
-                            - message
                             - code
                             - message
                           properties:
@@ -1453,6 +1463,8 @@ paths:
                         required:
                           - writesExecuted
                           - writesIgnored
+                          - documentLookups
+                          - seeks
                           - scannedFull
                           - scannedIndex
                           - cursorsCreated
@@ -1463,18 +1475,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -1484,6 +1485,17 @@ paths:
                             description: |
                               The total number of data-modification operations that were unsuccessful,
                               but have been ignored because of the `ignoreErrors` query option.
+                            type: integer
+                          documentLookups:
+                            description: |
+                              The number of real document lookups caused by late materialization.
+                              This is how many documents had to fetched from storage after an index scan
+                              that initially covered the attribute access for these documents.
+                            type: integer
+                          seeks:
+                            description: |
+                              The number of seek calls done by RocksDB iterators for merge joins
+                              (`JoinNode` in the execution plan).
                             type: integer
                           scannedFull:
                             description: |
@@ -1580,10 +1592,6 @@ paths:
                                 - calls
                                 - items
                                 - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
                               properties:
                                 id:
                                   description: |
@@ -1608,15 +1616,6 @@ paths:
                           The duration of the different query execution phases in seconds.
                         type: object
                         required:
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
                           - initializing
                           - parsing
                           - optimizing ast
@@ -1666,13 +1665,6 @@ paths:
                           - estimatedCost
                           - estimatedNrItems
                           - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
                         properties:
                           nodes:
                             description: |
@@ -1694,8 +1686,6 @@ paths:
                             items:
                               type: object
                               required:
-                                - name
-                                - type
                                 - name
                                 - type
                               properties:
@@ -2083,10 +2073,6 @@ paths:
                     required:
                       - warnings
                       - stats
-                      - warnings
-                      - stats
-                      - warnings
-                      - stats
                     properties:
                       warnings:
                         description: |
@@ -2095,10 +2081,6 @@ paths:
                         items:
                           type: object
                           required:
-                            - code
-                            - message
-                            - code
-                            - message
                             - code
                             - message
                           properties:
@@ -2117,6 +2099,8 @@ paths:
                         required:
                           - writesExecuted
                           - writesIgnored
+                          - documentLookups
+                          - seeks
                           - scannedFull
                           - scannedIndex
                           - cursorsCreated
@@ -2127,30 +2111,7 @@ paths:
                           - httpRequests
                           - executionTime
                           - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
-                          - writesExecuted
-                          - writesIgnored
-                          - scannedFull
-                          - scannedIndex
-                          - cursorsCreated
-                          - cursorsRearmed
-                          - cacheHits
-                          - cacheMisses
-                          - filtered
-                          - httpRequests
-                          - executionTime
-                          - peakMemoryUsage
+                          - intermediateCommits
                         properties:
                           writesExecuted:
                             description: |
@@ -2160,6 +2121,17 @@ paths:
                             description: |
                               The total number of data-modification operations that were unsuccessful,
                               but have been ignored because of the `ignoreErrors` query option.
+                            type: integer
+                          documentLookups:
+                            description: |
+                              The number of real document lookups caused by late materialization.
+                              This is how many documents had to fetched from storage after an index scan
+                              that initially covered the attribute access for these documents.
+                            type: integer
+                          seeks:
+                            description: |
+                              The number of seek calls done by RocksDB iterators for merge joins
+                              (`JoinNode` in the execution plan).
                             type: integer
                           scannedFull:
                             description: |
@@ -2256,14 +2228,6 @@ paths:
                                 - calls
                                 - items
                                 - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
-                                - id
-                                - calls
-                                - items
-                                - runtime
                               properties:
                                 id:
                                   description: |
@@ -2288,24 +2252,6 @@ paths:
                           The duration of the different query execution phases in seconds.
                         type: object
                         required:
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
-                          - initializing
-                          - parsing
-                          - optimizing ast
-                          - loading collections
-                          - instantiating plan
-                          - optimizing plan
-                          - instantiating executors
-                          - executing
-                          - finalizing
                           - initializing
                           - parsing
                           - optimizing ast
@@ -2355,20 +2301,6 @@ paths:
                           - estimatedCost
                           - estimatedNrItems
                           - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
-                          - nodes
-                          - rules
-                          - collections
-                          - variables
-                          - estimatedCost
-                          - estimatedNrItems
-                          - isModificationQuery
                         properties:
                           nodes:
                             description: |
@@ -2390,10 +2322,6 @@ paths:
                             items:
                               type: object
                               required:
-                                - name
-                                - type
-                                - name
-                                - type
                                 - name
                                 - type
                               properties:

--- a/site/content/3.13/index-and-search/indexing/basics.md
+++ b/site/content/3.13/index-and-search/indexing/basics.md
@@ -622,12 +622,12 @@ To create an index in the background in *arangosh* just specify `inBackground: t
 like in the following examples:
 
 ```js
-// create the persistent index in the background
+// create the persistent indexes in the background
 db.collection.ensureIndex({ type: "persistent", fields: [ "value" ], unique: false, inBackground: true });
 db.collection.ensureIndex({ type: "persistent", fields: [ "email" ], unique: true, inBackground: true });
 
 // also supported for geo and fulltext indexes
-db.collection.ensureIndex({ type: "geo", fields: [ "latitude", "longitude"], inBackground: true });
+db.collection.ensureIndex({ type: "geo", fields: [ "location"], inBackground: true });
 db.collection.ensureIndex({ type: "geo", fields: [ "latitude", "longitude"], inBackground: true });
 db.collection.ensureIndex({ type: "fulltext", fields: [ "text" ], minLength: 4, inBackground: true })
 ```

--- a/site/content/3.13/operations/security/security-options.md
+++ b/site/content/3.13/operations/security/security-options.md
@@ -227,12 +227,8 @@ ensure that no other than the intended URLs are matched.
 
 Specifying `arangodb.org` will match:
 - `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
+- `http://arangodb.org/`
+- `http://arangodb.org/folder/file.html`
 - `https://arangodb.org`
 - `https://arangodb.org:12345`
 - `https://subdomain.arangodb.organic` **(!)**
@@ -242,12 +238,6 @@ Specifying `arangodb.org` will match:
 An unescaped `.` represents any character. For a literal dot use `\.`.
 
 Specifying `http://arangodb\.org` will match:
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
-- `http://arangodb.org`
-- `http://arangodb.org` 
 - `http://arangodb.org`
 - `http://arangodb.org:12345`
 - `http://arangodb.organic` **(!)**

--- a/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
@@ -309,6 +309,34 @@ the versioning attribute in the supplied document that is supposed to update/rep
 The document is only changed if the new number is higher. See the
 [Document API](../../develop/http-api/documents.md#create-a-document) for details.
 
+#### Cursor API
+
+##### `documentLookups` and `seeks` statistics
+
+Two new statistics are included in the response when you execute an AQL query:
+
+- `documentLookups`: The number of real document lookups caused by late materialization.
+  This is how many documents had to fetched from storage after an index scan
+  that initially covered the attribute access for these documents.
+- `seeks`: The number of seek calls done by RocksDB iterators for merge joins
+  (`JoinNode` in the execution plan).
+
+```js
+{
+  "result": [
+    // ...
+  ],
+  // ...
+  "extra": {
+    "stats": {
+      "documentLookups": 10,
+      "seeks": 0,
+      // ...
+    }
+  }
+}
+```
+
 #### Index API
 
 ##### `optimizeTopK` for inverted indexes

--- a/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
@@ -503,6 +503,16 @@ Optimization rules applied:
   4   move-filters-up-2                          8   reduce-extraction-to-projection  
 ```
 
+The number of document lookups caused by late materialization is now reported
+under `extra.stats.documentLookups` by the Cursor HTTP API and shown in a column
+of the query profile output:
+
+```aql
+Query Statistics:
+ Writes Exec      Writes Ign      Doc. Lookups      Scan Full      Scan Index      Cache Hits/Misses      Filtered      Peak Mem [b]      Exec Time [s]
+           0               0               290              0            3708                  0 / 0          3418             32768            0.01247
+```
+
 ---
 
 <small>Introduced in: v3.12.1</small>


### PR DESCRIPTION
### Description

Is it correct that documentLookups are reported for late materialization or are there additional cases?

It seems to be limited to the IndexNode, i.e. the statistic is not populated for merge joins which use "document lookup with late materialization" according to the query explain output.

Also correct required properties in HTTP API and some misc mistakes

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
