### PR TITLE
Escape `|` in table even if it's in inline code

### DIFF
--- a/site/content/3.11/aql/operators.md
+++ b/site/content/3.11/aql/operators.md
@@ -718,7 +718,7 @@ The operator precedence in AQL is similar as in other familiar languages
 | `AT LEAST`           | at least modifier (array comparison operator, question mark operator)
 | `OUTBOUND`, `INBOUND`, `ANY`, `ALL`, `NONE` | graph traversal directions, array comparison operators, question mark operator
 | `&&`, `AND`          | logical and
-| `||`, `OR`           | logical or
+| `\|\|`, `OR`         | logical or
 | `INTO`               | into operator (INSERT / UPDATE / REPLACE / REMOVE / COLLECT operations)
 | `WITH`               | with operator (WITH / UPDATE / REPLACE / COLLECT operations)
 | `=`                  | variable assignment (LET / COLLECT operations, AGGREGATE / PRUNE clauses)

--- a/site/content/3.12/aql/operators.md
+++ b/site/content/3.12/aql/operators.md
@@ -977,7 +977,7 @@ The operator precedence in AQL is similar as in other familiar languages
 | `AT LEAST`           | at least modifier (array comparison operator, question mark operator)
 | `OUTBOUND`, `INBOUND`, `ANY`, `ALL`, `NONE` | graph traversal directions, array comparison operators, question mark operator
 | `&&`, `AND`          | logical and
-| `||`, `OR`           | logical or
+| `\|\|`, `OR`         | logical or
 | `INTO`               | into operator (INSERT / UPDATE / REPLACE / REMOVE / COLLECT operations)
 | `WITH`               | with operator (WITH / UPDATE / REPLACE / COLLECT operations)
 | `=`                  | variable assignment (LET / COLLECT operations, AGGREGATE / PRUNE clauses)

--- a/site/content/3.13/aql/operators.md
+++ b/site/content/3.13/aql/operators.md
@@ -977,7 +977,7 @@ The operator precedence in AQL is similar as in other familiar languages
 | `AT LEAST`           | at least modifier (array comparison operator, question mark operator)
 | `OUTBOUND`, `INBOUND`, `ANY`, `ALL`, `NONE` | graph traversal directions, array comparison operators, question mark operator
 | `&&`, `AND`          | logical and
-| `||`, `OR`           | logical or
+| `\|\|`, `OR`         | logical or
 | `INTO`               | into operator (INSERT / UPDATE / REPLACE / REMOVE / COLLECT operations)
 | `WITH`               | with operator (WITH / UPDATE / REPLACE / COLLECT operations)
 | `=`                  | variable assignment (LET / COLLECT operations, AGGREGATE / PRUNE clauses)


### PR DESCRIPTION
### Description

This is according to the GFM spec, https://github.com/yuin/goldmark/issues/194

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
