### PR TITLE
Fix 3.12 example generation with self-compiled ArangoDB

### DIFF
--- a/site/content/3.12/_index.md
+++ b/site/content/3.12/_index.md
@@ -6,8 +6,6 @@ layout: default
 ---
 {{< cloudbanner >}}
 
-## ---TESTING---
-
 {{< cards >}}
 
 {{% card title="What is ArangoDB?" link="about-arangodb/" %}}

--- a/site/content/3.12/_index.md
+++ b/site/content/3.12/_index.md
@@ -6,6 +6,8 @@ layout: default
 ---
 {{< cloudbanner >}}
 
+## ---TESTING---
+
 {{< cards >}}
 
 {{% card title="What is ArangoDB?" link="about-arangodb/" %}}

--- a/site/content/3.12/components/arangodb-server/environment-variables.md
+++ b/site/content/3.12/components/arangodb-server/environment-variables.md
@@ -102,7 +102,7 @@ description: >-
   Path to a directory with stop word files for
   [ArangoSearch Text Analyzers](../../index-and-search/analyzers.md#text).
 
-<!-- ARANGODB_CONFIG_PATH, ICU_DATA, ... (TRI_GETENV, iresearch::getenv) -->
+<!-- ARANGODB_CONFIG_PATH, ICU_DATA, ICU_DATA_LEGACY, ... (TRI_GETENV, iresearch::getenv) -->
 
 For Docker specific environment variables please refer to
 [Docker Hub](https://hub.docker.com/_/arangodb)

--- a/site/content/3.13/components/arangodb-server/environment-variables.md
+++ b/site/content/3.13/components/arangodb-server/environment-variables.md
@@ -102,7 +102,7 @@ description: >-
   Path to a directory with stop word files for
   [ArangoSearch Text Analyzers](../../index-and-search/analyzers.md#text).
 
-<!-- ARANGODB_CONFIG_PATH, ICU_DATA, ... (TRI_GETENV, iresearch::getenv) -->
+<!-- ARANGODB_CONFIG_PATH, ICU_DATA, ICU_DATA_LEGACY, ... (TRI_GETENV, iresearch::getenv) -->
 
 For Docker specific environment variables please refer to
 [Docker Hub](https://hub.docker.com/_/arangodb)

--- a/toolchain/scripts/toolchain.sh
+++ b/toolchain/scripts/toolchain.sh
@@ -285,7 +285,7 @@ function setup_arangoproxy_arangosh() {
 
   #docker cp "$container_name":/usr/bin/icudtl.dat ../arangoproxy/arangosh/"$name"/"$version"/usr/bin/icudtl.dat
   docker exec  $container_name sh -c "cp -r /usr/share/ /tmp/arangosh/$version/usr/"
-  docker exec  $container_name sh -c "cp -r /usr/bin/icudtl.dat /tmp/arangosh/$version/usr/share/arangodb3/"
+  docker exec  $container_name sh -c "cp -r /usr/bin/icudtl*.dat /tmp/arangosh/$version/usr/share/arangodb3/"
 
   docker exec  $container_name sh -c "sed 's~startup-directory.*$~startup-directory = /arangosh/arangosh/$version/usr/share/arangodb3/js~' /etc/arangodb3/arangosh.conf > /tmp/arangosh/$version/usr/bin/etc/relative/arangosh.conf"
   echo ""


### PR DESCRIPTION
### Description

Test whether 3.12 compiles with 3.11 LDAP fix.
This revealed that arangoproxy can hang if arangosh fails to start e.g. due to a missing `icudtl_legacy.dat`.
Add a missing `cmd.Wait()` which is apparently required on Unix so that a failed arangosh doesn't linger around as a zombie process and report a non-zero exit code. Also log stderr output.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
