### PR TITLE
JS API: collection.truncate() takes options

### DIFF
--- a/site/content/3.11/aql/execution-and-performance/explaining-queries.md
+++ b/site/content/3.11/aql/execution-and-performance/explaining-queries.md
@@ -6,6 +6,9 @@ description: >-
   You can explain and profile AQL queries to inspect the execution plans and to
   understand the performance characteristics, as well as create debug packages
   for reporting issues
+# Undocumented on purpose:
+#   require("@arangodb/aql/explainer").explainRegisters(data, options, shouldPrint);
+#   require("@arangodb/aql/explainer").debug(query, bindVars, options);
 ---
 If it is unclear how a given query will perform, clients can retrieve a query's execution plan 
 from the AQL query optimizer without actually executing the query. Getting the query execution 

--- a/site/content/3.11/aql/how-to-invoke-aql/with-arangosh.md
+++ b/site/content/3.11/aql/how-to-invoke-aql/with-arangosh.md
@@ -5,6 +5,8 @@ weight: 5
 description: >-
   How to run queries, set bind parameters, and obtain the resulting and
   additional information using the JavaScript API
+# Undocumented on purpose:
+#   db._query(<query>, <bindVars>, <mainOptions>, { forceOneShardAttributeValue: "..."} )
 ---
 In the ArangoDB shell, you can use the `db._query()` and `db._createStatement()`
 methods to execute AQL queries. This chapter also describes

--- a/site/content/3.11/develop/http-api/administration.md
+++ b/site/content/3.11/develop/http-api/administration.md
@@ -5,7 +5,10 @@ weight: 110
 description: >-
   You can get information about ArangoDB servers, toggle the maintenance mode,
   shut down server nodes, and start actions like compaction
-# Internal /_admin/debug and /_api/test endpoints for maintainers not documented on purpose
+# Undocumented on purpose:
+#   /_admin/debug       (internal)
+#   /_api/test          (internal)
+#   /_admin/telemetrics (internal)
 ---
 ## Information
 

--- a/site/content/3.11/develop/http-api/graphs/edges.md
+++ b/site/content/3.11/develop/http-api/graphs/edges.md
@@ -5,6 +5,8 @@ weight: 10
 description: >-
   The Edge API lets you retrieve the connected edges of a single vertex,
   optionally restricted to incoming or outgoing edges
+# Undocumented on purpose:
+#   POST /_api/edges/{coll}  (internal)
 ---
 You can use the general [Document API](../documents.md) to create,
 read, modify, and delete edge documents. The only difference to working with

--- a/site/content/3.11/develop/http-api/indexes/_index.md
+++ b/site/content/3.11/develop/http-api/indexes/_index.md
@@ -4,6 +4,8 @@ menuTitle: Indexes
 weight: 55
 description: >-
   The HTTP API for indexes lets you create, delete, and list indexes
+# Undocumented on purpose:
+#   POST /_api/index/sync-caches  (internal)
 ---
 ## Addresses of indexes
 

--- a/site/content/3.11/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.11/develop/http-api/queries/aql-queries.md
@@ -316,6 +316,8 @@ paths:
               required:
                 - query
               properties:
+                # Purposefully undocumented:
+                #   forceOneShardAttributeValue
                 query:
                   description: |
                     contains the query string to be executed
@@ -2951,6 +2953,10 @@ paths:
                     Options for the query
                   type: object
                   properties:
+                    # Purposefully undocumented:
+                    #   verbosePlans
+                    #   explainInternals
+                    #   explainRegisters
                     allPlans:
                       description: |
                         if set to `true`, all possible execution plans will be returned.

--- a/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
@@ -5,6 +5,8 @@ weight: 10
 description: >-
   Collection objects represent document collections and provide access to
   information and methods for executing collection-related operations
+# Undocumented on purpose:
+#   collection.count(true); // document count per shard (cluster only)
 ---
 The JavaScript API returns _collection_ objects when you use the following methods
 of the [`db` object](db-object.md) from the `@arangodb`:
@@ -426,10 +428,22 @@ The leader shards are always first in the arrays of responsible servers.
 The `shards()` method can only be used on Coordinators in clusters.
 {{< /info >}}
 
-### `collection.truncate()`
+### `collection.truncate([options])`
 
 Truncates a `collection`, removing all documents but keeping all its
 indexes.
+
+The optional `options` parameter must be an object and can be
+used to specify the following options:
+
+- `waitForSync` (boolean, default: `false`):
+  If set to `true`, the data is synchronized to disk before returning from the
+  truncate operation.
+
+- `compact` (boolean, default: `true`):
+  If set to `true`, the storage engine is told to start a compaction in order to
+  free up disk space. This can be resource intensive. If the only intention is
+  to start over with an empty collection, specify `false`.
 
 **Examples**
 

--- a/site/content/3.11/develop/transactions/stream-transactions.md
+++ b/site/content/3.11/develop/transactions/stream-transactions.md
@@ -169,7 +169,7 @@ collection operations:
 - [`remove()`](../javascript-api/@arangodb/collection-object.md#collectionremoveobject)
 - [`replace()`](../javascript-api/@arangodb/collection-object.md#collectionreplacedocument-data--options)
 - [`save()`](../javascript-api/@arangodb/collection-object.md#collectionsavedata--options)
-- [`truncate()`](../javascript-api/@arangodb/collection-object.md#collectiontruncate)
+- [`truncate()`](../javascript-api/@arangodb/collection-object.md#collectiontruncateoptions)
 - [`update()`](../javascript-api/@arangodb/collection-object.md#collectionupdatedocument-data--options)
 
 Compared to the collection object returned by `db._collection()`, only a subset

--- a/site/content/3.12/aql/execution-and-performance/explaining-queries.md
+++ b/site/content/3.12/aql/execution-and-performance/explaining-queries.md
@@ -6,6 +6,9 @@ description: >-
   You can explain and profile AQL queries to inspect the execution plans and to
   understand the performance characteristics, as well as create debug packages
   for reporting issues
+# Undocumented on purpose:
+#   require("@arangodb/aql/explainer").explainRegisters(data, options, shouldPrint);
+#   require("@arangodb/aql/explainer").debug(query, bindVars, options);
 ---
 If it is unclear how a given query will perform, clients can retrieve a query's execution plan 
 from the AQL query optimizer without actually executing the query. Getting the query execution 

--- a/site/content/3.12/aql/how-to-invoke-aql/with-arangosh.md
+++ b/site/content/3.12/aql/how-to-invoke-aql/with-arangosh.md
@@ -5,6 +5,8 @@ weight: 5
 description: >-
   How to run queries, set bind parameters, and obtain the resulting and
   additional information using the JavaScript API
+# Undocumented on purpose:
+#   db._query(<query>, <bindVars>, <mainOptions>, { forceOneShardAttributeValue: "..."} )
 ---
 In the ArangoDB shell, you can use the `db._query()` and `db._createStatement()`
 methods to execute AQL queries. This chapter also describes

--- a/site/content/3.12/develop/http-api/administration.md
+++ b/site/content/3.12/develop/http-api/administration.md
@@ -5,7 +5,10 @@ weight: 110
 description: >-
   You can get information about ArangoDB servers, toggle the maintenance mode,
   shut down server nodes, and start actions like compaction
-# Internal /_admin/debug and /_api/test endpoints for maintainers not documented on purpose
+# Undocumented on purpose:
+#   /_admin/debug       (internal)
+#   /_api/test          (internal)
+#   /_admin/telemetrics (internal)
 ---
 ## Information
 

--- a/site/content/3.12/develop/http-api/graphs/edges.md
+++ b/site/content/3.12/develop/http-api/graphs/edges.md
@@ -5,6 +5,8 @@ weight: 10
 description: >-
   The Edge API lets you retrieve the connected edges of a single vertex,
   optionally restricted to incoming or outgoing edges
+# Undocumented on purpose:
+#   POST /_api/edges/{coll}  (internal)
 ---
 You can use the general [Document API](../documents.md) to create,
 read, modify, and delete edge documents. The only difference to working with

--- a/site/content/3.12/develop/http-api/indexes/_index.md
+++ b/site/content/3.12/develop/http-api/indexes/_index.md
@@ -4,6 +4,8 @@ menuTitle: Indexes
 weight: 55
 description: >-
   The HTTP API for indexes lets you create, delete, and list indexes
+# Undocumented on purpose:
+#   POST /_api/index/sync-caches  (internal)
 ---
 ## Addresses of indexes
 

--- a/site/content/3.12/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.12/develop/http-api/queries/aql-queries.md
@@ -316,6 +316,8 @@ paths:
               required:
                 - query
               properties:
+                # Purposefully undocumented:
+                #   forceOneShardAttributeValue
                 query:
                   description: |
                     contains the query string to be executed
@@ -3002,6 +3004,10 @@ paths:
                     Options for the query
                   type: object
                   properties:
+                    # Purposefully undocumented:
+                    #   verbosePlans
+                    #   explainInternals
+                    #   explainRegisters
                     allPlans:
                       description: |
                         if set to `true`, all possible execution plans will be returned.

--- a/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
@@ -5,6 +5,8 @@ weight: 10
 description: >-
   Collection objects represent document collections and provide access to
   information and methods for executing collection-related operations
+# Undocumented on purpose:
+#   collection.count(true); // document count per shard (cluster only)
 ---
 The JavaScript API returns _collection_ objects when you use the following methods
 of the [`db` object](db-object.md) from the `@arangodb`:
@@ -426,10 +428,22 @@ The leader shards are always first in the arrays of responsible servers.
 The `shards()` method can only be used on Coordinators in clusters.
 {{< /info >}}
 
-### `collection.truncate()`
+### `collection.truncate([options])`
 
 Truncates a `collection`, removing all documents but keeping all its
 indexes.
+
+The optional `options` parameter must be an object and can be
+used to specify the following options:
+
+- `waitForSync` (boolean, default: `false`):
+  If set to `true`, the data is synchronized to disk before returning from the
+  truncate operation.
+
+- `compact` (boolean, default: `true`):
+  If set to `true`, the storage engine is told to start a compaction in order to
+  free up disk space. This can be resource intensive. If the only intention is
+  to start over with an empty collection, specify `false`.
 
 **Examples**
 

--- a/site/content/3.12/develop/transactions/stream-transactions.md
+++ b/site/content/3.12/develop/transactions/stream-transactions.md
@@ -185,7 +185,7 @@ collection operations:
 - [`remove()`](../javascript-api/@arangodb/collection-object.md#collectionremoveobject)
 - [`replace()`](../javascript-api/@arangodb/collection-object.md#collectionreplacedocument-data--options)
 - [`save()`](../javascript-api/@arangodb/collection-object.md#collectionsavedata--options)
-- [`truncate()`](../javascript-api/@arangodb/collection-object.md#collectiontruncate)
+- [`truncate()`](../javascript-api/@arangodb/collection-object.md#collectiontruncateoptions)
 - [`update()`](../javascript-api/@arangodb/collection-object.md#collectionupdatedocument-data--options)
 
 Compared to the collection object returned by `db._collection()`, only a subset

--- a/site/content/3.13/aql/execution-and-performance/explaining-queries.md
+++ b/site/content/3.13/aql/execution-and-performance/explaining-queries.md
@@ -6,6 +6,9 @@ description: >-
   You can explain and profile AQL queries to inspect the execution plans and to
   understand the performance characteristics, as well as create debug packages
   for reporting issues
+# Undocumented on purpose:
+#   require("@arangodb/aql/explainer").explainRegisters(data, options, shouldPrint);
+#   require("@arangodb/aql/explainer").debug(query, bindVars, options);
 ---
 If it is unclear how a given query will perform, clients can retrieve a query's execution plan 
 from the AQL query optimizer without actually executing the query. Getting the query execution 

--- a/site/content/3.13/aql/how-to-invoke-aql/with-arangosh.md
+++ b/site/content/3.13/aql/how-to-invoke-aql/with-arangosh.md
@@ -5,6 +5,8 @@ weight: 5
 description: >-
   How to run queries, set bind parameters, and obtain the resulting and
   additional information using the JavaScript API
+# Undocumented on purpose:
+#   db._query(<query>, <bindVars>, <mainOptions>, { forceOneShardAttributeValue: "..."} )
 ---
 In the ArangoDB shell, you can use the `db._query()` and `db._createStatement()`
 methods to execute AQL queries. This chapter also describes

--- a/site/content/3.13/develop/http-api/administration.md
+++ b/site/content/3.13/develop/http-api/administration.md
@@ -5,7 +5,10 @@ weight: 110
 description: >-
   You can get information about ArangoDB servers, toggle the maintenance mode,
   shut down server nodes, and start actions like compaction
-# Internal /_admin/debug and /_api/test endpoints for maintainers not documented on purpose
+# Undocumented on purpose:
+#   /_admin/debug       (internal)
+#   /_api/test          (internal)
+#   /_admin/telemetrics (internal)
 ---
 ## Information
 

--- a/site/content/3.13/develop/http-api/graphs/edges.md
+++ b/site/content/3.13/develop/http-api/graphs/edges.md
@@ -5,6 +5,8 @@ weight: 10
 description: >-
   The Edge API lets you retrieve the connected edges of a single vertex,
   optionally restricted to incoming or outgoing edges
+# Undocumented on purpose:
+#   POST /_api/edges/{coll}  (internal)
 ---
 You can use the general [Document API](../documents.md) to create,
 read, modify, and delete edge documents. The only difference to working with

--- a/site/content/3.13/develop/http-api/indexes/_index.md
+++ b/site/content/3.13/develop/http-api/indexes/_index.md
@@ -4,6 +4,8 @@ menuTitle: Indexes
 weight: 55
 description: >-
   The HTTP API for indexes lets you create, delete, and list indexes
+# Undocumented on purpose:
+#   POST /_api/index/sync-caches  (internal)
 ---
 ## Addresses of indexes
 

--- a/site/content/3.13/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.13/develop/http-api/queries/aql-queries.md
@@ -316,6 +316,8 @@ paths:
               required:
                 - query
               properties:
+                # Purposefully undocumented:
+                #   forceOneShardAttributeValue
                 query:
                   description: |
                     contains the query string to be executed
@@ -3002,6 +3004,10 @@ paths:
                     Options for the query
                   type: object
                   properties:
+                    # Purposefully undocumented:
+                    #   verbosePlans
+                    #   explainInternals
+                    #   explainRegisters
                     allPlans:
                       description: |
                         if set to `true`, all possible execution plans will be returned.

--- a/site/content/3.13/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.13/develop/javascript-api/@arangodb/collection-object.md
@@ -5,6 +5,13 @@ weight: 10
 description: >-
   Collection objects represent document collections and provide access to
   information and methods for executing collection-related operations
+# Undocumented on purpose:
+#   collection.count(true); // document count per shard (cluster only)
+#   collection.load()   // MMFiles legacy
+#   collection.unload() // MMFiles legacy
+#   collection.documents(keys)    // Simple Queries
+#   collection.removeByKeys(keys) // Simple Queries
+#   collection.iterate(iterator [, options]) // Deprecated
 ---
 The JavaScript API returns _collection_ objects when you use the following methods
 of the [`db` object](db-object.md) from the `@arangodb`:
@@ -412,10 +419,22 @@ The leader shards are always first in the arrays of responsible servers.
 The `shards()` method can only be used on Coordinators in clusters.
 {{< /info >}}
 
-### `collection.truncate()`
+### `collection.truncate([options])`
 
 Truncates a `collection`, removing all documents but keeping all its
 indexes.
+
+The optional `options` parameter must be an object and can be
+used to specify the following options:
+
+- `waitForSync` (boolean, default: `false`):
+  If set to `true`, the data is synchronized to disk before returning from the
+  truncate operation.
+
+- `compact` (boolean, default: `true`):
+  If set to `true`, the storage engine is told to start a compaction in order to
+  free up disk space. This can be resource intensive. If the only intention is
+  to start over with an empty collection, specify `false`.
 
 **Examples**
 

--- a/site/content/3.13/develop/javascript-api/@arangodb/db-object.md
+++ b/site/content/3.13/develop/javascript-api/@arangodb/db-object.md
@@ -6,6 +6,8 @@ description: >-
   The database object represents the currently selected database and provides
   access to information and methods for executing operations in the context of
   this database
+# Undocumented on purpose:
+#   db._path() // MMFiles legacy  
 ---
 The `db` object of the JavaScript API is available in [arangosh](../../../components/tools/arangodb-shell/_index.md)
 by default, and can also be imported and used in Foxx services and other

--- a/site/content/3.13/develop/transactions/stream-transactions.md
+++ b/site/content/3.13/develop/transactions/stream-transactions.md
@@ -179,7 +179,7 @@ collection operations:
 - [`remove()`](../javascript-api/@arangodb/collection-object.md#collectionremoveobject)
 - [`replace()`](../javascript-api/@arangodb/collection-object.md#collectionreplacedocument-data--options)
 - [`save()`](../javascript-api/@arangodb/collection-object.md#collectionsavedata--options)
-- [`truncate()`](../javascript-api/@arangodb/collection-object.md#collectiontruncate)
+- [`truncate()`](../javascript-api/@arangodb/collection-object.md#collectiontruncateoptions)
 - [`update()`](../javascript-api/@arangodb/collection-object.md#collectionupdatedocument-data--options)
 
 Compared to the collection object returned by `db._collection()`, only a subset


### PR DESCRIPTION
### Description

Also add internal remarks that certain methods / endpoints and properties in the HTTP API are undocumented on purpose

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
