### PR TITLE
Collections API

### DIFF
--- a/site/content/3.11/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.11/develop/http-api/queries/aql-queries.md
@@ -605,7 +605,7 @@ paths:
                       type: integer
                     skipInaccessibleCollections:
                       description: |
-                        Let AQL queries (especially graph traversals) treat collection to which a user
+                        Let AQL queries (especially graph traversals) treat collections to which a user
                         has no access rights for as if these collections are empty. Instead of returning a
                         forbidden access error, your queries execute normally. This is intended to help
                         with certain use-cases: A graph contains several collections and different users

--- a/site/content/3.12/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.12/develop/http-api/queries/aql-queries.md
@@ -606,7 +606,7 @@ paths:
                       type: integer
                     skipInaccessibleCollections:
                       description: |
-                        Let AQL queries (especially graph traversals) treat collection to which a user
+                        Let AQL queries (especially graph traversals) treat collections to which a user
                         has no access rights for as if these collections are empty. Instead of returning a
                         forbidden access error, your queries execute normally. This is intended to help
                         with certain use-cases: A graph contains several collections and different users

--- a/site/content/3.13/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.13/develop/http-api/queries/aql-queries.md
@@ -606,7 +606,7 @@ paths:
                       type: integer
                     skipInaccessibleCollections:
                       description: |
-                        Let AQL queries (especially graph traversals) treat collection to which a user
+                        Let AQL queries (especially graph traversals) treat collections to which a user
                         has no access rights for as if these collections are empty. Instead of returning a
                         forbidden access error, your queries execute normally. This is intended to help
                         with certain use-cases: A graph contains several collections and different users


### PR DESCRIPTION
### Description

Small typo fix. The docs should refer to "collections", as the term is used throughout the sentence.
