### PR TITLE
Update Stream Transaction default size

### DIFF
--- a/site/content/3.12/develop/transactions/stream-transactions.md
+++ b/site/content/3.12/develop/transactions/stream-transactions.md
@@ -44,7 +44,7 @@ on the Coordinator to ensure that abandoned transactions cannot block the
 cluster from operating properly:
 
 - Maximum idle timeout of up to **120 seconds** between operations.
-- Maximum transaction size with a default of **128 MiB** (per DB-Server in clusters).
+- Maximum transaction size with a default of **512 MiB** (per DB-Server in clusters).
 
 These limits are also enforced for Stream Transactions on single servers.
 

--- a/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -180,7 +180,8 @@ The [Stream Transactions HTTP API](../../develop/http-api/transactions/stream-tr
 may now allow larger transactions or be limited to smaller transactions because
 the maximum transaction size can now be configured with the
 `--transaction.streaming-max-transaction-size` startup option.
-The default value remains 128 MiB.
+The default value remains 128 MiB up to v3.12.3.
+From v3.12.4 onward, the default value is 512 MiB.
 
 #### Analyzer API
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -270,8 +270,9 @@ the global limit with the `--query.global-memory-limit` startup option.
 [Stream Transactions](../../develop/transactions/stream-transactions.md) may
 now be limited to smaller transaction sizes because the maximum transaction size
 can now be configured with the `--transaction.streaming-max-transaction-size`
-startup option. The default value remains 128 MiB but configuring a lower limit
-can cause previously working Stream Transactions to fail.
+startup option. The default value remains 128 MiB (up to v3.12.3) but configuring
+a lower limit can cause previously working Stream Transactions to fail.
+From v3.12.4 onward, the default value is 512 MiB.
 
 ## Exit code adjustments
 

--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1106,7 +1106,8 @@ in the `--server.endpoint` startup option of the server.
 
 The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
 can now be configured with the new `--transaction.streaming-max-transaction-size`
-startup option. The default value remains 128 MiB.
+startup option. The default value remains 128 MiB up to v3.12.3.
+From v3.12.4 onward, the default value is 512 MiB.
 
 ### Transparent compression of requests and responses between ArangoDB servers and client tools
 

--- a/site/content/3.13/develop/transactions/stream-transactions.md
+++ b/site/content/3.13/develop/transactions/stream-transactions.md
@@ -44,7 +44,7 @@ on the Coordinator to ensure that abandoned transactions cannot block the
 cluster from operating properly:
 
 - Maximum idle timeout of up to **120 seconds** between operations.
-- Maximum transaction size with a default of **128 MiB** (per DB-Server in clusters).
+- Maximum transaction size with a default of **512 MiB** (per DB-Server in clusters).
 
 These limits are also enforced for Stream Transactions on single servers.
 

--- a/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/api-changes-in-3-12.md
@@ -180,7 +180,8 @@ The [Stream Transactions HTTP API](../../develop/http-api/transactions/stream-tr
 may now allow larger transactions or be limited to smaller transactions because
 the maximum transaction size can now be configured with the
 `--transaction.streaming-max-transaction-size` startup option.
-The default value remains 128 MiB.
+The default value remains 128 MiB up to v3.12.3.
+From v3.12.4 onward, the default value is 512 MiB.
 
 #### Analyzer API
 

--- a/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -270,8 +270,9 @@ the global limit with the `--query.global-memory-limit` startup option.
 [Stream Transactions](../../develop/transactions/stream-transactions.md) may
 now be limited to smaller transaction sizes because the maximum transaction size
 can now be configured with the `--transaction.streaming-max-transaction-size`
-startup option. The default value remains 128 MiB but configuring a lower limit
-can cause previously working Stream Transactions to fail.
+startup option. The default value remains 128 MiB (up to v3.12.3) but configuring
+a lower limit can cause previously working Stream Transactions to fail.
+From v3.12.4 onward, the default value is 512 MiB.
 
 ## Exit code adjustments
 

--- a/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1106,7 +1106,8 @@ in the `--server.endpoint` startup option of the server.
 
 The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
 can now be configured with the new `--transaction.streaming-max-transaction-size`
-startup option. The default value remains 128 MiB.
+startup option. The default value remains 128 MiB up to v3.12.3.
+From v3.12.4 onward, the default value is 512 MiB.
 
 ### Transparent compression of requests and responses between ArangoDB servers and client tools
 


### PR DESCRIPTION
### Description

Default max size for Stream Transactions increased from 128 to 512 MiB

- https://github.com/arangodb/arangodb/pull/21553

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
