### PR TITLE
DOC-739 | Move Inkeep Ask AI button

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/inkeep-widget.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/inkeep-widget.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
   const SCRIPT_SRC =
-    "https://unpkg.com/@inkeep/widgets-embed@0.2.278/dist/embed.js";
+    "https://unpkg.com/@inkeep/widgets-embed@0.2.290/dist/embed.js";
 
   function loadAndInitializeInkeep() {
     if (document.querySelector(`script[src="${SCRIPT_SRC}]"`)) {

--- a/site/themes/arangodb-docs-theme/layouts/partials/inkeep-widget.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/inkeep-widget.html
@@ -79,7 +79,7 @@
       componentType: "ChatButton",
       properties: {
         stylesheetUrls: ["/css/fonts.css"],
-        fixedPositionXOffset: '52px',
+        fixedPositionXOffset: '90px',
         baseSettings: {
           theme: {
             primaryColors: {

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -2184,3 +2184,7 @@ nav.pagination .next {
     height: 50px !important;
     width: 200px !important;
 }
+
+#ikp-chat-button {
+    z-index: 9991; /* HubSpot has 9990 */
+}


### PR DESCRIPTION
### Description

This avoids an overlap with HubSpot.

<img width="244" alt="image" src="https://github.com/user-attachments/assets/e0e37d78-30cc-417a-8895-054cba2dd7ac" />

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
