### PR TITLE
Add missing collection properties

### DIFF
--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -1251,7 +1251,7 @@ paths:
                           indexes:
                             description: |
                               The detailed index metrics with the number of entries per index.
-                              type: array
+                            type: array
                             items:
                               type: object
                               properties:

--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -329,7 +329,31 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -347,8 +371,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -543,12 +607,66 @@ paths:
                     type: string
         '400':
           description: |
-            If the `collection-name` placeholder is missing, then a *HTTP 400* is
-            returned.
+            The `name` attribute is missing or has an invalid value.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the collection is unknown, then a *HTTP 404*
-            is returned.
+            A collection called `collection-name` could not be found.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Collections
 ```
@@ -656,11 +774,35 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   count:
                     description: |
                       The number of documents currently present in the collection.
                     type: integer
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -678,8 +820,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -986,6 +1168,15 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   count:
                     description: |
@@ -1000,7 +1191,7 @@ paths:
                     properties:
                       indexes:
                         description: |
-                          The index metrics.
+                          The coarse index metrics.
                         type: object
                         required:
                           - count
@@ -1015,6 +1206,78 @@ paths:
                             description: |
                               The total memory allocated for indexes in bytes.
                             type: integer
+                      documentsSize:
+                        description: |
+                          The approximate on-disk size of the documents in bytes.
+                        type: integer
+                      cacheInUse:
+                        description: |
+                          Whether the document cache is enabled for this collection.
+                        type: boolean
+                      cacheSize:
+                        description: |
+                          The total memory usage of the document cache in bytes.
+                        type: integer
+                      cacheUsage:
+                        description: |
+                          The current data memory usage of the document cache in bytes.
+                        type: integer
+                      cacheLifeTimeHitRate:
+                        description: |
+                          The overall cache hit ratio in percent.
+                          Only present if `cacheInUse` is `true`.
+                        type: number
+                      cacheWindowedHitRate:
+                        description: |
+                          The cache hit ratio of the past several thousand find
+                          operations in percent. Only present if `cacheInUse` is `true`.
+                        type: number
+                      engine:
+                        description: |
+                          Extended, storage-engine specific figures.
+                          Only included if the `details` query parameter is set to `true`.
+                        type: object
+                        properties:
+                          documents:
+                            description: |
+                              The number of documents determined by iterating over all
+                              RocksDB keys in range of the column family and counting them.
+                            type: integer
+                          indexes:
+                            description: |
+                              The detailed index metrics with the number of entries per index.
+                              type: array
+                            items:
+                              type: object
+                              properties:
+                                type:
+                                  description: |
+                                    The index type.
+                                    A `persistent` index is reported as `rocksdb-persistent`.
+                                  type: string
+                                id:
+                                  description: |
+                                    The identifier of the index.
+                                  type: integer
+                                count:
+                                  description: |
+                                    The number of index entries.
+                                  type: integer
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -1032,8 +1295,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -1770,11 +2073,35 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   revision:
                     description: |
                       The collection revision ID as a string.
                     type: string
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -1792,8 +2119,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -2335,10 +2702,40 @@ paths:
                   default: false
                 schema:
                   description: |
-                    Optional object that specifies the collection level schema for
-                    documents. The attribute keys `rule`, `level` and `message` must follow the
-                    rules documented in [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                    The configuration of the collection-level schema validation for documents.
                   type: object
+                  required:
+                    - rule
+                  properties:
+                    rule:
+                      description: |
+                        A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                        object (draft-4, without remote schemas).
+
+                        See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                        for details.
+                      type: object
+                    level:
+                      description: |
+                        The level controls when the validation is triggered:
+                        - `"none"`: The rule is inactive and validation thus turned off.
+                        - `"new"`: Only newly inserted documents are validated.
+                        - `"moderate"`: New and modified documents must pass validation,
+                          except for modified documents where the OLD value did not pass
+                          validation already. This level is useful if you have documents
+                          which do not match your target structure, but you want to stop
+                          the insertion of more invalid documents and prohibit that valid
+                          documents are changed to invalid documents.
+                        - `"strict"`: All new and modified document must strictly pass
+                          validation. No exceptions are made.
+                      type: string
+                      enum: [none, new, moderate, strict]
+                      default: strict
+                    message:
+                      description: |
+                        The error message to raise if the schema validation fails
+                        for a document.
+                      type: string
                 computedValues:
                   description: |
                     An optional list of objects, each representing a computed value.
@@ -2618,14 +3015,58 @@ paths:
           content:
             application/json:
               schema:
-                description: ''
                 type: object
                 required:
+                  - error
+                  - code
+                  - name
+                  - type
+                  - status
+                  - statusString
+                  - isSystem
+                  - id
+                  - globallyUniqueId
                   - waitForSync
                   - keyOptions
+                  - schema
+                  - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
                   waitForSync:
                     description: |
                       If `true`, creating, changing, or removing
@@ -2633,8 +3074,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -3372,10 +3853,40 @@ paths:
                   type: boolean
                 schema:
                   description: |
-                    Optional object that specifies the collection level schema for
-                    documents. The attribute keys `rule`, `level` and `message` must follow the
-                    rules documented in [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                    The configuration of the collection-level schema validation for documents.
                   type: object
+                  required:
+                    - rule
+                  properties:
+                    rule:
+                      description: |
+                        A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                        object (draft-4, without remote schemas).
+
+                        See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                        for details.
+                      type: object
+                    level:
+                      description: |
+                        The level controls when the validation is triggered:
+                        - `"none"`: The rule is inactive and validation thus turned off.
+                        - `"new"`: Only newly inserted documents are validated.
+                        - `"moderate"`: New and modified documents must pass validation,
+                          except for modified documents where the OLD value did not pass
+                          validation already. This level is useful if you have documents
+                          which do not match your target structure, but you want to stop
+                          the insertion of more invalid documents and prohibit that valid
+                          documents are changed to invalid documents.
+                        - `"strict"`: All new and modified document must strictly pass
+                          validation. No exceptions are made.
+                      type: string
+                      enum: [none, new, moderate, strict]
+                      default: strict
+                    message:
+                      description: |
+                        The error message to raise if the schema validation fails
+                        for a document.
+                      type: string
                 computedValues:
                   description: |
                     An optional list of objects, each representing a computed value.
@@ -3481,7 +3992,31 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -3499,8 +4034,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -4005,11 +4580,42 @@ paths:
                   - code
                   - name
                   - type
-                  - isSystem
                   - status
+                  - statusString
+                  - isSystem
                   - id
                   - globallyUniqueId
+                  - waitForSync
+                  - keyOptions
+                  - schema
+                  - computedValues
+                  - cacheEnabled
+                  - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -4020,11 +4626,227 @@ paths:
                       The HTTP response status code.
                     type: integer
                     example: 200
+                  waitForSync:
+                    description: |
+                      If `true`, creating, changing, or removing
+                      documents waits until the data has been synchronized to disk.
+                    type: boolean
+                  schema:
+                    description: |
+                      The configuration of the collection-level schema validation for documents.
+                    type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
+                  computedValues:
+                    description: |
+                      A list of objects, each representing a computed value.
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - expression
+                        - overwrite
+                      properties:
+                        name:
+                          description: |
+                            The name of the target attribute.
+                          type: string
+                        expression:
+                          description: |
+                            An AQL `RETURN` operation with an expression that computes the desired value.
+                          type: string
+                        overwrite:
+                          description: |
+                            Whether the computed value takes precedence over a user-provided or
+                            existing attribute.
+                          type: boolean
+                        computeOn:
+                          description: |
+                            An array of strings that defines on which write operations the value is
+                            computed.
+                          type: array
+                          uniqueItems: true
+                          items:
+                            type: string
+                            enum: [insert, update, replace]
+                          example: ["insert", "update", "replace"]
+                        keepNull:
+                          description: |
+                            Whether the target attribute is set if the expression evaluates to `null`.
+                          type: boolean
+                        failOnWarning:
+                          description: |
+                            Whether the write operation fails if the expression produces a warning.
+                          type: boolean
+                  keyOptions:
+                    description: |
+                      An object which contains key generation options.
+                    type: object
+                    required:
+                      - type
+                      - allowUserKeys
+                    properties:
+                      type:
+                        description: |
+                          Specifies the type of the key generator.
+                        type: string
+                        enum: [traditional, autoincrement, uuid, padded]
+                      allowUserKeys:
+                        description: |
+                          If set to `true`, then you are allowed to supply
+                          own key values in the `_key` attribute of a document. If set to
+                          `false`, then the key generator is solely responsible for
+                          generating keys and an error is raised if you supply own key values in the
+                          `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
+                        type: boolean
+                      increment:
+                        description: |
+                          The increment value for the `autoincrement` key generator.
+                          Not used by other key generator types.
+                        type: integer
+                      offset:
+                        description: |
+                          The initial offset value for the `autoincrement` key generator.
+                          Not used by other key generator types.
+                        type: integer
+                      lastValue:
+                        description: |
+                          The offset value of the `autoincrement` or `padded` key generator.
+                          This is an internal property for restoring dumps properly.
+                        type: integer
+                  cacheEnabled:
+                    description: |
+                      Whether the in-memory hash cache for documents is enabled for this
+                      collection.
+                    type: boolean
+                  numberOfShards:
+                    description: |
+                      The number of shards of the collection. _(cluster only)_
+                    type: integer
+                  shardKeys:
+                    description: |
+                      Contains the names of document attributes that are used to
+                      determine the target shard for documents. _(cluster only)_
+                    type: array
+                    items:
+                      type: string
+                  replicationFactor:
+                    description: |
+                      Contains how many copies of each shard are kept on different DB-Servers.
+                      It is an integer number in the range of 1-10 or the string `"satellite"`
+                      for SatelliteCollections (Enterprise Edition only). _(cluster only)_
+                    type: integer
+                  writeConcern:
+                    description: |
+                      Determines how many copies of each shard are required to be
+                      in-sync on the different DB-Servers. If there are less than these many copies
+                      in the cluster, a shard refuses to write. Writes to shards with enough
+                      up-to-date copies succeed at the same time, however. The value of
+                      `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the default `writeConcern`
+                      is that of the prototype collection.
+                      For SatelliteCollections, the `writeConcern` is automatically controlled to
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
+                    type: integer
+                  shardingStrategy:
+                    description: |
+                      The sharding strategy selected for the collection. _(cluster only)_
+                    type: string
+                    enum:
+                      - community-compat
+                      - enterprise-compat
+                      - enterprise-smart-edge-compat
+                      - hash
+                      - enterprise-hash-smart-edge
+                      - enterprise-hex-smart-vertex
+                  distributeShardsLike:
+                    description: |
+                      The name of another collection. This collection uses the `replicationFactor`,
+                      `numberOfShards` and `shardingStrategy` properties of the other collection and
+                      the shards of this collection are distributed in the same way as the shards of
+                      the other collection.
+                    type: string
+                  isSmart:
+                    description: |
+                      Whether the collection is used in a SmartGraph or EnterpriseGraph (Enterprise Edition only).
+                      This is an internal property. _(cluster only)_
+                    type: boolean
+                  isDisjoint:
+                    description: |
+                      Whether the SmartGraph or EnterpriseGraph this collection belongs to is disjoint
+                      (Enterprise Edition only). This is an internal property. _(cluster only)_
+                    type: boolean
+                  smartGraphAttribute:
+                    description: |
+                      The attribute that is used for sharding: vertices with the same value of
+                      this attribute are placed in the same shard. All vertices are required to
+                      have this attribute set and it has to be a string. Edges derive the
+                      attribute from their connected vertices (Enterprise Edition only). _(cluster only)_
+                    type: string
+                  smartJoinAttribute:
+                    description: |
+                      Determines an attribute of the collection that must contain the shard key value
+                      of the referred-to SmartJoin collection (Enterprise Edition only). _(cluster only)_
+                    type: string
                   name:
                     description: |
-                      The name of the collection.
+                      The name of this collection.
                     type: string
                     example: coll
+                  id:
+                    description: |
+                      A unique identifier of the collection (deprecated).
+                    type: string
                   type:
                     description: |
                       The type of the collection:
@@ -4039,19 +4861,11 @@ paths:
                       an underscore are usually system collections.
                     type: boolean
                     example: false
-                  status:
+                  syncByRevision:
                     description: |
-                      The status of the collection.
-                      - `3`: loaded
-                      - `5`: deleted
-
-                      Every other status indicates a corrupted collection.
-                    type: integer
-                    example: 3
-                  id:
-                    description: |
-                      A unique identifier of the collection (deprecated).
-                    type: string
+                      Whether the newer revision-based replication protocol is
+                      enabled for this collection. This is an internal property.
+                    type: boolean
                   globallyUniqueId:
                     description: |
                       A unique identifier of the collection. This is an internal property.

--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -1224,13 +1224,18 @@ paths:
                         type: integer
                       cacheLifeTimeHitRate:
                         description: |
-                          The overall cache hit ratio in percent.
-                          Only present if `cacheInUse` is `true`.
+                          The overall cache hit ratio in percent. In cluster deployments,
+                          it is the sum of percentages of all shards.
+                          
+                          The attribute is only present if `cacheInUse` is `true`.
                         type: number
                       cacheWindowedHitRate:
                         description: |
                           The cache hit ratio of the past several thousand find
-                          operations in percent. Only present if `cacheInUse` is `true`.
+                          operations in percent. In cluster deployments,
+                          it is the sum of percentages of all shards.
+
+                          The attribute is only present if `cacheInUse` is `true`.
                         type: number
                       engine:
                         description: |

--- a/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
@@ -102,14 +102,25 @@ debugging ArangoDB itself and their format is subject to change. By default,
 `details` is set to `false`, so no details are returned and the behavior is
 identical to previous versions of ArangoDB.
 
-- `indexes.count`: The total number of indexes defined for the
-  collection, including the pre-defined indexes (e.g. primary index).
-- `indexes.size`: The total memory allocated for indexes in bytes.
-<!-- TODO: describe RocksDB figures -->
-- `documentsSize`
-- `cacheInUse`
-- `cacheSize`
-- `cacheUsage`
+- `indexes`: The coarse index metrics.
+  - `count`: The total number of indexes defined for the
+    collection, including the pre-defined indexes (e.g. primary index).
+  - `size`: The total memory allocated for indexes in bytes.
+- `documentsSize`: The approximate on-disk size of the documents in bytes.
+- `cacheInUse`: Whether the document cache is enabled for this collection.
+- `cacheSize`: The total memory usage of the document cache in bytes.
+- `cacheUsage`: The current data memory usage of the document cache in bytes.
+- `cacheLifeTimeHitRate`: The overall cache hit ratio in percent.
+  Only present if `cacheInUse` is `true`.
+- `cacheWindowedHitRate`: The cache hit ratio of the past several thousand find
+  operations in percent. Only present if `cacheInUse` is `true`.
+- `engine`: Extended, storage-engine specific figures.
+  - `documents`: The number of documents determined by iterating over all
+    RocksDB keys in range of the column family and counting them.
+  - `indexes`: The detailed index metrics with the number of entries per index (array of objects).
+    - `type`: The index type. A `persistent` index is reported as `rocksdb-persistent`.
+    - `id`: The identifier of the index.
+    - `count`: The number of index entries.
 
 **Examples**
 

--- a/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.11/develop/javascript-api/@arangodb/collection-object.md
@@ -111,9 +111,11 @@ identical to previous versions of ArangoDB.
 - `cacheSize`: The total memory usage of the document cache in bytes.
 - `cacheUsage`: The current data memory usage of the document cache in bytes.
 - `cacheLifeTimeHitRate`: The overall cache hit ratio in percent.
-  Only present if `cacheInUse` is `true`.
+  In cluster deployments, it is the sum of percentages of all shards.
+  The attribute is only present if `cacheInUse` is `true`.
 - `cacheWindowedHitRate`: The cache hit ratio of the past several thousand find
-  operations in percent. Only present if `cacheInUse` is `true`.
+  operations in percent. In cluster deployments, it is the sum of percentages
+  of all shards. The attribute is only present if `cacheInUse` is `true`.
 - `engine`: Extended, storage-engine specific figures.
   - `documents`: The number of documents determined by iterating over all
     RocksDB keys in range of the column family and counting them.

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -329,7 +329,31 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -347,8 +371,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -543,12 +607,66 @@ paths:
                     type: string
         '400':
           description: |
-            If the `collection-name` placeholder is missing, then a *HTTP 400* is
-            returned.
+            The `name` attribute is missing or has an invalid value.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the collection is unknown, then a *HTTP 404*
-            is returned.
+            A collection called `collection-name` could not be found.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Collections
 ```
@@ -656,11 +774,35 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   count:
                     description: |
                       The number of documents currently present in the collection.
                     type: integer
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -678,8 +820,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -986,6 +1168,15 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   count:
                     description: |
@@ -1000,7 +1191,7 @@ paths:
                     properties:
                       indexes:
                         description: |
-                          The index metrics.
+                          The coarse index metrics.
                         type: object
                         required:
                           - count
@@ -1015,6 +1206,78 @@ paths:
                             description: |
                               The total memory allocated for indexes in bytes.
                             type: integer
+                      documentsSize:
+                        description: |
+                          The approximate on-disk size of the documents in bytes.
+                        type: integer
+                      cacheInUse:
+                        description: |
+                          Whether the document cache is enabled for this collection.
+                        type: boolean
+                      cacheSize:
+                        description: |
+                          The total memory usage of the document cache in bytes.
+                        type: integer
+                      cacheUsage:
+                        description: |
+                          The current data memory usage of the document cache in bytes.
+                        type: integer
+                      cacheLifeTimeHitRate:
+                        description: |
+                          The overall cache hit ratio in percent.
+                          Only present if `cacheInUse` is `true`.
+                        type: number
+                      cacheWindowedHitRate:
+                        description: |
+                          The cache hit ratio of the past several thousand find
+                          operations in percent. Only present if `cacheInUse` is `true`.
+                        type: number
+                      engine:
+                        description: |
+                          Extended, storage-engine specific figures.
+                          Only included if the `details` query parameter is set to `true`.
+                        type: object
+                        properties:
+                          documents:
+                            description: |
+                              The number of documents determined by iterating over all
+                              RocksDB keys in range of the column family and counting them.
+                            type: integer
+                          indexes:
+                            description: |
+                              The detailed index metrics with the number of entries per index.
+                              type: array
+                            items:
+                              type: object
+                              properties:
+                                type:
+                                  description: |
+                                    The index type.
+                                    A `persistent` index is reported as `rocksdb-persistent`.
+                                  type: string
+                                id:
+                                  description: |
+                                    The identifier of the index.
+                                  type: integer
+                                count:
+                                  description: |
+                                    The number of index entries.
+                                  type: integer
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -1032,8 +1295,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -1770,11 +2073,35 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   revision:
                     description: |
                       The collection revision ID as a string.
                     type: string
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -1792,8 +2119,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -2393,10 +2760,40 @@ paths:
                   default: false
                 schema:
                   description: |
-                    Optional object that specifies the collection level schema for
-                    documents. The attribute keys `rule`, `level` and `message` must follow the
-                    rules documented in [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                    The configuration of the collection-level schema validation for documents.
                   type: object
+                  required:
+                    - rule
+                  properties:
+                    rule:
+                      description: |
+                        A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                        object (draft-4, without remote schemas).
+
+                        See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                        for details.
+                      type: object
+                    level:
+                      description: |
+                        The level controls when the validation is triggered:
+                        - `"none"`: The rule is inactive and validation thus turned off.
+                        - `"new"`: Only newly inserted documents are validated.
+                        - `"moderate"`: New and modified documents must pass validation,
+                          except for modified documents where the OLD value did not pass
+                          validation already. This level is useful if you have documents
+                          which do not match your target structure, but you want to stop
+                          the insertion of more invalid documents and prohibit that valid
+                          documents are changed to invalid documents.
+                        - `"strict"`: All new and modified document must strictly pass
+                          validation. No exceptions are made.
+                      type: string
+                      enum: [none, new, moderate, strict]
+                      default: strict
+                    message:
+                      description: |
+                        The error message to raise if the schema validation fails
+                        for a document.
+                      type: string
                 computedValues:
                   description: |
                     An optional list of objects, each representing a computed value.
@@ -2676,14 +3073,58 @@ paths:
           content:
             application/json:
               schema:
-                description: ''
                 type: object
                 required:
+                  - error
+                  - code
+                  - name
+                  - type
+                  - status
+                  - statusString
+                  - isSystem
+                  - id
+                  - globallyUniqueId
                   - waitForSync
                   - keyOptions
+                  - schema
+                  - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
                   waitForSync:
                     description: |
                       If `true`, creating, changing, or removing
@@ -2691,8 +3132,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -3430,10 +3911,40 @@ paths:
                   type: boolean
                 schema:
                   description: |
-                    Optional object that specifies the collection level schema for
-                    documents. The attribute keys `rule`, `level` and `message` must follow the
-                    rules documented in [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                    The configuration of the collection-level schema validation for documents.
                   type: object
+                  required:
+                    - rule
+                  properties:
+                    rule:
+                      description: |
+                        A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                        object (draft-4, without remote schemas).
+
+                        See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                        for details.
+                      type: object
+                    level:
+                      description: |
+                        The level controls when the validation is triggered:
+                        - `"none"`: The rule is inactive and validation thus turned off.
+                        - `"new"`: Only newly inserted documents are validated.
+                        - `"moderate"`: New and modified documents must pass validation,
+                          except for modified documents where the OLD value did not pass
+                          validation already. This level is useful if you have documents
+                          which do not match your target structure, but you want to stop
+                          the insertion of more invalid documents and prohibit that valid
+                          documents are changed to invalid documents.
+                        - `"strict"`: All new and modified document must strictly pass
+                          validation. No exceptions are made.
+                      type: string
+                      enum: [none, new, moderate, strict]
+                      default: strict
+                    message:
+                      description: |
+                        The error message to raise if the schema validation fails
+                        for a document.
+                      type: string
                 computedValues:
                   description: |
                     An optional list of objects, each representing a computed value.
@@ -3539,7 +4050,31 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -3557,8 +4092,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -4063,11 +4638,42 @@ paths:
                   - code
                   - name
                   - type
-                  - isSystem
                   - status
+                  - statusString
+                  - isSystem
                   - id
                   - globallyUniqueId
+                  - waitForSync
+                  - keyOptions
+                  - schema
+                  - computedValues
+                  - cacheEnabled
+                  - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  # For backward compatibility:
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  status:
+                    description: |
+                      The status of the collection (deprecated).
+                      - `3`: loaded
+                      - `5`: deleted
+
+                      Every other status indicates a corrupted collection.
+                    type: integer
+                    example: 3
+                  statusString:
+                    description: |
+                      The status of the collection as a descriptive string (deprecated).
+                    type: string
+                    enum: [loaded, deleted]
+                    example: loaded
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -4078,11 +4684,227 @@ paths:
                       The HTTP response status code.
                     type: integer
                     example: 200
+                  waitForSync:
+                    description: |
+                      If `true`, creating, changing, or removing
+                      documents waits until the data has been synchronized to disk.
+                    type: boolean
+                  schema:
+                    description: |
+                      The configuration of the collection-level schema validation for documents.
+                    type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
+                  computedValues:
+                    description: |
+                      A list of objects, each representing a computed value.
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - expression
+                        - overwrite
+                      properties:
+                        name:
+                          description: |
+                            The name of the target attribute.
+                          type: string
+                        expression:
+                          description: |
+                            An AQL `RETURN` operation with an expression that computes the desired value.
+                          type: string
+                        overwrite:
+                          description: |
+                            Whether the computed value takes precedence over a user-provided or
+                            existing attribute.
+                          type: boolean
+                        computeOn:
+                          description: |
+                            An array of strings that defines on which write operations the value is
+                            computed.
+                          type: array
+                          uniqueItems: true
+                          items:
+                            type: string
+                            enum: [insert, update, replace]
+                          example: ["insert", "update", "replace"]
+                        keepNull:
+                          description: |
+                            Whether the target attribute is set if the expression evaluates to `null`.
+                          type: boolean
+                        failOnWarning:
+                          description: |
+                            Whether the write operation fails if the expression produces a warning.
+                          type: boolean
+                  keyOptions:
+                    description: |
+                      An object which contains key generation options.
+                    type: object
+                    required:
+                      - type
+                      - allowUserKeys
+                    properties:
+                      type:
+                        description: |
+                          Specifies the type of the key generator.
+                        type: string
+                        enum: [traditional, autoincrement, uuid, padded]
+                      allowUserKeys:
+                        description: |
+                          If set to `true`, then you are allowed to supply
+                          own key values in the `_key` attribute of a document. If set to
+                          `false`, then the key generator is solely responsible for
+                          generating keys and an error is raised if you supply own key values in the
+                          `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
+                        type: boolean
+                      increment:
+                        description: |
+                          The increment value for the `autoincrement` key generator.
+                          Not used by other key generator types.
+                        type: integer
+                      offset:
+                        description: |
+                          The initial offset value for the `autoincrement` key generator.
+                          Not used by other key generator types.
+                        type: integer
+                      lastValue:
+                        description: |
+                          The offset value of the `autoincrement` or `padded` key generator.
+                          This is an internal property for restoring dumps properly.
+                        type: integer
+                  cacheEnabled:
+                    description: |
+                      Whether the in-memory hash cache for documents is enabled for this
+                      collection.
+                    type: boolean
+                  numberOfShards:
+                    description: |
+                      The number of shards of the collection. _(cluster only)_
+                    type: integer
+                  shardKeys:
+                    description: |
+                      Contains the names of document attributes that are used to
+                      determine the target shard for documents. _(cluster only)_
+                    type: array
+                    items:
+                      type: string
+                  replicationFactor:
+                    description: |
+                      Contains how many copies of each shard are kept on different DB-Servers.
+                      It is an integer number in the range of 1-10 or the string `"satellite"`
+                      for SatelliteCollections (Enterprise Edition only). _(cluster only)_
+                    type: integer
+                  writeConcern:
+                    description: |
+                      Determines how many copies of each shard are required to be
+                      in-sync on the different DB-Servers. If there are less than these many copies
+                      in the cluster, a shard refuses to write. Writes to shards with enough
+                      up-to-date copies succeed at the same time, however. The value of
+                      `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the default `writeConcern`
+                      is that of the prototype collection.
+                      For SatelliteCollections, the `writeConcern` is automatically controlled to
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
+                    type: integer
+                  shardingStrategy:
+                    description: |
+                      The sharding strategy selected for the collection. _(cluster only)_
+                    type: string
+                    enum:
+                      - community-compat
+                      - enterprise-compat
+                      - enterprise-smart-edge-compat
+                      - hash
+                      - enterprise-hash-smart-edge
+                      - enterprise-hex-smart-vertex
+                  distributeShardsLike:
+                    description: |
+                      The name of another collection. This collection uses the `replicationFactor`,
+                      `numberOfShards` and `shardingStrategy` properties of the other collection and
+                      the shards of this collection are distributed in the same way as the shards of
+                      the other collection.
+                    type: string
+                  isSmart:
+                    description: |
+                      Whether the collection is used in a SmartGraph or EnterpriseGraph (Enterprise Edition only).
+                      This is an internal property. _(cluster only)_
+                    type: boolean
+                  isDisjoint:
+                    description: |
+                      Whether the SmartGraph or EnterpriseGraph this collection belongs to is disjoint
+                      (Enterprise Edition only). This is an internal property. _(cluster only)_
+                    type: boolean
+                  smartGraphAttribute:
+                    description: |
+                      The attribute that is used for sharding: vertices with the same value of
+                      this attribute are placed in the same shard. All vertices are required to
+                      have this attribute set and it has to be a string. Edges derive the
+                      attribute from their connected vertices (Enterprise Edition only). _(cluster only)_
+                    type: string
+                  smartJoinAttribute:
+                    description: |
+                      Determines an attribute of the collection that must contain the shard key value
+                      of the referred-to SmartJoin collection (Enterprise Edition only). _(cluster only)_
+                    type: string
                   name:
                     description: |
-                      The name of the collection.
+                      The name of this collection.
                     type: string
                     example: coll
+                  id:
+                    description: |
+                      A unique identifier of the collection (deprecated).
+                    type: string
                   type:
                     description: |
                       The type of the collection:
@@ -4097,19 +4919,11 @@ paths:
                       an underscore are usually system collections.
                     type: boolean
                     example: false
-                  status:
+                  syncByRevision:
                     description: |
-                      The status of the collection.
-                      - `3`: loaded
-                      - `5`: deleted
-
-                      Every other status indicates a corrupted collection.
-                    type: integer
-                    example: 3
-                  id:
-                    description: |
-                      A unique identifier of the collection (deprecated).
-                    type: string
+                      Whether the newer revision-based replication protocol is
+                      enabled for this collection. This is an internal property.
+                    type: boolean
                   globallyUniqueId:
                     description: |
                       A unique identifier of the collection. This is an internal property.

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -1251,7 +1251,7 @@ paths:
                           indexes:
                             description: |
                               The detailed index metrics with the number of entries per index.
-                              type: array
+                            type: array
                             items:
                               type: object
                               properties:

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -1224,13 +1224,18 @@ paths:
                         type: integer
                       cacheLifeTimeHitRate:
                         description: |
-                          The overall cache hit ratio in percent.
-                          Only present if `cacheInUse` is `true`.
+                          The overall cache hit ratio in percent. In cluster deployments,
+                          it is the sum of percentages of all shards.
+                          
+                          The attribute is only present if `cacheInUse` is `true`.
                         type: number
                       cacheWindowedHitRate:
                         description: |
                           The cache hit ratio of the past several thousand find
-                          operations in percent. Only present if `cacheInUse` is `true`.
+                          operations in percent. In cluster deployments,
+                          it is the sum of percentages of all shards.
+
+                          The attribute is only present if `cacheInUse` is `true`.
                         type: number
                       engine:
                         description: |

--- a/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
@@ -102,14 +102,25 @@ debugging ArangoDB itself and their format is subject to change. By default,
 `details` is set to `false`, so no details are returned and the behavior is
 identical to previous versions of ArangoDB.
 
-- `indexes.count`: The total number of indexes defined for the
-  collection, including the pre-defined indexes (e.g. primary index).
-- `indexes.size`: The total memory allocated for indexes in bytes.
-<!-- TODO: describe RocksDB figures -->
-- `documentsSize`
-- `cacheInUse`
-- `cacheSize`
-- `cacheUsage`
+- `indexes`: The coarse index metrics.
+  - `count`: The total number of indexes defined for the
+    collection, including the pre-defined indexes (e.g. primary index).
+  - `size`: The total memory allocated for indexes in bytes.
+- `documentsSize`: The approximate on-disk size of the documents in bytes.
+- `cacheInUse`: Whether the document cache is enabled for this collection.
+- `cacheSize`: The total memory usage of the document cache in bytes.
+- `cacheUsage`: The current data memory usage of the document cache in bytes.
+- `cacheLifeTimeHitRate`: The overall cache hit ratio in percent.
+  Only present if `cacheInUse` is `true`.
+- `cacheWindowedHitRate`: The cache hit ratio of the past several thousand find
+  operations in percent. Only present if `cacheInUse` is `true`.
+- `engine`: Extended, storage-engine specific figures.
+  - `documents`: The number of documents determined by iterating over all
+    RocksDB keys in range of the column family and counting them.
+  - `indexes`: The detailed index metrics with the number of entries per index (array of objects).
+    - `type`: The index type. A `persistent` index is reported as `rocksdb-persistent`.
+    - `id`: The identifier of the index.
+    - `count`: The number of index entries.
 
 **Examples**
 

--- a/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.12/develop/javascript-api/@arangodb/collection-object.md
@@ -111,9 +111,11 @@ identical to previous versions of ArangoDB.
 - `cacheSize`: The total memory usage of the document cache in bytes.
 - `cacheUsage`: The current data memory usage of the document cache in bytes.
 - `cacheLifeTimeHitRate`: The overall cache hit ratio in percent.
-  Only present if `cacheInUse` is `true`.
+  In cluster deployments, it is the sum of percentages of all shards.
+  The attribute is only present if `cacheInUse` is `true`.
 - `cacheWindowedHitRate`: The cache hit ratio of the past several thousand find
-  operations in percent. Only present if `cacheInUse` is `true`.
+  operations in percent. In cluster deployments, it is the sum of percentages
+  of all shards. The attribute is only present if `cacheInUse` is `true`.
 - `engine`: Extended, storage-engine specific figures.
   - `documents`: The number of documents determined by iterating over all
     RocksDB keys in range of the column family and counting them.

--- a/site/content/3.13/develop/http-api/collections.md
+++ b/site/content/3.13/develop/http-api/collections.md
@@ -1191,13 +1191,18 @@ paths:
                         type: integer
                       cacheLifeTimeHitRate:
                         description: |
-                          The overall cache hit ratio in percent.
-                          Only present if `cacheInUse` is `true`.
+                          The overall cache hit ratio in percent. In cluster deployments,
+                          it is the sum of percentages of all shards.
+                          
+                          The attribute is only present if `cacheInUse` is `true`.
                         type: number
                       cacheWindowedHitRate:
                         description: |
                           The cache hit ratio of the past several thousand find
-                          operations in percent. Only present if `cacheInUse` is `true`.
+                          operations in percent. In cluster deployments,
+                          it is the sum of percentages of all shards.
+
+                          The attribute is only present if `cacheInUse` is `true`.
                         type: number
                       engine:
                         description: |

--- a/site/content/3.13/develop/http-api/collections.md
+++ b/site/content/3.13/develop/http-api/collections.md
@@ -329,6 +329,14 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   error:
                     description: |
@@ -347,8 +355,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -543,12 +591,66 @@ paths:
                     type: string
         '400':
           description: |
-            If the `collection-name` placeholder is missing, then a *HTTP 400* is
-            returned.
+            The `name` attribute is missing or has an invalid value.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the collection is unknown, then a *HTTP 404*
-            is returned.
+            A collection called `collection-name` could not be found.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Collections
 ```
@@ -656,6 +758,14 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   count:
                     description: |
@@ -678,8 +788,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -986,6 +1136,14 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   count:
                     description: |
@@ -1000,7 +1158,7 @@ paths:
                     properties:
                       indexes:
                         description: |
-                          The index metrics.
+                          The coarse index metrics.
                         type: object
                         required:
                           - count
@@ -1015,6 +1173,63 @@ paths:
                             description: |
                               The total memory allocated for indexes in bytes.
                             type: integer
+                      documentsSize:
+                        description: |
+                          The approximate on-disk size of the documents in bytes.
+                        type: integer
+                      cacheInUse:
+                        description: |
+                          Whether the document cache is enabled for this collection.
+                        type: boolean
+                      cacheSize:
+                        description: |
+                          The total memory usage of the document cache in bytes.
+                        type: integer
+                      cacheUsage:
+                        description: |
+                          The current data memory usage of the document cache in bytes.
+                        type: integer
+                      cacheLifeTimeHitRate:
+                        description: |
+                          The overall cache hit ratio in percent.
+                          Only present if `cacheInUse` is `true`.
+                        type: number
+                      cacheWindowedHitRate:
+                        description: |
+                          The cache hit ratio of the past several thousand find
+                          operations in percent. Only present if `cacheInUse` is `true`.
+                        type: number
+                      engine:
+                        description: |
+                          Extended, storage-engine specific figures.
+                          Only included if the `details` query parameter is set to `true`.
+                        type: object
+                        properties:
+                          documents:
+                            description: |
+                              The number of documents determined by iterating over all
+                              RocksDB keys in range of the column family and counting them.
+                            type: integer
+                          indexes:
+                            description: |
+                              The detailed index metrics with the number of entries per index.
+                              type: array
+                            items:
+                              type: object
+                              properties:
+                                type:
+                                  description: |
+                                    The index type.
+                                    A `persistent` index is reported as `rocksdb-persistent`.
+                                  type: string
+                                id:
+                                  description: |
+                                    The identifier of the index.
+                                  type: integer
+                                count:
+                                  description: |
+                                    The number of index entries.
+                                  type: integer
                   error:
                     description: |
                       A flag indicating that no error occurred.
@@ -1032,8 +1247,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -1770,6 +2025,14 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   revision:
                     description: |
@@ -1792,8 +2055,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -2393,10 +2696,40 @@ paths:
                   default: false
                 schema:
                   description: |
-                    Optional object that specifies the collection level schema for
-                    documents. The attribute keys `rule`, `level` and `message` must follow the
-                    rules documented in [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                    The configuration of the collection-level schema validation for documents.
                   type: object
+                  required:
+                    - rule
+                  properties:
+                    rule:
+                      description: |
+                        A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                        object (draft-4, without remote schemas).
+
+                        See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                        for details.
+                      type: object
+                    level:
+                      description: |
+                        The level controls when the validation is triggered:
+                        - `"none"`: The rule is inactive and validation thus turned off.
+                        - `"new"`: Only newly inserted documents are validated.
+                        - `"moderate"`: New and modified documents must pass validation,
+                          except for modified documents where the OLD value did not pass
+                          validation already. This level is useful if you have documents
+                          which do not match your target structure, but you want to stop
+                          the insertion of more invalid documents and prohibit that valid
+                          documents are changed to invalid documents.
+                        - `"strict"`: All new and modified document must strictly pass
+                          validation. No exceptions are made.
+                      type: string
+                      enum: [none, new, moderate, strict]
+                      default: strict
+                    message:
+                      description: |
+                        The error message to raise if the schema validation fails
+                        for a document.
+                      type: string
                 computedValues:
                   description: |
                     An optional list of objects, each representing a computed value.
@@ -2676,14 +3009,42 @@ paths:
           content:
             application/json:
               schema:
-                description: ''
                 type: object
                 required:
+                  - error
+                  - code
+                  - name
+                  - type
+                  - status
+                  - statusString
+                  - isSystem
+                  - id
+                  - globallyUniqueId
                   - waitForSync
                   - keyOptions
+                  - schema
+                  - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
                   waitForSync:
                     description: |
                       If `true`, creating, changing, or removing
@@ -2691,8 +3052,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -3430,10 +3831,40 @@ paths:
                   type: boolean
                 schema:
                   description: |
-                    Optional object that specifies the collection level schema for
-                    documents. The attribute keys `rule`, `level` and `message` must follow the
-                    rules documented in [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                    The configuration of the collection-level schema validation for documents.
                   type: object
+                  required:
+                    - rule
+                  properties:
+                    rule:
+                      description: |
+                        A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                        object (draft-4, without remote schemas).
+
+                        See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                        for details.
+                      type: object
+                    level:
+                      description: |
+                        The level controls when the validation is triggered:
+                        - `"none"`: The rule is inactive and validation thus turned off.
+                        - `"new"`: Only newly inserted documents are validated.
+                        - `"moderate"`: New and modified documents must pass validation,
+                          except for modified documents where the OLD value did not pass
+                          validation already. This level is useful if you have documents
+                          which do not match your target structure, but you want to stop
+                          the insertion of more invalid documents and prohibit that valid
+                          documents are changed to invalid documents.
+                        - `"strict"`: All new and modified document must strictly pass
+                          validation. No exceptions are made.
+                      type: string
+                      enum: [none, new, moderate, strict]
+                      default: strict
+                    message:
+                      description: |
+                        The error message to raise if the schema validation fails
+                        for a document.
+                      type: string
                 computedValues:
                   description: |
                     An optional list of objects, each representing a computed value.
@@ -3539,6 +3970,14 @@ paths:
                   - computedValues
                   - cacheEnabled
                   - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   error:
                     description: |
@@ -3557,8 +3996,48 @@ paths:
                     type: boolean
                   schema:
                     description: |
-                      An object that specifies the collection-level schema for documents.
+                      The configuration of the collection-level schema validation for documents.
                     type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
                   computedValues:
                     description: |
                       A list of objects, each representing a computed value.
@@ -4063,10 +4542,25 @@ paths:
                   - code
                   - name
                   - type
-                  - isSystem
                   - status
+                  - statusString
+                  - isSystem
                   - id
                   - globallyUniqueId
+                  - waitForSync
+                  - keyOptions
+                  - schema
+                  - computedValues
+                  - cacheEnabled
+                  - syncByRevision
+                  # Purposefully undocumented:
+                  #   internalValidatorType (internal)
+                  #   isSmartChild (internal)
+                  #   minReplicationFactor (now writeConcern)
+                  #   shadowCollections (internal)
+                  #   usesRevisionsAsDocumentIds (internal)
+                  #   status (legacy)
+                  #   statusString (legacy)
                 properties:
                   error:
                     description: |
@@ -4078,11 +4572,228 @@ paths:
                       The HTTP response status code.
                     type: integer
                     example: 200
+                  waitForSync:
+                    description: |
+                      If `true`, creating, changing, or removing
+                      documents waits until the data has been synchronized to disk.
+                    type: boolean
+                  schema:
+                    description: |
+                      The configuration of the collection-level schema validation for documents.
+                    type: object
+                    required:
+                      - rule
+                      - level
+                      - message
+                      - type
+                    properties:
+                      rule:
+                        description: |
+                          A [JSON Schema](https://json-schema.org/specification-links#draft-4)
+                          object (draft-4, without remote schemas).
+
+                          See [Document Schema Validation](../../concepts/data-structure/documents/schema-validation.md)
+                          for details.
+                        type: object
+                      level:
+                        description: |
+                          The level controls when the validation is triggered:
+                          - `"none"`: The rule is inactive and validation thus turned off.
+                          - `"new"`: Only newly inserted documents are validated.
+                          - `"moderate"`: New and modified documents must pass validation,
+                            except for modified documents where the OLD value did not pass
+                            validation already. This level is useful if you have documents
+                            which do not match your target structure, but you want to stop
+                            the insertion of more invalid documents and prohibit that valid
+                            documents are changed to invalid documents.
+                          - `"strict"`: All new and modified document must strictly pass
+                            validation. No exceptions are made.
+                        type: string
+                        enum: [none, new, moderate, strict]
+                        default: strict
+                      message:
+                        description: |
+                          The error message to raise if the schema validation fails
+                          for a document.
+                        type: string
+                      type:
+                        description: |
+                          The schema validation type. Only JSON Schema is supported.
+                        type: string
+                        enum: [json]
+                  computedValues:
+                    description: |
+                      A list of objects, each representing a computed value.
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - expression
+                        - overwrite
+                      properties:
+                        name:
+                          description: |
+                            The name of the target attribute.
+                          type: string
+                        expression:
+                          description: |
+                            An AQL `RETURN` operation with an expression that computes the desired value.
+                          type: string
+                        overwrite:
+                          description: |
+                            Whether the computed value takes precedence over a user-provided or
+                            existing attribute.
+                          type: boolean
+                        computeOn:
+                          description: |
+                            An array of strings that defines on which write operations the value is
+                            computed.
+                          type: array
+                          uniqueItems: true
+                          items:
+                            type: string
+                            enum: [insert, update, replace]
+                          example: ["insert", "update", "replace"]
+                        keepNull:
+                          description: |
+                            Whether the target attribute is set if the expression evaluates to `null`.
+                          type: boolean
+                        failOnWarning:
+                          description: |
+                            Whether the write operation fails if the expression produces a warning.
+                          type: boolean
+                  keyOptions:
+                    description: |
+                      An object which contains key generation options.
+                    type: object
+                    required:
+                      - type
+                      - allowUserKeys
+                    properties:
+                      type:
+                        description: |
+                          Specifies the type of the key generator.
+                        type: string
+                        enum: [traditional, autoincrement, uuid, padded]
+                      allowUserKeys:
+                        description: |
+                          If set to `true`, then you are allowed to supply
+                          own key values in the `_key` attribute of a document. If set to
+                          `false`, then the key generator is solely responsible for
+                          generating keys and an error is raised if you supply own key values in the
+                          `_key` attribute of documents.
+
+                          {{</* warning */>}}
+                          You should not use both user-specified and automatically generated document keys
+                          in the same collection in cluster deployments for collections with more than a
+                          single shard. Mixing the two can lead to conflicts because Coordinators that
+                          auto-generate keys in this case are not aware of all keys which are already used.
+                          {{</* /warning */>}}
+                        type: boolean
+                      increment:
+                        description: |
+                          The increment value for the `autoincrement` key generator.
+                          Not used by other key generator types.
+                        type: integer
+                      offset:
+                        description: |
+                          The initial offset value for the `autoincrement` key generator.
+                          Not used by other key generator types.
+                        type: integer
+                      lastValue:
+                        description: |
+                          The offset value of the `autoincrement` or `padded` key generator.
+                          This is an internal property for restoring dumps properly.
+                        type: integer
+                  cacheEnabled:
+                    description: |
+                      Whether the in-memory hash cache for documents is enabled for this
+                      collection.
+                    type: boolean
+                  numberOfShards:
+                    description: |
+                      The number of shards of the collection. _(cluster only)_
+                    type: integer
+                  shardKeys:
+                    description: |
+                      Contains the names of document attributes that are used to
+                      determine the target shard for documents. _(cluster only)_
+                    type: array
+                    items:
+                      type: string
+                  replicationFactor:
+                    description: |
+                      Contains how many copies of each shard are kept on different DB-Servers.
+                      It is an integer number in the range of 1-10 or the string `"satellite"`
+                      for SatelliteCollections (Enterprise Edition only). _(cluster only)_
+                    type: integer
+                  writeConcern:
+                    description: |
+                      Determines how many copies of each shard are required to be
+                      in-sync on the different DB-Servers. If there are less than these many copies
+                      in the cluster, a shard refuses to write. Writes to shards with enough
+                      up-to-date copies succeed at the same time, however. The value of
+                      `writeConcern` cannot be greater than `replicationFactor`.
+
+                      If `distributeShardsLike` is set, the default `writeConcern`
+                      is that of the prototype collection.
+                      For SatelliteCollections, the `writeConcern` is automatically controlled to
+                      equal the number of DB-Servers and has a value of `0`.
+                      Otherwise, the default value is controlled by the current database's
+                      default `writeConcern`, which uses the `--cluster.write-concern`
+                      startup option as default, which defaults to `1`. _(cluster only)_
+                    type: integer
+                  shardingStrategy:
+                    description: |
+                      The sharding strategy selected for the collection. _(cluster only)_
+                    type: string
+                    enum:
+                      - community-compat
+                      - enterprise-compat
+                      - enterprise-smart-edge-compat
+                      - hash
+                      - enterprise-hash-smart-edge
+                      - enterprise-hex-smart-vertex
+                  distributeShardsLike:
+                    description: |
+                      The name of another collection. This collection uses the `replicationFactor`,
+                      `numberOfShards` and `shardingStrategy` properties of the other collection and
+                      the shards of this collection are distributed in the same way as the shards of
+                      the other collection.
+                    type: string
+                  isSmart:
+                    description: |
+                      Whether the collection is used in a SmartGraph or EnterpriseGraph (Enterprise Edition only).
+                      This is an internal property. _(cluster only)_
+                    type: boolean
+                  isDisjoint:
+                    description: |
+                      Whether the SmartGraph or EnterpriseGraph this collection belongs to is disjoint
+                      (Enterprise Edition only). This is an internal property. _(cluster only)_
+                    type: boolean
+                  smartGraphAttribute:
+                    description: |
+                      The attribute that is used for sharding: vertices with the same value of
+                      this attribute are placed in the same shard. All vertices are required to
+                      have this attribute set and it has to be a string. Edges derive the
+                      attribute from their connected vertices (Enterprise Edition only). _(cluster only)_
+                    type: string
+                  smartJoinAttribute:
+                    description: |
+                      Determines an attribute of the collection that must contain the shard key value
+                      of the referred-to SmartJoin collection (Enterprise Edition only). _(cluster only)_
+                    type: string
                   name:
                     description: |
-                      The name of the collection.
+                      The name of this collection.
                     type: string
                     example: coll
+                  id:
+                    description: |
+                      A unique identifier of the collection (deprecated).
+                    type: string
+
                   type:
                     description: |
                       The type of the collection:
@@ -4097,19 +4808,11 @@ paths:
                       an underscore are usually system collections.
                     type: boolean
                     example: false
-                  status:
+                  syncByRevision:
                     description: |
-                      The status of the collection.
-                      - `3`: loaded
-                      - `5`: deleted
-
-                      Every other status indicates a corrupted collection.
-                    type: integer
-                    example: 3
-                  id:
-                    description: |
-                      A unique identifier of the collection (deprecated).
-                    type: string
+                      Whether the newer revision-based replication protocol is
+                      enabled for this collection. This is an internal property.
+                    type: boolean
                   globallyUniqueId:
                     description: |
                       A unique identifier of the collection. This is an internal property.

--- a/site/content/3.13/develop/http-api/collections.md
+++ b/site/content/3.13/develop/http-api/collections.md
@@ -1218,7 +1218,7 @@ paths:
                           indexes:
                             description: |
                               The detailed index metrics with the number of entries per index.
-                              type: array
+                            type: array
                             items:
                               type: object
                               properties:

--- a/site/content/3.13/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.13/develop/javascript-api/@arangodb/collection-object.md
@@ -116,9 +116,11 @@ identical to previous versions of ArangoDB.
 - `cacheSize`: The total memory usage of the document cache in bytes.
 - `cacheUsage`: The current data memory usage of the document cache in bytes.
 - `cacheLifeTimeHitRate`: The overall cache hit ratio in percent.
-  Only present if `cacheInUse` is `true`.
+  In cluster deployments, it is the sum of percentages of all shards.
+  The attribute is only present if `cacheInUse` is `true`.
 - `cacheWindowedHitRate`: The cache hit ratio of the past several thousand find
-  operations in percent. Only present if `cacheInUse` is `true`.
+  operations in percent. In cluster deployments, it is the sum of percentages
+  of all shards. The attribute is only present if `cacheInUse` is `true`.
 - `engine`: Extended, storage-engine specific figures.
   - `documents`: The number of documents determined by iterating over all
     RocksDB keys in range of the column family and counting them.

--- a/site/content/3.13/develop/javascript-api/@arangodb/collection-object.md
+++ b/site/content/3.13/develop/javascript-api/@arangodb/collection-object.md
@@ -107,14 +107,25 @@ debugging ArangoDB itself and their format is subject to change. By default,
 `details` is set to `false`, so no details are returned and the behavior is
 identical to previous versions of ArangoDB.
 
-- `indexes.count`: The total number of indexes defined for the
-  collection, including the pre-defined indexes (e.g. primary index).
-- `indexes.size`: The total memory allocated for indexes in bytes.
-<!-- TODO: describe RocksDB figures -->
-- `documentsSize`
-- `cacheInUse`
-- `cacheSize`
-- `cacheUsage`
+- `indexes`: The coarse index metrics.
+  - `count`: The total number of indexes defined for the
+    collection, including the pre-defined indexes (e.g. primary index).
+  - `size`: The total memory allocated for indexes in bytes.
+- `documentsSize`: The approximate on-disk size of the documents in bytes.
+- `cacheInUse`: Whether the document cache is enabled for this collection.
+- `cacheSize`: The total memory usage of the document cache in bytes.
+- `cacheUsage`: The current data memory usage of the document cache in bytes.
+- `cacheLifeTimeHitRate`: The overall cache hit ratio in percent.
+  Only present if `cacheInUse` is `true`.
+- `cacheWindowedHitRate`: The cache hit ratio of the past several thousand find
+  operations in percent. Only present if `cacheInUse` is `true`.
+- `engine`: Extended, storage-engine specific figures.
+  - `documents`: The number of documents determined by iterating over all
+    RocksDB keys in range of the column family and counting them.
+  - `indexes`: The detailed index metrics with the number of entries per index (array of objects).
+    - `type`: The index type. A `persistent` index is reported as `rocksdb-persistent`.
+    - `id`: The identifier of the index.
+    - `count`: The number of index entries.
 
 **Examples**
 


### PR DESCRIPTION
* Describe the schema validation sub-properties
* Add missing RocksDB figures (thanks @Burlango for pointing this out)
* Add status / statusString properties to 3.11 and 3.12, but not in 3.13 to move forward with the deprecation
* Add code comments about purposefully undocumented properties
* Fix response description for the endpoint to rename collections

TODO: The windowed cache hit-rate seems to remain 0 at all times, bug? https://arangodb.atlassian.net/browse/BTS-2101

### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
