### PR TITLE
Upgrade to Swagger 5.20.1

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -179,6 +179,16 @@ section, as well as in the **API** tab of Foxx services and Foxx routes that use
 The new version adds support for OpenAPI 3.x specifications in addition to
 Swagger 2.x compatibility.
 
+---
+
+<small>Introduced in: v3.12.5</small>
+
+Swagger UI has been updated to version 5.20.1.
+
+The default model rendering has been adjusted to display the **Schema** tab
+instead of the **Example Value** tab by default. This makes it easier to
+discover the structured request and response body descriptions.
+
 ## External versioning support
 
 Document operations that update or replace documents now support a `versionAttribute` option.

--- a/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/whats-new-in-3-12.md
@@ -179,6 +179,16 @@ section, as well as in the **API** tab of Foxx services and Foxx routes that use
 The new version adds support for OpenAPI 3.x specifications in addition to
 Swagger 2.x compatibility.
 
+---
+
+<small>Introduced in: v3.12.5</small>
+
+Swagger UI has been updated to version 5.20.1.
+
+The default model rendering has been adjusted to display the **Schema** tab
+instead of the **Example Value** tab by default. This makes it easier to discover
+the structured request and response body descriptions.
+
 ## External versioning support
 
 Document operations that update or replace documents now support a `versionAttribute` option.


### PR DESCRIPTION
### Description

Also: Change default model rendering to display Schema instead of Example Value

https://github.com/arangodb/arangodb/pull/21685/

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
