### PR TITLE
Fix OpenAPI validation errors and add more metadata

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,10 @@
+# Configuration file for Redocly CLI:
+#   redocly lint ./site/data/3.xx/api-docs.json
+
+extends:
+  - recommended
+
+rules:
+  no-empty-servers: off
+  security-defined: off
+  operation-4xx-response: off # Known issue: Error replies are inconsistently documented

--- a/site/content/3.11/develop/http-api/collections.md
+++ b/site/content/3.11/develop/http-api/collections.md
@@ -4427,16 +4427,16 @@ paths:
                       A flag indicating that no error occurred.
                     type: boolean
                     example: false
-                code:
-                  description: |
-                    The HTTP response status code.
-                  type: integer
-                  example: 200
-                result:
-                  description: |
-                    The value `true`.
-                  type: boolean
-                  example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      The value `true`.
+                    type: boolean
+                    example: true
         '400':
           description: |
             The `collection-name` parameter is missing.

--- a/site/content/3.11/develop/http-api/foxx.md
+++ b/site/content/3.11/develop/http-api/foxx.md
@@ -199,6 +199,14 @@ paths:
 
         Returns an empty response on success.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -756,7 +764,6 @@ paths:
                   description: |
                     An arbitrary JSON value that will be parsed and passed to the
                     script as its first argument.
-                  type: json
       responses:
         '200':
           description: |

--- a/site/content/3.11/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.11/develop/http-api/queries/aql-queries.md
@@ -661,8 +661,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results
@@ -1394,8 +1392,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results
@@ -2009,8 +2005,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results

--- a/site/content/3.11/develop/http-api/tasks.md
+++ b/site/content/3.11/develop/http-api/tasks.md
@@ -10,7 +10,7 @@ description: >-
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/tasks/:
+  /_db/{database-name}/_api/tasks:
     get:
       operationId: listTasks
       description: |
@@ -227,7 +227,7 @@ paths:
     post:
       operationId: createTask
       description: |
-        creates a new task with a generated id
+        Creates a new task with a generated identifier.
       parameters:
         - name: database-name
           in: path
@@ -243,90 +243,84 @@ paths:
             schema:
               type: object
               required:
-                - name
                 - command
-                - params
               properties:
                 name:
                   description: |
-                    The name of the task
+                    The name of the task.
                   type: string
                 command:
                   description: |
-                    The JavaScript code to be executed
+                    The JavaScript code to be executed.
                   type: string
                 params:
                   description: |
-                    The parameters to be passed into command
+                    The parameters to be passed to the command.
                   type: string
                 period:
                   description: |
-                    number of seconds between the executions
+                    The number of seconds between the executions.
                   type: integer
                 offset:
                   description: |
-                    Number of seconds initial delay
+                    The number of seconds for the initial delay.
                   type: integer
       responses:
         '200':
           description: |
-            The task was registered
+            The task has been registered.
           content:
             application/json:
               schema:
                 type: object
                 required:
                   - id
+                  - name
                   - created
                   - type
                   - period
                   - offset
                   - command
                   - database
-                  - code
-                  - error
                 properties:
                   id:
                     description: |
-                      A string identifying the task
+                      A string identifying the task.
+                    type: string
+                  name:
+                    description: |
+                      The name of the task.
                     type: string
                   created:
                     description: |
-                      The timestamp when this task was created
+                      The timestamp when this task was created.
                     type: number
                   type:
                     description: |
-                      What type of task is this [ `periodic`, `timed`]
-                        - periodic are tasks that repeat periodically
-                        - timed are tasks that execute once at a specific time
+                      The kind of the task:
+                      - `"periodic"`: The task repeats periodically
+                      - `"timed"`: The task executes once at a specific time
                     type: string
+                    enum: [periodic, timed]
                   period:
                     description: |
-                      this task should run each `period` seconds
+                      The task runs every `period` seconds.
                     type: number
                   offset:
                     description: |
-                      time offset in seconds from the created timestamp
+                      The time offset in seconds from the created timestamp.
                     type: number
                   command:
                     description: |
-                      the javascript function for this task
+                      The JavaScript code of this task.
                     type: string
                   database:
                     description: |
-                      the database this task belongs to
+                      The database this task belongs to.
                     type: string
-                  code:
-                    description: |
-                      The status code, 200 in this case.
-                    type: number
-                  error:
-                    description: |
-                      `false` in this case
-                    type: boolean
         '400':
           description: |
-            If the post body is not accurate, a *HTTP 400* is returned.
+            The task can't be registered because the request is invalid.
       tags:
         - Tasks
 ```
@@ -391,34 +385,87 @@ paths:
             schema:
               type: object
               required:
-                - name
                 - command
-                - params
               properties:
                 name:
                   description: |
-                    The name of the task
+                    The name of the task.
                   type: string
                 command:
                   description: |
-                    The JavaScript code to be executed
+                    The JavaScript code to be executed.
                   type: string
                 params:
                   description: |
-                    The parameters to be passed into command
+                    The parameters to be passed to the command.
                   type: string
                 period:
                   description: |
-                    number of seconds between the executions
+                    The number of seconds between the executions.
                   type: integer
                 offset:
                   description: |
-                    Number of seconds initial delay
+                    The number of seconds for the initial delay.
                   type: integer
       responses:
+        '200':
+          description: |
+            The task has been registered.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                  - created
+                  - type
+                  - period
+                  - offset
+                  - command
+                  - database
+                properties:
+                  id:
+                    description: |
+                      The user-provided string identifying the task.
+                    type: string
+                  name:
+                    description: |
+                      The name of the task.
+                    type: string
+                  created:
+                    description: |
+                      The timestamp when this task was created.
+                    type: number
+                  type:
+                    description: |
+                      The kind of the task:
+                      - `"periodic"`: The task repeats periodically
+                      - `"timed"`: The task executes once at a specific time
+                    type: string
+                    enum: [periodic, timed]
+                  period:
+                    description: |
+                      The task runs every `period` seconds.
+                    type: number
+                  offset:
+                    description: |
+                      The time offset in seconds from the created timestamp.
+                    type: number
+                  command:
+                    description: |
+                      The JavaScript code of this task.
+                    type: string
+                  database:
+                    description: |
+                      The database this task belongs to.
+                    type: string
         '400':
           description: |
-            If the task `id` already exists or the rest body is not accurate, *HTTP 400* is returned.
+            The task can't be registered because the request is invalid.
+        '409':
+          description: |
+            A task with the specified `id` already exists.
       tags:
         - Tasks
 ```

--- a/site/content/3.11/develop/http-api/users.md
+++ b/site/content/3.11/develop/http-api/users.md
@@ -443,7 +443,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/user/:
+  /_db/{database-name}/_api/user:
     get:
       operationId: listUsers
       description: |
@@ -853,7 +853,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/user/{user}/database/:
+  /_db/{database-name}/_api/user/{user}/database:
     get:
       operationId: listUserDatabases
       description: |

--- a/site/content/3.11/develop/http-api/views/search-alias-views.md
+++ b/site/content/3.11/develop/http-api/views/search-alias-views.md
@@ -976,7 +976,7 @@ paths:
                   errorMessage:
                     description: |
                       A descriptive error message.
-                    type: string.
+                    type: string
       tags:
         - Views
 ```
@@ -1145,7 +1145,7 @@ paths:
                   errorMessage:
                     description: |
                       A descriptive error message.
-                    type: string.
+                    type: string
       tags:
         - Views
 ```

--- a/site/content/3.12/develop/http-api/collections.md
+++ b/site/content/3.12/develop/http-api/collections.md
@@ -4485,16 +4485,16 @@ paths:
                       A flag indicating that no error occurred.
                     type: boolean
                     example: false
-                code:
-                  description: |
-                    The HTTP response status code.
-                  type: integer
-                  example: 200
-                result:
-                  description: |
-                    The value `true`.
-                  type: boolean
-                  example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      The value `true`.
+                    type: boolean
+                    example: true
         '400':
           description: |
             The `collection-name` parameter is missing.

--- a/site/content/3.12/develop/http-api/foxx.md
+++ b/site/content/3.12/develop/http-api/foxx.md
@@ -199,6 +199,14 @@ paths:
 
         Returns an empty response on success.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true

--- a/site/content/3.12/develop/http-api/foxx.md
+++ b/site/content/3.12/develop/http-api/foxx.md
@@ -756,7 +756,6 @@ paths:
                   description: |
                     An arbitrary JSON value that will be parsed and passed to the
                     script as its first argument.
-                  type: json
       responses:
         '200':
           description: |

--- a/site/content/3.12/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.12/develop/http-api/queries/aql-queries.md
@@ -677,8 +677,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results
@@ -1432,8 +1430,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results
@@ -2071,8 +2067,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results

--- a/site/content/3.12/develop/http-api/tasks.md
+++ b/site/content/3.12/develop/http-api/tasks.md
@@ -227,7 +227,7 @@ paths:
     post:
       operationId: createTask
       description: |
-        creates a new task with a generated id
+        Creates a new task with a generated identifier.
       parameters:
         - name: database-name
           in: path
@@ -243,90 +243,84 @@ paths:
             schema:
               type: object
               required:
-                - name
                 - command
-                - params
               properties:
                 name:
                   description: |
-                    The name of the task
+                    The name of the task.
                   type: string
                 command:
                   description: |
-                    The JavaScript code to be executed
+                    The JavaScript code to be executed.
                   type: string
                 params:
                   description: |
-                    The parameters to be passed into command
+                    The parameters to be passed to the command.
                   type: string
                 period:
                   description: |
-                    number of seconds between the executions
+                    The number of seconds between the executions.
                   type: integer
                 offset:
                   description: |
-                    Number of seconds initial delay
+                    The number of seconds for the initial delay.
                   type: integer
       responses:
         '200':
           description: |
-            The task was registered
+            The task has been registered.
           content:
             application/json:
               schema:
                 type: object
                 required:
                   - id
+                  - name
                   - created
                   - type
                   - period
                   - offset
                   - command
                   - database
-                  - code
-                  - error
                 properties:
                   id:
                     description: |
-                      A string identifying the task
+                      A string identifying the task.
+                    type: string
+                  name:
+                    description: |
+                      The name of the task.
                     type: string
                   created:
                     description: |
-                      The timestamp when this task was created
+                      The timestamp when this task was created.
                     type: number
                   type:
                     description: |
-                      What type of task is this [ `periodic`, `timed`]
-                        - periodic are tasks that repeat periodically
-                        - timed are tasks that execute once at a specific time
+                      The kind of the task:
+                      - `"periodic"`: The task repeats periodically
+                      - `"timed"`: The task executes once at a specific time
                     type: string
+                    enum: [periodic, timed]
                   period:
                     description: |
-                      this task should run each `period` seconds
+                      The task runs every `period` seconds.
                     type: number
                   offset:
                     description: |
-                      time offset in seconds from the created timestamp
+                      The time offset in seconds from the created timestamp.
                     type: number
                   command:
                     description: |
-                      the javascript function for this task
+                      The JavaScript code of this task.
                     type: string
                   database:
                     description: |
-                      the database this task belongs to
+                      The database this task belongs to.
                     type: string
-                  code:
-                    description: |
-                      The status code, 200 in this case.
-                    type: number
-                  error:
-                    description: |
-                      `false` in this case
-                    type: boolean
         '400':
           description: |
-            If the post body is not accurate, a *HTTP 400* is returned.
+            The task can't be registered because the request is invalid.
       tags:
         - Tasks
 ```
@@ -391,34 +385,87 @@ paths:
             schema:
               type: object
               required:
-                - name
                 - command
-                - params
               properties:
                 name:
                   description: |
-                    The name of the task
+                    The name of the task.
                   type: string
                 command:
                   description: |
-                    The JavaScript code to be executed
+                    The JavaScript code to be executed.
                   type: string
                 params:
                   description: |
-                    The parameters to be passed into command
+                    The parameters to be passed to the command.
                   type: string
                 period:
                   description: |
-                    number of seconds between the executions
+                    The number of seconds between the executions.
                   type: integer
                 offset:
                   description: |
-                    Number of seconds initial delay
+                    The number of seconds for the initial delay.
                   type: integer
       responses:
+        '200':
+          description: |
+            The task has been registered.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                  - created
+                  - type
+                  - period
+                  - offset
+                  - command
+                  - database
+                properties:
+                  id:
+                    description: |
+                      The user-provided string identifying the task.
+                    type: string
+                  name:
+                    description: |
+                      The name of the task.
+                    type: string
+                  created:
+                    description: |
+                      The timestamp when this task was created.
+                    type: number
+                  type:
+                    description: |
+                      The kind of the task:
+                      - `"periodic"`: The task repeats periodically
+                      - `"timed"`: The task executes once at a specific time
+                    type: string
+                    enum: [periodic, timed]
+                  period:
+                    description: |
+                      The task runs every `period` seconds.
+                    type: number
+                  offset:
+                    description: |
+                      The time offset in seconds from the created timestamp.
+                    type: number
+                  command:
+                    description: |
+                      The JavaScript code of this task.
+                    type: string
+                  database:
+                    description: |
+                      The database this task belongs to.
+                    type: string
         '400':
           description: |
-            If the task `id` already exists or the rest body is not accurate, *HTTP 400* is returned.
+            The task can't be registered because the request is invalid.
+        '409':
+          description: |
+            A task with the specified `id` already exists.
       tags:
         - Tasks
 ```

--- a/site/content/3.12/develop/http-api/tasks.md
+++ b/site/content/3.12/develop/http-api/tasks.md
@@ -10,7 +10,7 @@ description: >-
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/tasks/:
+  /_db/{database-name}/_api/tasks:
     get:
       operationId: listTasks
       description: |

--- a/site/content/3.12/develop/http-api/users.md
+++ b/site/content/3.12/develop/http-api/users.md
@@ -443,7 +443,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/user/:
+  /_db/{database-name}/_api/user:
     get:
       operationId: listUsers
       description: |
@@ -853,7 +853,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/user/{user}/database/:
+  /_db/{database-name}/_api/user/{user}/database:
     get:
       operationId: listUserDatabases
       description: |

--- a/site/content/3.12/develop/http-api/views/search-alias-views.md
+++ b/site/content/3.12/develop/http-api/views/search-alias-views.md
@@ -976,7 +976,7 @@ paths:
                   errorMessage:
                     description: |
                       A descriptive error message.
-                    type: string.
+                    type: string
       tags:
         - Views
 ```
@@ -1145,7 +1145,7 @@ paths:
                   errorMessage:
                     description: |
                       A descriptive error message.
-                    type: string.
+                    type: string
       tags:
         - Views
 ```

--- a/site/content/3.13/develop/http-api/collections.md
+++ b/site/content/3.13/develop/http-api/collections.md
@@ -4389,16 +4389,16 @@ paths:
                       A flag indicating that no error occurred.
                     type: boolean
                     example: false
-                code:
-                  description: |
-                    The HTTP response status code.
-                  type: integer
-                  example: 200
-                result:
-                  description: |
-                    The value `true`.
-                  type: boolean
-                  example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      The value `true`.
+                    type: boolean
+                    example: true
         '400':
           description: |
             The `collection-name` parameter is missing.

--- a/site/content/3.13/develop/http-api/foxx.md
+++ b/site/content/3.13/develop/http-api/foxx.md
@@ -199,6 +199,14 @@ paths:
 
         Returns an empty response on success.
       parameters:
+        - name: database-name
+          in: path
+          required: true
+          example: _system
+          description: |
+            The name of the database.
+          schema:
+            type: string
         - name: mount
           in: query
           required: true
@@ -756,7 +764,6 @@ paths:
                   description: |
                     An arbitrary JSON value that will be parsed and passed to the
                     script as its first argument.
-                  type: json
       responses:
         '200':
           description: |

--- a/site/content/3.13/develop/http-api/queries/aql-queries.md
+++ b/site/content/3.13/develop/http-api/queries/aql-queries.md
@@ -677,8 +677,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results
@@ -1432,8 +1430,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results
@@ -2071,8 +2067,6 @@ paths:
                       An array of result documents for the current batch
                       (might be empty if the query has no results).
                     type: array
-                    items:
-                      type: ''
                   hasMore:
                     description: |
                       A boolean indicator whether there are more results

--- a/site/content/3.13/develop/http-api/tasks.md
+++ b/site/content/3.13/develop/http-api/tasks.md
@@ -10,7 +10,7 @@ description: >-
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/tasks/:
+  /_db/{database-name}/_api/tasks:
     get:
       operationId: listTasks
       description: |
@@ -227,7 +227,7 @@ paths:
     post:
       operationId: createTask
       description: |
-        creates a new task with a generated id
+        Creates a new task with a generated identifier.
       parameters:
         - name: database-name
           in: path
@@ -243,90 +243,84 @@ paths:
             schema:
               type: object
               required:
-                - name
                 - command
-                - params
               properties:
                 name:
                   description: |
-                    The name of the task
+                    The name of the task.
                   type: string
                 command:
                   description: |
-                    The JavaScript code to be executed
+                    The JavaScript code to be executed.
                   type: string
                 params:
                   description: |
-                    The parameters to be passed into command
+                    The parameters to be passed to the command.
                   type: string
                 period:
                   description: |
-                    number of seconds between the executions
+                    The number of seconds between the executions.
                   type: integer
                 offset:
                   description: |
-                    Number of seconds initial delay
+                    The number of seconds for the initial delay.
                   type: integer
       responses:
         '200':
           description: |
-            The task was registered
+            The task has been registered.
           content:
             application/json:
               schema:
                 type: object
                 required:
                   - id
+                  - name
                   - created
                   - type
                   - period
                   - offset
                   - command
                   - database
-                  - code
-                  - error
                 properties:
                   id:
                     description: |
-                      A string identifying the task
+                      A string identifying the task.
+                    type: string
+                  name:
+                    description: |
+                      The name of the task.
                     type: string
                   created:
                     description: |
-                      The timestamp when this task was created
+                      The timestamp when this task was created.
                     type: number
                   type:
                     description: |
-                      What type of task is this [ `periodic`, `timed`]
-                        - periodic are tasks that repeat periodically
-                        - timed are tasks that execute once at a specific time
+                      The kind of the task:
+                      - `"periodic"`: The task repeats periodically
+                      - `"timed"`: The task executes once at a specific time
                     type: string
+                    enum: [periodic, timed]
                   period:
                     description: |
-                      this task should run each `period` seconds
+                      The task runs every `period` seconds.
                     type: number
                   offset:
                     description: |
-                      time offset in seconds from the created timestamp
+                      The time offset in seconds from the created timestamp.
                     type: number
                   command:
                     description: |
-                      the javascript function for this task
+                      The JavaScript code of this task.
                     type: string
                   database:
                     description: |
-                      the database this task belongs to
+                      The database this task belongs to.
                     type: string
-                  code:
-                    description: |
-                      The status code, 200 in this case.
-                    type: number
-                  error:
-                    description: |
-                      `false` in this case
-                    type: boolean
         '400':
           description: |
-            If the post body is not accurate, a *HTTP 400* is returned.
+            The task can't be registered because the request is invalid.
       tags:
         - Tasks
 ```
@@ -391,34 +385,87 @@ paths:
             schema:
               type: object
               required:
-                - name
                 - command
-                - params
               properties:
                 name:
                   description: |
-                    The name of the task
+                    The name of the task.
                   type: string
                 command:
                   description: |
-                    The JavaScript code to be executed
+                    The JavaScript code to be executed.
                   type: string
                 params:
                   description: |
-                    The parameters to be passed into command
+                    The parameters to be passed to the command.
                   type: string
                 period:
                   description: |
-                    number of seconds between the executions
+                    The number of seconds between the executions.
                   type: integer
                 offset:
                   description: |
-                    Number of seconds initial delay
+                    The number of seconds for the initial delay.
                   type: integer
       responses:
+        '200':
+          description: |
+            The task has been registered.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                  - created
+                  - type
+                  - period
+                  - offset
+                  - command
+                  - database
+                properties:
+                  id:
+                    description: |
+                      The user-provided string identifying the task.
+                    type: string
+                  name:
+                    description: |
+                      The name of the task.
+                    type: string
+                  created:
+                    description: |
+                      The timestamp when this task was created.
+                    type: number
+                  type:
+                    description: |
+                      The kind of the task:
+                      - `"periodic"`: The task repeats periodically
+                      - `"timed"`: The task executes once at a specific time
+                    type: string
+                    enum: [periodic, timed]
+                  period:
+                    description: |
+                      The task runs every `period` seconds.
+                    type: number
+                  offset:
+                    description: |
+                      The time offset in seconds from the created timestamp.
+                    type: number
+                  command:
+                    description: |
+                      The JavaScript code of this task.
+                    type: string
+                  database:
+                    description: |
+                      The database this task belongs to.
+                    type: string
         '400':
           description: |
-            If the task `id` already exists or the rest body is not accurate, *HTTP 400* is returned.
+            The task can't be registered because the request is invalid.
+        '409':
+          description: |
+            A task with the specified `id` already exists.
       tags:
         - Tasks
 ```

--- a/site/content/3.13/develop/http-api/users.md
+++ b/site/content/3.13/develop/http-api/users.md
@@ -443,7 +443,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/user/:
+  /_db/{database-name}/_api/user:
     get:
       operationId: listUsers
       description: |
@@ -853,7 +853,7 @@ users.remove(theUser);
 
 ```openapi
 paths:
-  /_db/{database-name}/_api/user/{user}/database/:
+  /_db/{database-name}/_api/user/{user}/database:
     get:
       operationId: listUserDatabases
       description: |

--- a/site/content/3.13/develop/http-api/views/search-alias-views.md
+++ b/site/content/3.13/develop/http-api/views/search-alias-views.md
@@ -976,7 +976,7 @@ paths:
                   errorMessage:
                     description: |
                       A descriptive error message.
-                    type: string.
+                    type: string
       tags:
         - Views
 ```
@@ -1145,7 +1145,7 @@ paths:
                   errorMessage:
                     description: |
                       A descriptive error message.
-                    type: string.
+                    type: string
       tags:
         - Views
 ```

--- a/toolchain/arangoproxy/internal/service/service.go
+++ b/toolchain/arangoproxy/internal/service/service.go
@@ -153,15 +153,35 @@ func init() {
 		}
 
 		yaml.Unmarshal(yamlFile, &tags)
+
+		// License of the exposed API (but we assume it is the same as the source code)
+		license := map[string]interface{}{
+			"name": "Business Source License 1.1",
+			"url":  "https://github.com/arangodb/arangodb/blob/devel/LICENSE",
+		}
+		if version.Name == "3.10" || version.Name == "3.11" {
+			license["name"] = "Apache 2.0"
+			license["url"] = fmt.Sprintf("https://github.com/arangodb/arangodb/blob/%s/LICENSE", version.Name)
+		}
+
 		OpenapiGlobalMap[version.Name] = map[string]interface{}{
 			"openapi": "3.1.0",
 			"info": map[string]interface{}{
-				"description": "ArangoDB REST API Interface",
-				"version":     version.Version,
-				"title":       "ArangoDB",
+				"title":   "ArangoDB Core API",
+				"summary": "The RESTful HTTP API of the ArangoDB Core Database System",
+				"version": version.Version,
+				"license": license,
+				"contact": map[string]interface{}{
+					"name": "ArangoDB Inc.",
+					"url":  "https://arangodb.com",
+				},
 			},
 			"paths": make(map[string]interface{}),
 			"tags":  tags,
+			"externalDocs": map[string]interface{}{
+				"description": "ArangoDB Documentation",
+				"url":         "https://docs.arangodb.com",
+			},
 		}
 	}
 }


### PR DESCRIPTION
### Description

Fix a couple of issues reported by Swagger Editor web service as well as by the Redocly CLI linter.

Extend metadata. Before:

```json
{
 "info": {
  "description": "ArangoDB REST API Interface",
  "title": "ArangoDB",
  "version": "3.12.4"
 }
}
```

After (3.10 and 3.11 have Apache 2.0 license set accordingly):

```json
{
 "externalDocs": {
  "description": "ArangoDB Documentation",
  "url": "https://docs.arangodb.com"
 },
 "info": {
  "contact": {
   "name": "ArangoDB Inc.",
   "url": "https://arangodb.com"
  },
  "license": {
   "name": "Business Source License 1.1",
   "url": "https://github.com/arangodb/arangodb/blob/devel/LICENSE"
  },
  "summary": "The RESTful HTTP API of the ArangoDB Core Database System",
  "title": "ArangoDB Core API",
  "version": "3.12.4"
 },
```

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
