### PR TITLE
Add remark to use kube-arangodb 1.2.47+ for upgrading 3.12.2/3.12.3

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -27,8 +27,9 @@ blog post.
 ## Upgrading 3.12 Kubernetes deployments
 
 To avoid potential issues when upgrading Kubernetes-managed ArangoDB deployments
-from version 3.12.2 or 3.12.3 to 3.12.4, make sure to use the ArangoDB
-Kubernetes Operator (`kube-arangodb`) version 1.2.47 or later.
+from version 3.12.2 or 3.12.3 to 3.12.4, make sure to use the
+ArangoDB Kubernetes Operator (`kube-arangodb`) version 1.2.47 or later for any
+deployment that was previously on version 3.11.
 
 ## Resolving known issues with versions prior to 3.12.4
 

--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -24,6 +24,12 @@ For details, see the
 [Evolving ArangoDB's Licensing Model for a Sustainable Future](https://arangodb.com/2024/02/update-evolving-arangodbs-licensing-model-for-a-sustainable-future/)
 blog post.
 
+## Upgrading 3.12 Kubernetes deployments
+
+To avoid potential issues when upgrading Kubernetes-managed ArangoDB deployments
+from version 3.12.2 or 3.12.3 to 3.12.4, make sure to use the ArangoDB
+Kubernetes Operator (`kube-arangodb`) version 1.2.47 or later.
+
 ## Resolving known issues with versions prior to 3.12.4
 
 Due to issues with the versions 3.12.0 through 3.12.3 and prior to 3.11.11,

--- a/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -27,8 +27,9 @@ blog post.
 ## Upgrading 3.12 Kubernetes deployments
 
 To avoid potential issues when upgrading Kubernetes-managed ArangoDB deployments
-from version 3.12.2 or 3.12.3 to 3.12.4, make sure to use the ArangoDB
-Kubernetes Operator (`kube-arangodb`) version 1.2.47 or later.
+from version 3.12.2 or 3.12.3 to 3.12.4, make sure to use the
+ArangoDB Kubernetes Operator (`kube-arangodb`) version 1.2.47 or later for any
+deployment that was previously on version 3.11.
 
 ## Resolving known issues with versions prior to 3.12.4
 

--- a/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -24,6 +24,12 @@ For details, see the
 [Evolving ArangoDB's Licensing Model for a Sustainable Future](https://arangodb.com/2024/02/update-evolving-arangodbs-licensing-model-for-a-sustainable-future/)
 blog post.
 
+## Upgrading 3.12 Kubernetes deployments
+
+To avoid potential issues when upgrading Kubernetes-managed ArangoDB deployments
+from version 3.12.2 or 3.12.3 to 3.12.4, make sure to use the ArangoDB
+Kubernetes Operator (`kube-arangodb`) version 1.2.47 or later.
+
 ## Resolving known issues with versions prior to 3.12.4
 
 Due to issues with the versions 3.12.0 through 3.12.3 and prior to 3.11.11,


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
