### PR TITLE
DOC-746 | Removing vertices with Gharial deletes its edges

### DIFF
--- a/site/content/3.11/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.11/develop/http-api/graphs/named-graphs.md
@@ -5218,7 +5218,9 @@ paths:
     delete:
       operationId: deleteVertex
       description: |
-        Removes a vertex from the collection.
+        Removes a vertex from a collection of the named graph. Additionally removes all
+        incoming and outgoing edges of the vertex. If these edge are used as vertices by
+        other edges, the other edges are removed, too (recursively).
       parameters:
         - name: database-name
           in: path
@@ -7302,7 +7304,8 @@ paths:
     delete:
       operationId: deleteEdge
       description: |
-        Removes an edge from the collection.
+        Removes an edge from an edge collection of the named graph. If this edge is used
+        as a vertex by another edge, the other edge is removed, too (recursively).
       parameters:
         - name: database-name
           in: path

--- a/site/content/3.11/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.11/develop/http-api/graphs/named-graphs.md
@@ -5219,8 +5219,7 @@ paths:
       operationId: deleteVertex
       description: |
         Removes a vertex from a collection of the named graph. Additionally removes all
-        incoming and outgoing edges of the vertex. If these edge are used as vertices by
-        other edges, the other edges are removed, too (recursively).
+        incoming and outgoing edges of the vertex.
       parameters:
         - name: database-name
           in: path
@@ -7304,8 +7303,8 @@ paths:
     delete:
       operationId: deleteEdge
       description: |
-        Removes an edge from an edge collection of the named graph. If this edge is used
-        as a vertex by another edge, the other edge is removed, too (recursively).
+        Removes an edge from an edge collection of the named graph. Any other edges
+        that directly reference this edge like a vertex are removed, too.
       parameters:
         - name: database-name
           in: path

--- a/site/content/3.11/graphs/general-graphs/management.md
+++ b/site/content/3.11/graphs/general-graphs/management.md
@@ -671,8 +671,7 @@ graph.female.update("female/linda", {name: "Linda", _key: "linda"}, { returnOld:
 ### Remove a Vertex
 
 Removes a vertex from a collection of the named graph. Additionally removes all
-incoming and outgoing edges of the vertex. If these edge are used as vertices by
-other edges, the other edges are removed, too (recursively).
+incoming and outgoing edges of the vertex.
 
 `graph.vertexCollectionName.remove(vertexId, options)`
 
@@ -807,10 +806,8 @@ graph.relation.update("relation/aliceAndDiana",
 
 ### Remove an Edge
 
-Removes an edge in collection `edgeCollectionName`.
-
-Removes an edge from an edge collection of the named graph. If this edge is used
-as a vertex by another edge, the other edge is removed, too (recursively).
+Removes an edge from an edge collection of the named graph. Any other edges
+that directly reference this edge like a vertex are removed, too.
 
 `graph.edgeCollectionName.remove(edgeId, options)`
 

--- a/site/content/3.11/graphs/general-graphs/management.md
+++ b/site/content/3.11/graphs/general-graphs/management.md
@@ -670,7 +670,9 @@ graph.female.update("female/linda", {name: "Linda", _key: "linda"}, { returnOld:
 
 ### Remove a Vertex
 
-Removes a vertex in collection `vertexCollectionName`.
+Removes a vertex from a collection of the named graph. Additionally removes all
+incoming and outgoing edges of the vertex. If these edge are used as vertices by
+other edges, the other edges are removed, too (recursively).
 
 `graph.vertexCollectionName.remove(vertexId, options)`
 
@@ -678,9 +680,6 @@ Removes a vertex in collection `vertexCollectionName`.
   `_id` attribute of the vertex
 - `options` (object, _optional_):
   See the [_collection_ object](../../develop/javascript-api/@arangodb/collection-object.md#collectionremoveobject)
-
-Additionally removes all ingoing and outgoing edges of the vertex recursively
-(see [edge remove](#remove-an-edge)).
 
 **Examples**
 
@@ -810,15 +809,15 @@ graph.relation.update("relation/aliceAndDiana",
 
 Removes an edge in collection `edgeCollectionName`.
 
+Removes an edge from an edge collection of the named graph. If this edge is used
+as a vertex by another edge, the other edge is removed, too (recursively).
+
 `graph.edgeCollectionName.remove(edgeId, options)`
 
 - `edgeId` (string):
   `_id` attribute of the edge
 - `options` (object, _optional_):
   See the [_collection_ object](../../develop/javascript-api/@arangodb/collection-object.md#collectionremoveobject)
-
-If this edge is used as a vertex by another edge, the other edge is removed
-(recursively).
 
 **Examples**
 

--- a/site/content/3.12/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.12/develop/http-api/graphs/named-graphs.md
@@ -5218,7 +5218,9 @@ paths:
     delete:
       operationId: deleteVertex
       description: |
-        Removes a vertex from the collection.
+        Removes a vertex from a collection of the named graph. Additionally removes all
+        incoming and outgoing edges of the vertex. If these edge are used as vertices by
+        other edges, the other edges are removed, too (recursively).
       parameters:
         - name: database-name
           in: path
@@ -7302,7 +7304,8 @@ paths:
     delete:
       operationId: deleteEdge
       description: |
-        Removes an edge from the collection.
+        Removes an edge from an edge collection of the named graph. If this edge is used
+        as a vertex by another edge, the other edge is removed, too (recursively).
       parameters:
         - name: database-name
           in: path

--- a/site/content/3.12/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.12/develop/http-api/graphs/named-graphs.md
@@ -5219,8 +5219,7 @@ paths:
       operationId: deleteVertex
       description: |
         Removes a vertex from a collection of the named graph. Additionally removes all
-        incoming and outgoing edges of the vertex. If these edge are used as vertices by
-        other edges, the other edges are removed, too (recursively).
+        incoming and outgoing edges of the vertex.
       parameters:
         - name: database-name
           in: path
@@ -7304,8 +7303,8 @@ paths:
     delete:
       operationId: deleteEdge
       description: |
-        Removes an edge from an edge collection of the named graph. If this edge is used
-        as a vertex by another edge, the other edge is removed, too (recursively).
+        Removes an edge from an edge collection of the named graph. Any other edges
+        that directly reference this edge like a vertex are removed, too.
       parameters:
         - name: database-name
           in: path

--- a/site/content/3.12/graphs/general-graphs/management.md
+++ b/site/content/3.12/graphs/general-graphs/management.md
@@ -671,8 +671,7 @@ graph.female.update("female/linda", {name: "Linda", _key: "linda"}, { returnOld:
 ### Remove a Vertex
 
 Removes a vertex from a collection of the named graph. Additionally removes all
-incoming and outgoing edges of the vertex. If these edge are used as vertices by
-other edges, the other edges are removed, too (recursively).
+incoming and outgoing edges of the vertex.
 
 `graph.vertexCollectionName.remove(vertexId, options)`
 
@@ -807,10 +806,8 @@ graph.relation.update("relation/aliceAndDiana",
 
 ### Remove an Edge
 
-Removes an edge in collection `edgeCollectionName`.
-
-Removes an edge from an edge collection of the named graph. If this edge is used
-as a vertex by another edge, the other edge is removed, too (recursively).
+Removes an edge from an edge collection of the named graph. Any other edges
+that directly reference this edge like a vertex are removed, too.
 
 `graph.edgeCollectionName.remove(edgeId, options)`
 

--- a/site/content/3.12/graphs/general-graphs/management.md
+++ b/site/content/3.12/graphs/general-graphs/management.md
@@ -670,7 +670,9 @@ graph.female.update("female/linda", {name: "Linda", _key: "linda"}, { returnOld:
 
 ### Remove a Vertex
 
-Removes a vertex in collection `vertexCollectionName`.
+Removes a vertex from a collection of the named graph. Additionally removes all
+incoming and outgoing edges of the vertex. If these edge are used as vertices by
+other edges, the other edges are removed, too (recursively).
 
 `graph.vertexCollectionName.remove(vertexId, options)`
 
@@ -678,9 +680,6 @@ Removes a vertex in collection `vertexCollectionName`.
   `_id` attribute of the vertex
 - `options` (object, _optional_):
   See the [_collection_ object](../../develop/javascript-api/@arangodb/collection-object.md#collectionremoveobject)
-
-Additionally removes all ingoing and outgoing edges of the vertex recursively
-(see [edge remove](#remove-an-edge)).
 
 **Examples**
 
@@ -810,15 +809,15 @@ graph.relation.update("relation/aliceAndDiana",
 
 Removes an edge in collection `edgeCollectionName`.
 
+Removes an edge from an edge collection of the named graph. If this edge is used
+as a vertex by another edge, the other edge is removed, too (recursively).
+
 `graph.edgeCollectionName.remove(edgeId, options)`
 
 - `edgeId` (string):
   `_id` attribute of the edge
 - `options` (object, _optional_):
   See the [_collection_ object](../../develop/javascript-api/@arangodb/collection-object.md#collectionremoveobject)
-
-If this edge is used as a vertex by another edge, the other edge is removed
-(recursively).
 
 **Examples**
 

--- a/site/content/3.13/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.13/develop/http-api/graphs/named-graphs.md
@@ -5218,7 +5218,9 @@ paths:
     delete:
       operationId: deleteVertex
       description: |
-        Removes a vertex from the collection.
+        Removes a vertex from a collection of the named graph. Additionally removes all
+        incoming and outgoing edges of the vertex. If these edge are used as vertices by
+        other edges, the other edges are removed, too (recursively).
       parameters:
         - name: database-name
           in: path
@@ -7302,7 +7304,8 @@ paths:
     delete:
       operationId: deleteEdge
       description: |
-        Removes an edge from the collection.
+        Removes an edge from an edge collection of the named graph. If this edge is used
+        as a vertex by another edge, the other edge is removed, too (recursively).
       parameters:
         - name: database-name
           in: path

--- a/site/content/3.13/develop/http-api/graphs/named-graphs.md
+++ b/site/content/3.13/develop/http-api/graphs/named-graphs.md
@@ -5219,8 +5219,7 @@ paths:
       operationId: deleteVertex
       description: |
         Removes a vertex from a collection of the named graph. Additionally removes all
-        incoming and outgoing edges of the vertex. If these edge are used as vertices by
-        other edges, the other edges are removed, too (recursively).
+        incoming and outgoing edges of the vertex.
       parameters:
         - name: database-name
           in: path
@@ -7304,8 +7303,8 @@ paths:
     delete:
       operationId: deleteEdge
       description: |
-        Removes an edge from an edge collection of the named graph. If this edge is used
-        as a vertex by another edge, the other edge is removed, too (recursively).
+        Removes an edge from an edge collection of the named graph. Any other edges
+        that directly reference this edge like a vertex are removed, too.
       parameters:
         - name: database-name
           in: path

--- a/site/content/3.13/graphs/general-graphs/management.md
+++ b/site/content/3.13/graphs/general-graphs/management.md
@@ -671,8 +671,7 @@ graph.female.update("female/linda", {name: "Linda", _key: "linda"}, { returnOld:
 ### Remove a Vertex
 
 Removes a vertex from a collection of the named graph. Additionally removes all
-incoming and outgoing edges of the vertex. If these edge are used as vertices by
-other edges, the other edges are removed, too (recursively).
+incoming and outgoing edges of the vertex.
 
 `graph.vertexCollectionName.remove(vertexId, options)`
 
@@ -807,10 +806,8 @@ graph.relation.update("relation/aliceAndDiana",
 
 ### Remove an Edge
 
-Removes an edge in collection `edgeCollectionName`.
-
-Removes an edge from an edge collection of the named graph. If this edge is used
-as a vertex by another edge, the other edge is removed, too (recursively).
+Removes an edge from an edge collection of the named graph. Any other edges
+that directly reference this edge like a vertex are removed, too.
 
 `graph.edgeCollectionName.remove(edgeId, options)`
 

--- a/site/content/3.13/graphs/general-graphs/management.md
+++ b/site/content/3.13/graphs/general-graphs/management.md
@@ -670,7 +670,9 @@ graph.female.update("female/linda", {name: "Linda", _key: "linda"}, { returnOld:
 
 ### Remove a Vertex
 
-Removes a vertex in collection `vertexCollectionName`.
+Removes a vertex from a collection of the named graph. Additionally removes all
+incoming and outgoing edges of the vertex. If these edge are used as vertices by
+other edges, the other edges are removed, too (recursively).
 
 `graph.vertexCollectionName.remove(vertexId, options)`
 
@@ -678,9 +680,6 @@ Removes a vertex in collection `vertexCollectionName`.
   `_id` attribute of the vertex
 - `options` (object, _optional_):
   See the [_collection_ object](../../develop/javascript-api/@arangodb/collection-object.md#collectionremoveobject)
-
-Additionally removes all ingoing and outgoing edges of the vertex recursively
-(see [edge remove](#remove-an-edge)).
 
 **Examples**
 
@@ -810,15 +809,15 @@ graph.relation.update("relation/aliceAndDiana",
 
 Removes an edge in collection `edgeCollectionName`.
 
+Removes an edge from an edge collection of the named graph. If this edge is used
+as a vertex by another edge, the other edge is removed, too (recursively).
+
 `graph.edgeCollectionName.remove(edgeId, options)`
 
 - `edgeId` (string):
   `_id` attribute of the edge
 - `options` (object, _optional_):
   See the [_collection_ object](../../develop/javascript-api/@arangodb/collection-object.md#collectionremoveobject)
-
-If this edge is used as a vertex by another edge, the other edge is removed
-(recursively).
 
 **Examples**
 


### PR DESCRIPTION
### Description

And removing edges may remove other edges if the former are used as vertices - it seems to work differently than documented though (non-recursive?) -> It only deleted incoming and outgoing edges for both vertices and edges, non-recursively

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
