### PR TITLE
PoC: llms.txt based on page titles and descriptions

### DIFF
--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -54,9 +54,13 @@ outputFormats:
     baseName: notfound
     isHTML: true
     mediaType: text/html
+  llms:
+    baseName: llms
+    isHTML: false
+    mediaType: text/plain
 
 outputs:
-  home: ["HTML", "navigation", "notfound"]
+  home: ["HTML", "navigation", "notfound", "llms"]
 
 enableRobotsTXT: true
 

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.llms.txt
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.llms.txt
@@ -1,0 +1,28 @@
+# ArangoDB
+
+> ArangoDB is a scalable graph database system to drive value from connected data, faster. Native graphs, an integrated search engine, and JSON support, via a single query language. ArangoDB runs on-prem, in the cloud – anywhere.
+{{ range .Site.Sections.ByWeight }}
+{{- if eq (.Store.Get "alias") "stable" }}
+{{- /* ## Version {{ .Type }} */}}
+
+{{- $pages := .Pages }}
+{{- range $pages.ByWeight }}
+## {{ .Title | safeHTML }}{{ if .Description }}
+
+{{ replace .Description "\n" " " | safeHTML }}{{ end }}
+
+{{ template "section-tree-llm" . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "section-tree-llm" }}
+{{- range .Pages.ByWeight }}
+{{- if .Description -}}
+- [{{ .Title | safeHTML }}]({{ .Permalink }}):
+  {{ replace .Description "\n" " " | safeHTML }}
+
+{{ end }}
+{{- template "section-tree-llm" . }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
### Description

Proof of concept that implements https://llmstxt.org/

- Hand-written introduction
- Top-level navigation entries as headlines, with their descriptions as regular text (should we also provide a link?)
- Child pages as links, with the front matter title as label and the lead paragraph as a description (pages without description are skipped, excluding e.g. all the auto-generated command reference for oasisctl)

https://deploy-preview-714--docs-hugo.netlify.app/llms.txt

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
