### PR TITLE
Update references to directly published Docker images

### DIFF
--- a/site/content/3.12/components/tools/arangodb-starter/options.md
+++ b/site/content/3.12/components/tools/arangodb-starter/options.md
@@ -83,7 +83,7 @@ unreachable for other starters, which is only allowed for
 
 `image` is the name of a Docker image to run instead of the normal
 executable. For each started instance a Docker container is launched.
-Usually one would use the Docker image `arangodb/arangodb`.
+You typically use the `arangodb/enterprise` Docker image.
 
 - `--docker.container=containerName`
 

--- a/site/content/3.12/deploy/cluster/deployment/manual-start.md
+++ b/site/content/3.12/deploy/cluster/deployment/manual-start.md
@@ -339,7 +339,7 @@ to enable process intercommunication.
 An example configuration might look like this:
 
 ```
-docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8530 arangodb/arangodb arangod \
+docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8530 arangodb/enterprise arangod \
   --server.endpoint tcp://0.0.0.0:8530 \
   --cluster.my-address tcp://192.168.1.1:10000 \
   --cluster.my-role DBSERVER \
@@ -378,8 +378,10 @@ options:
 
    Let ArangoDB generate a random root password.
        
-For an in depth guide about Docker and ArangoDB please check the official documentation:
-[hub.docker.com/r/arangodb/arangodb/](https://hub.docker.com/r/arangodb/arangodb/).
-Note that we are using the image `arangodb/arangodb` here which is always the most current one.
-There is also the "official" one called `arangodb` whose documentation is here:
-[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/)
+For an in-depth guide about Docker and ArangoDB please check the official documentation:
+[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/).
+The `arangodb` images are the "official" images built and approved by Docker.
+
+You can also use the `arangodb/enterprise` images published directly by ArangoDB.
+New releases are available here first:
+[hub.docker.com/r/arangodb/enterprise/](https://hub.docker.com/r/arangodb/enterprise/)

--- a/site/content/3.12/deploy/cluster/deployment/using-the-arangodb-starter.md
+++ b/site/content/3.12/deploy/cluster/deployment/using-the-arangodb-starter.md
@@ -140,8 +140,8 @@ to elect a leader for the runtime phase.
 The _Starter_ can also be used to launch clusters based on ArangoDB
 _Docker_ containers.
 
-If you use `arangodb` in a Docker container, it runs all servers in a Docker
-using the `arangodb/arangodb:latest` Docker image by default. If you wish to run
+If you use the `arangodb/arangodb-starter` Docker image, it runs all servers in a container
+using the `arangodb/enterprise:latest` Docker image by default. If you wish to run
 a specific Docker image for the servers, specify it using the `--docker.image`
 option.
 

--- a/site/content/3.12/deploy/single-instance/manual-start.md
+++ b/site/content/3.12/deploy/single-instance/manual-start.md
@@ -35,7 +35,7 @@ to enable process intercommunication.
 An example configuration might look like this:
 
 ```bash
-docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8529 arangodb/arangodb arangod \
+docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8529 arangodb/enterprise arangod \
   --server.endpoint tcp://0.0.0.0:8529\
 ```
 
@@ -66,8 +66,10 @@ options:
 
    Let ArangoDB generate a random root password.
        
-For an in depth guide about Docker and ArangoDB please check the official documentation:
-[hub.docker.com/r/arangodb/arangodb/](https://hub.docker.com/r/arangodb/arangodb/).
-Note that we are using the image `arangodb/arangodb` here which is always the most current one.
-There is also the "official" one called `arangodb` whose documentation is here:
-[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/)
+For an in-depth guide about Docker and ArangoDB please check the official documentation:
+[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/).
+The `arangodb` images are the "official" images built and approved by Docker.
+
+You can also use the `arangodb/enterprise` images published directly by ArangoDB.
+New releases are available here first:
+[hub.docker.com/r/arangodb/enterprise/](https://hub.docker.com/r/arangodb/enterprise/)

--- a/site/content/3.12/operations/installation/docker.md
+++ b/site/content/3.12/operations/installation/docker.md
@@ -11,7 +11,7 @@ for instance, [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 You can choose one of the following:
 - [`arangodb` official Docker images](https://hub.docker.com/_/arangodb),
   verified and published by Docker.
-- [`arangodb/arangodb` Docker images](https://hub.docker.com/r/arangodb/arangodb), 
+- [`arangodb/enterprise` Docker images](https://hub.docker.com/r/arangodb/enterprise), 
   maintained and directly published by ArangoDB on a regular basis.
 
 Check also the following resources:

--- a/site/content/3.13/components/tools/arangodb-starter/options.md
+++ b/site/content/3.13/components/tools/arangodb-starter/options.md
@@ -83,7 +83,7 @@ unreachable for other starters, which is only allowed for
 
 `image` is the name of a Docker image to run instead of the normal
 executable. For each started instance a Docker container is launched.
-Usually one would use the Docker image `arangodb/arangodb`.
+You typically use the `arangodb/enterprise` Docker image.
 
 - `--docker.container=containerName`
 

--- a/site/content/3.13/deploy/cluster/deployment/manual-start.md
+++ b/site/content/3.13/deploy/cluster/deployment/manual-start.md
@@ -339,7 +339,7 @@ to enable process intercommunication.
 An example configuration might look like this:
 
 ```
-docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8530 arangodb/arangodb arangod \
+docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8530 arangodb/enterprise arangod \
   --server.endpoint tcp://0.0.0.0:8530 \
   --cluster.my-address tcp://192.168.1.1:10000 \
   --cluster.my-role DBSERVER \
@@ -378,8 +378,10 @@ options:
 
    Let ArangoDB generate a random root password.
        
-For an in depth guide about Docker and ArangoDB please check the official documentation:
-[hub.docker.com/r/arangodb/arangodb/](https://hub.docker.com/r/arangodb/arangodb/).
-Note that we are using the image `arangodb/arangodb` here which is always the most current one.
-There is also the "official" one called `arangodb` whose documentation is here:
-[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/)
+For an in-depth guide about Docker and ArangoDB please check the official documentation:
+[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/).
+The `arangodb` images are the "official" images built and approved by Docker.
+
+You can also use the `arangodb/enterprise` images published directly by ArangoDB.
+New releases are available here first:
+[hub.docker.com/r/arangodb/enterprise/](https://hub.docker.com/r/arangodb/enterprise/)

--- a/site/content/3.13/deploy/cluster/deployment/using-the-arangodb-starter.md
+++ b/site/content/3.13/deploy/cluster/deployment/using-the-arangodb-starter.md
@@ -140,8 +140,8 @@ to elect a leader for the runtime phase.
 The _Starter_ can also be used to launch clusters based on ArangoDB
 _Docker_ containers.
 
-If you use `arangodb` in a Docker container, it runs all servers in a Docker
-using the `arangodb/arangodb:latest` Docker image by default. If you wish to run
+If you use the `arangodb/arangodb-starter` Docker image, it runs all servers in a container
+using the `arangodb/enterprise:latest` Docker image by default. If you wish to run
 a specific Docker image for the servers, specify it using the `--docker.image`
 option.
 

--- a/site/content/3.13/deploy/single-instance/manual-start.md
+++ b/site/content/3.13/deploy/single-instance/manual-start.md
@@ -35,7 +35,7 @@ to enable process intercommunication.
 An example configuration might look like this:
 
 ```bash
-docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8529 arangodb/arangodb arangod \
+docker run -e ARANGO_NO_AUTH=1 -p 192.168.1.1:10000:8529 arangodb/enterprise arangod \
   --server.endpoint tcp://0.0.0.0:8529\
 ```
 
@@ -66,8 +66,10 @@ options:
 
    Let ArangoDB generate a random root password.
        
-For an in depth guide about Docker and ArangoDB please check the official documentation:
-[hub.docker.com/r/arangodb/arangodb/](https://hub.docker.com/r/arangodb/arangodb/).
-Note that we are using the image `arangodb/arangodb` here which is always the most current one.
-There is also the "official" one called `arangodb` whose documentation is here:
-[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/)
+For an in-depth guide about Docker and ArangoDB please check the official documentation:
+[hub.docker.com/\_/arangodb/](https://hub.docker.com/_/arangodb/).
+The `arangodb` images are the "official" images built and approved by Docker.
+
+You can also use the `arangodb/enterprise` images published directly by ArangoDB.
+New releases are available here first:
+[hub.docker.com/r/arangodb/enterprise/](https://hub.docker.com/r/arangodb/enterprise/)

--- a/site/content/3.13/operations/installation/docker.md
+++ b/site/content/3.13/operations/installation/docker.md
@@ -11,7 +11,7 @@ for instance, [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 You can choose one of the following:
 - [`arangodb` official Docker images](https://hub.docker.com/_/arangodb),
   verified and published by Docker.
-- [`arangodb/arangodb` Docker images](https://hub.docker.com/r/arangodb/arangodb), 
+- [`arangodb/enterprise` Docker images](https://hub.docker.com/r/arangodb/enterprise), 
   maintained and directly published by ArangoDB on a regular basis.
 
 Check also the following resources:

--- a/toolchain/scripts/toolchain.sh
+++ b/toolchain/scripts/toolchain.sh
@@ -186,7 +186,7 @@ function get_docker_imageid() {
   ## Get the docker image id to run of the server
   image_id=$(docker images --filter=reference=$image_name-$version | awk 'NR==2' | awk '{print $3}')
   if [ "$image_id" == "" ]; then
-    image_id=$(docker images --filter=reference=$branch_name | awk 'NR==2' | awk '{print $3}') ## this is used for official arangodb images, arangodb/arangodb:tag
+    image_id=$(docker images --filter=reference=$branch_name | awk 'NR==2' | awk '{print $3}') ## this is used for official arangodb images, arangodb/enterprise:tag
   fi
   echo "$image_id"
 }


### PR DESCRIPTION
### Description

In v3.12.5+, `arangodb/arangodb` images no longer published, use `arangodb/enterprise`

Change in Starter TBD:
- https://github.com/arangodb-helper/arangodb/pull/457

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
