### PR TITLE
Move Graph analytics page in the Graph chapter

### DIFF
--- a/site/content/3.13/data-science/_index.md
+++ b/site/content/3.13/data-science/_index.md
@@ -53,8 +53,7 @@ Graph analytics can answer questions like _**Who are the most connected persons*
 
 ArangoDB offers _Graph Analytics Engines_ to run algorithms such as
 connected components, label propagation, and PageRank on your data. This feature
-is available for the ArangoGraph Insights Platform. See
-[Graph Analytics](graph-analytics.md) for details.
+is available for the ArangoGraph Insights Platform.
 
 ### GraphML
 

--- a/site/content/3.13/data-science/_index.md
+++ b/site/content/3.13/data-science/_index.md
@@ -53,7 +53,8 @@ Graph analytics can answer questions like _**Who are the most connected persons*
 
 ArangoDB offers _Graph Analytics Engines_ to run algorithms such as
 connected components, label propagation, and PageRank on your data. This feature
-is available for the ArangoGraph Insights Platform.
+is available for the ArangoGraph Insights Platform. See 
+[Graph Analytics](../graphs/graph-analytics.md) for details.
 
 ### GraphML
 

--- a/site/content/3.13/graphs/graph-analytics.md
+++ b/site/content/3.13/graphs/graph-analytics.md
@@ -5,6 +5,8 @@ weight: 123
 description: |
   ArangoGraph offers Graph Analytics Engines to run graph algorithms on your
   data separately from your ArangoDB deployments
+aliases:
+  - ../data-science/graph-analytics
 ---
 Graph analytics is a branch of data science that deals with analyzing information
 networks known as graphs, and extracting information from the data relationships.

--- a/site/content/3.13/graphs/graph-analytics.md
+++ b/site/content/3.13/graphs/graph-analytics.md
@@ -1,7 +1,7 @@
 ---
 title: Graph Analytics
 menuTitle: Graph Analytics
-weight: 123
+weight: 115
 description: |
   ArangoGraph offers Graph Analytics Engines to run graph algorithms on your
   data separately from your ArangoDB deployments


### PR DESCRIPTION
### Description

Move Graph analytics page in the Graph chapter, it is not part of the GenAI suite.
