### PR TITLE
Rename menu title to Graph Intelligence

### DIFF
--- a/site/content/3.12/graphs/_index.md
+++ b/site/content/3.12/graphs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Graphs
-menuTitle: Graphs
+menuTitle: Graph Intelligence
 weight: 75
 description: >-
   Graphs let you represent things and the relationships between them using

--- a/site/content/3.13/graphs/_index.md
+++ b/site/content/3.13/graphs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Graphs
-menuTitle: Graphs
+menuTitle: Graph Intelligence
 weight: 75
 description: >-
   Graphs let you represent things and the relationships between them using


### PR DESCRIPTION
### Description

Agreed that for the time being we should only rename the menu title and not the URL(s) as this will lead to extra effort, maintenance, and plenty of external broken links (from main website, readmes, and other ArangoDB resources).
