### PR TITLE
Release notes about deprecation of --rocksdb.transaction-lock-timeout startup option

### DIFF
--- a/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -1075,6 +1075,16 @@ background compactions. The changed default ensures this cleanup to happen more
 frequently. Compactions can potentially lead to spikes in CPU, memory, and I/O
 usage. You may now observe this daily instead of monthly.
 
+### RocksDB transaction lock timeout controlled internally
+
+<small>Deprecated in: v3.12.6</small>
+
+The `--rocksdb.transaction-lock-timeout` startup option has been deprecated.
+It was supposed to let you configure the wait timeout in milliseconds for
+locking a document in a transaction. However, the lock timeout is actually set
+to differnet values internally, depending on what is a meaningful timeout for
+a given case.
+
 ## Client tools
 
 ### arangodump

--- a/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/3.13/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -1075,6 +1075,16 @@ background compactions. The changed default ensures this cleanup to happen more
 frequently. Compactions can potentially lead to spikes in CPU, memory, and I/O
 usage. You may now observe this daily instead of monthly.
 
+### RocksDB transaction lock timeout controlled internally
+
+<small>Deprecated in: v3.12.6</small>
+
+The `--rocksdb.transaction-lock-timeout` startup option has been deprecated.
+It was supposed to let you configure the wait timeout in milliseconds for
+locking a document in a transaction. However, the lock timeout is actually set
+to differnet values internally, depending on what is a meaningful timeout for
+a given case.
+
 ## Client tools
 
 ### arangodump


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
