### PR TITLE
Starter still defaults to `arangodb/arangodb:latest`

### DIFF
--- a/site/content/3.12/deploy/cluster/deployment/using-the-arangodb-starter.md
+++ b/site/content/3.12/deploy/cluster/deployment/using-the-arangodb-starter.md
@@ -141,9 +141,15 @@ The _Starter_ can also be used to launch clusters based on ArangoDB
 _Docker_ containers.
 
 If you use the `arangodb/arangodb-starter` Docker image, it runs all servers in a container
-using the `arangodb/enterprise:latest` Docker image by default. If you wish to run
+using the `arangodb/arangodb:latest` Docker image by default. If you wish to run
 a specific Docker image for the servers, specify it using the `--docker.image`
 option.
+
+{{< info >}}
+From ArangoDB version 3.12.5 onward, no new `arangodb/arangodb` images are
+published anymore. Use the `arangodb/enterprise` images instead, e.g.
+`--docker.image arangodb/enterprise:latest`.
+{{< /info >}}
 
 If you use Docker, it is important to care about the volume mappings on
 the container. Typically, you start the executable in Docker with the following

--- a/site/content/3.13/deploy/cluster/deployment/using-the-arangodb-starter.md
+++ b/site/content/3.13/deploy/cluster/deployment/using-the-arangodb-starter.md
@@ -141,9 +141,15 @@ The _Starter_ can also be used to launch clusters based on ArangoDB
 _Docker_ containers.
 
 If you use the `arangodb/arangodb-starter` Docker image, it runs all servers in a container
-using the `arangodb/enterprise:latest` Docker image by default. If you wish to run
+using the `arangodb/arangodb:latest` Docker image by default. If you wish to run
 a specific Docker image for the servers, specify it using the `--docker.image`
 option.
+
+{{< info >}}
+From ArangoDB version 3.12.5 onward, no new `arangodb/arangodb` images are
+published anymore. Use the `arangodb/enterprise` images instead, e.g.
+`--docker.image arangodb/enterprise:latest`.
+{{< /info >}}
 
 If you use Docker, it is important to care about the volume mappings on
 the container. Typically, you start the executable in Docker with the following


### PR DESCRIPTION
### Description

Follow-up to #727

Adam said the upstream PR would be invalid. At the very least, it is not merged yet, so we can't say that the default for `--docker.image` would be `arangodb/enterprise:latest`.
- https://github.com/arangodb-helper/arangodb/pull/457

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
