### PR TITLE
CircleCI: Retry to fetch download URLs from GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,26 @@ jobs:
           name: Checkout
           command: |
             mkdir -p .circleci && cd .circleci
-            curl https://api.github.com/repos/arangodb/docs-hugo/contents/.circleci?ref=$CIRCLE_SHA1 | jq ".[].download_url" | xargs wget
+            fetched=false
+            for i in $(seq 1 6); do
+              res=$(curl -fsS https://api.github.com/repos/arangodb/docs-hugo/contents/.circleci?ref=$CIRCLE_SHA1)
+              status=$?
+              if [[ "$status" -eq 0 ]]; then
+                urls=$(echo "$res" | jq ".[].download_url")
+                status=$?
+                if [[ "$status" -eq 0 ]]; then
+                  fetched=true
+                  break
+                fi
+              fi
+              echo "$res"
+              sleep 10
+            done
+            if [[ "$fetched" = false ]]; then
+              echo "Failed to fetch download URLs"
+              exit 1
+            fi
+            echo "$urls" | xargs wget
             wget https://raw.githubusercontent.com/arangodb/docs-hugo/$CIRCLE_SHA1/site/data/versions.yaml
 
             pip install pyyaml requests


### PR DESCRIPTION
### Description

Also add error reporting if this fails

There have been various failures recently in the generate-config step:

```
jq: error (at <stdin>:1): Cannot index string with string "download_url"
wget: missing URL
```

This should mitigate it or at least log the actual error we get from GitHub

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
