### PR TITLE
Bordered tab design

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/tabs.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/tabs.html
@@ -11,7 +11,7 @@
           {{- cond (eq $idx 0) " selected" ""}}" onclick="switchTab('{{ $groupid }}','{{ .name }}',event)">
           <span>{{ .name | markdownify }}</span>
         </button>
-      {{ end -}}
+      {{- end -}}
     {{ end -}}
     </div>
     {{ range $idx, $tab := $tabs -}}

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -496,6 +496,7 @@ a.section-link {
 
 .tab-panel .tab-item {
     display: none;
+    margin: 1rem;
 }
 
 .tab-panel .tab-item.selected {
@@ -504,11 +505,12 @@ a.section-link {
 
 .tab-panel {
     margin: 1rem 0;
+    border: 2px solid var(--gray-300);
+    border-radius: 7px;
 }
 
 .tab-nav {
     border-bottom: 2px solid var(--gray-300);
-    margin-bottom: 1rem;
 }
 
 .tab-nav-button {


### PR DESCRIPTION


### Description

This makes it visually clear where the tab content ends

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
