### PR TITLE
TTL index: Optional selectivity estimates

### DIFF
--- a/site/content/3.12/develop/http-api/indexes/multi-dimensional.md
+++ b/site/content/3.12/develop/http-api/indexes/multi-dimensional.md
@@ -128,8 +128,7 @@ paths:
                     competing indexes in AQL queries when there are multiple candidate indexes to
                     choose from.
 
-                    The `estimates` attribute is optional and defaults to `true` if not set.
-                    It has no effect on indexes other than `persistent`, `mdi`, and `mdi-prefixed`.
+                    The option has no effect on indexes other than `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes.
                     It cannot be disabled for non-unique `mdi` indexes because they have a fixed
                     selectivity estimate of `1`.
                   type: boolean

--- a/site/content/3.12/develop/http-api/indexes/persistent.md
+++ b/site/content/3.12/develop/http-api/indexes/persistent.md
@@ -139,7 +139,7 @@ paths:
                     competing indexes in AQL queries when there are multiple candidate indexes to
                     choose from.
 
-                    The option has no effect on indexes other than `persistent`, `mdi`, and `mdi-prefixed`.
+                    The option has no effect on indexes other than `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes.
                   type: boolean
                   default: true
                 cacheEnabled:

--- a/site/content/3.12/develop/http-api/indexes/ttl.md
+++ b/site/content/3.12/develop/http-api/indexes/ttl.md
@@ -59,6 +59,20 @@ paths:
                   maxItems: 1
                   items:
                     type: string
+                estimates:
+                  description: |
+                    This attribute controls whether index selectivity estimates are maintained for the
+                    index. Not maintaining index selectivity estimates can have a slightly positive
+                    impact on write performance.
+
+                    The downside of turning off index selectivity estimates is that
+                    the query optimizer is not able to determine the usefulness of different
+                    competing indexes in AQL queries when there are multiple candidate indexes to
+                    choose from.
+
+                    The option has no effect on indexes other than `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes.
+                  type: boolean
+                  default: true
                 expireAfter:
                   description: |
                     The time interval (in seconds) from the point in time stored in the `fields`

--- a/site/content/3.12/index-and-search/indexing/index-utilization.md
+++ b/site/content/3.12/index-and-search/indexing/index-utilization.md
@@ -20,7 +20,7 @@ to an index, an index can become more selective and thus reduce the number of do
 queries need to process.
 
 ArangoDB's `primary` and `edge` indexes automatically provide selectivity estimates.
-The `persistent`, `mdi`, and `mdi-prefixed` indexes do too, by default.
+The `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes do too, by default.
 Index selectivity estimates are provided in the web interface, the `indexes()` return 
 value and in the `explain()` output for a given query. 
 

--- a/site/content/3.13/develop/http-api/indexes/multi-dimensional.md
+++ b/site/content/3.13/develop/http-api/indexes/multi-dimensional.md
@@ -128,8 +128,7 @@ paths:
                     competing indexes in AQL queries when there are multiple candidate indexes to
                     choose from.
 
-                    The `estimates` attribute is optional and defaults to `true` if not set.
-                    It has no effect on indexes other than `persistent`, `mdi`, and `mdi-prefixed`.
+                    The option has no effect on indexes other than `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes.
                     It cannot be disabled for non-unique `mdi` indexes because they have a fixed
                     selectivity estimate of `1`.
                   type: boolean

--- a/site/content/3.13/develop/http-api/indexes/persistent.md
+++ b/site/content/3.13/develop/http-api/indexes/persistent.md
@@ -139,7 +139,7 @@ paths:
                     competing indexes in AQL queries when there are multiple candidate indexes to
                     choose from.
 
-                    The option has no effect on indexes other than `persistent`, `mdi`, and `mdi-prefixed`.
+                    The option has no effect on indexes other than `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes.
                   type: boolean
                   default: true
                 cacheEnabled:

--- a/site/content/3.13/develop/http-api/indexes/ttl.md
+++ b/site/content/3.13/develop/http-api/indexes/ttl.md
@@ -59,6 +59,20 @@ paths:
                   maxItems: 1
                   items:
                     type: string
+                estimates:
+                  description: |
+                    This attribute controls whether index selectivity estimates are maintained for the
+                    index. Not maintaining index selectivity estimates can have a slightly positive
+                    impact on write performance.
+
+                    The downside of turning off index selectivity estimates is that
+                    the query optimizer is not able to determine the usefulness of different
+                    competing indexes in AQL queries when there are multiple candidate indexes to
+                    choose from.
+
+                    The option has no effect on indexes other than `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes.
+                  type: boolean
+                  default: true
                 expireAfter:
                   description: |
                     The time interval (in seconds) from the point in time stored in the `fields`

--- a/site/content/3.13/index-and-search/indexing/index-utilization.md
+++ b/site/content/3.13/index-and-search/indexing/index-utilization.md
@@ -20,7 +20,7 @@ to an index, an index can become more selective and thus reduce the number of do
 queries need to process.
 
 ArangoDB's `primary` and `edge` indexes automatically provide selectivity estimates.
-The `persistent`, `mdi`, and `mdi-prefixed` indexes do too, by default.
+The `persistent`, `mdi`, `mdi-prefixed`, and `ttl` indexes do too, by default.
 Index selectivity estimates are provided in the web interface, the `indexes()` return 
 value and in the `explain()` output for a given query. 
 


### PR DESCRIPTION
### Description

TODO: Change base branch to `main` after https://github.com/arangodb/docs-hugo/pull/770 has been merged

One can set `estimates: false` for this index type, but not sure if this is accidental or an actual feature. One shouldn't use TTL indexes for covering queries in general, but does it affect the background thread for expiring docs?

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
