### PR TITLE
Hugo: Change templating from IDs to classes

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/404.html
+++ b/site/themes/arangodb-docs-theme/layouts/404.html
@@ -11,11 +11,11 @@
 
 <body>
     <noscript>You need to enable JavaScript to use the ArangoDB documentation.</noscript>
-    <div id="page-wrapper" class="page_content_splash" style="height: auto;opacity: 0;">
-        <section id="page-main">
-            <section class="page-container" id="page-container">
+    <div class="page-wrapper page_content_splash" style="height: auto;opacity: 0;">
+        <section class="page-main">
+            <section class="page-container">
                 {{ partialCached "header.html" . }}
-                <iframe src="/nav.html" title="description" id="menu-iframe" class="menu-iframe active" style="opacity: 0;"></iframe>
+                <iframe src="/nav.html" title="description" class="menu-iframe active" style="opacity: 0;"></iframe>
 
             
                 <div class="container-main">

--- a/site/themes/arangodb-docs-theme/layouts/_default/baseof.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/baseof.html
@@ -7,11 +7,11 @@
   <body>
     {{ if $isProduction }}{{ partialCached "tracking/body-start.html" . }}{{ end -}}
     <noscript>You need to enable JavaScript to use the ArangoDB documentation.</noscript>
-    <div id="page-wrapper" class="page_content_splash" style="height: auto; opacity: 0;">
-      <section id="page-main">
-        <section class="page-container" id="page-container">
+    <div class="page-wrapper page_content_splash" style="height: auto; opacity: 0;">
+      <section class="page-main">
+        <section class="page-container">
           {{ partialCached "header.html" . -}}
-          <iframe src="/nav.html" title="description" id="menu-iframe" class="menu-iframe active" style="opacity: 0;"></iframe>
+          <iframe src="/nav.html" title="description" class="menu-iframe active" style="opacity: 0;"></iframe>
           <div class="container-main">
             <div class="row-main">
               {{ if gt (len .Page.Ancestors) 1 }}{{ partial "breadcrumbs.html" . }}{{ end -}}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.navigation.html
@@ -1,7 +1,7 @@
-<div id="sidebar" class="default-animation active">
+<div class="sidebar default-animation active">
   <div class="sidenav-container-flex">
     <div class="sidenav-navigation">
-      <div id="content-wrapper" class="highlightable">
+      <div class="content-wrapper highlightable">
         <ul class="topics{{ if .Site.Params.collapsibleMenu }} collapsible-menu{{ end }}">
           {{- range .Site.Sections.ByWeight }}
             {{/* version folders */}}
@@ -16,7 +16,7 @@
       </div>
     </div>
   </div>
-  <button id="sidebar-toggle-navigation" class="desktop-menu-toggle" onclick="showSidebarHandler();"></button>
+  <button class="sidebar-toggle-navigation desktop-menu-toggle" onclick="showSidebarHandler();"></button>
 </div>
 
 {{- define "section-tree-nav" }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.notfound.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.notfound.html
@@ -1,10 +1,10 @@
-<section class="page-container" id="page-container">
+<section class="page-container">
   <div class="container-main">
     <div class="notfound">
       <div class="flex-block-wrapper">
         <div class="notfound-404">
           <p class="notfound-4">4</p>
-          <img id="notfound-image" src="{{ "images/sad-avocado.png" | relURL }}" alt="Page not found!">
+          <img class="notfound-image" src="{{ "images/sad-avocado.png" | relURL }}" alt="Page not found!">
           <p class="notfound-4">4</p>
         </div>
         <hgroup>

--- a/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
@@ -1,4 +1,4 @@
-<nav id="breadcrumbs">
+<nav class="breadcrumbs">
   <ol class="links" itemscope itemtype="http://schema.org/BreadcrumbList">
   <meta itemprop="itemListOrder" content="Descending" />
   {{ range .Ancestors.Reverse -}}

--- a/site/themes/arangodb-docs-theme/layouts/partials/header.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/header.html
@@ -1,9 +1,9 @@
 <!-- HEADER -->
-  <header id="header" style="transition: 0.5s padding ease-out, 0.15s" class="zn_header_white header-splash-new nav-down header-splash-wrap header1">
+  <header style="transition: 0.5s padding ease-out, 0.15s" class="header zn_header_white header-splash-new nav-down header-splash-wrap header1">
     <!--LOGO-->
     <div class="header-block-left">
     <div class="mobile-menu-toggle">
-      <button id="sidebar-toggle-navigation" onclick="showSidebarHandler()">
+      <button class="sidebar-toggle-navigation" onclick="showSidebarHandler()">
         <svg width="1.33em" height="1.33em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       </button>
     </div>
@@ -24,7 +24,7 @@
     </div>
     <div class="search-and-version-container" >
       <a href="#" class="home-link is-current" aria-label="Go to home page" onclick="goToHomepage(event);"></a>
-      <div id="searchbox">
+      <div class="docsearch">
       </div>
       {{ partialCached "inkeep-widget.html" . -}}
       {{ partialCached "version-selector.html" . }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/search.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/search.html
@@ -10,7 +10,7 @@
       apiKey: "500c85ccecb335d507fe4449aed12e1d",
       indexName: "arangodbdocs",
       insights: true, // Optional, automatically send insights when user interacts with search results
-      container: "#searchbox",
+      container: ".docsearch",
       debug: false, // Set debug to true if you want to inspect the modal,
       maxResultsPerGroup: 10,
       searchParameters: {

--- a/site/themes/arangodb-docs-theme/layouts/partials/toc.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/toc.html
@@ -11,7 +11,7 @@
     <div class="toc">
         <div class="toc-content">
         <div class="toc-header"><p>On this page</p></div>
-        <nav id="TableOfContents" >
+        <nav class="TableOfContents" >
           {{ template "nestedHeadline" dict "headings" .Page.Fragments.Headings "level" 1 }}
         </nav>
         </div>

--- a/site/themes/arangodb-docs-theme/layouts/partials/version-selector.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/version-selector.html
@@ -1,5 +1,5 @@
 <div class="version-selector">
-    <select id="arangodb-version" onchange="changeVersion();">
+    <select class="arangodb-version" onchange="changeVersion();">
     {{ $versions := site.Data.versions }}
     {{ range $i, $version := $versions }}
         <option value="{{ $version.name }}">{{ $version.name }}</option>

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -550,12 +550,12 @@ a.section-link {
 
 /* Body */
 
-#page-wrapper {
+.page-wrapper {
     position: relative;
     width: 100%;
 }
 
-body #page-main {
+body .page-main {
     position: relative;
 }
 
@@ -573,7 +573,7 @@ body .page-container {
 
 /* HEADER */
 
-#header {
+.header {
     height: 64px;
     padding: 16px;
     display: flex;
@@ -602,14 +602,14 @@ body .page-container {
     display: flex;
 }
 
-#sidebar code {
+.sidebar code {
     color: var(--gray-100);
     background: transparent;
     border: 0;
     padding: 0;
 }
 
-#sidebar > #sidebar-toggle-navigation {
+.sidebar > .sidebar-toggle-navigation {
     position: fixed;
     bottom: 3vh;
     left: 0.2vw;
@@ -628,7 +628,7 @@ body .page-container {
     border-radius: 24px;
 }
 
-#sidebar > #sidebar-toggle-navigation::after {
+.sidebar > .sidebar-toggle-navigation::after {
     font-family: "Font Awesome 5 Free";
     content: "\f054";
     display: inline-block;
@@ -639,14 +639,14 @@ body .page-container {
     color: var(--gray-100);
 }
 
-#sidebar.active > #sidebar-toggle-navigation {
+.sidebar.active > .sidebar-toggle-navigation {
     left: 286px;
 }
 
 
 @media screen and (max-width: 1024px) {
-    #sidebar > #sidebar-toggle-navigation,
-    #sidebar.active > #sidebar-toggle-navigation {
+    .sidebar > .sidebar-toggle-navigation,
+    .sidebar.active > .sidebar-toggle-navigation {
         display: none;
     }
     .mobile-menu-toggle {
@@ -656,7 +656,7 @@ body .page-container {
 
 
 
-#sidebar.active > #sidebar-toggle-navigation::after {
+.sidebar.active > .sidebar-toggle-navigation::after {
     font-family: "Font Awesome 5 Free";
     content: "\f053";
 }
@@ -667,7 +667,7 @@ body .page-container {
     }
 }
 
-.mobile-menu-toggle > #sidebar-toggle-navigation {
+.mobile-menu-toggle > .sidebar-toggle-navigation {
     background: none;
     padding: 0;
     color: var(--gray-950); 
@@ -677,7 +677,7 @@ body .page-container {
 }
 
 
-.mobile-menu-toggle > #sidebar-toggle-navigation > svg {
+.mobile-menu-toggle > .sidebar-toggle-navigation > svg {
     position: relative;
     top: -6px;
     font-size: 1.1rem;
@@ -784,13 +784,13 @@ header .logo {
     }
 }
 
-#arangodb-version {
+.arangodb-version {
     border: none;
     background: none;
 }
 
 @media screen and (max-width: 768px) {
-    #arangodb-version {
+    .arangodb-version {
         width: 4rem;
     }
 }
@@ -812,7 +812,7 @@ header .logo {
     border: none;
 }
 
-#sidebar {
+.sidebar {
     grid-area: sidenav;
     display: flex;
     align-items: stretch;
@@ -825,20 +825,20 @@ header .logo {
     background-color: var(--gray-950);
 }
 
-#sidebar .sidenav-navigation {
+.sidebar .sidenav-navigation {
     opacity: 0;
 }
-#sidebar.active .sidenav-navigation {
+.sidebar.active .sidenav-navigation {
     opacity: 1;
 }
 
 .menu-iframe.active,
-#sidebar.active {
+.sidebar.active {
     width: 300px;
 }
 
 @media screen and (max-width: 768px) {
-    .menu-iframe.active, #sidebar.active {
+    .menu-iframe.active, .sidebar.active {
         width: 100%;
     }
 }
@@ -867,7 +867,7 @@ header .logo {
     margin: 0 10px 0 0;
 }
 
-#content-wrapper {
+.content-wrapper {
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -876,27 +876,27 @@ header .logo {
     position: relative;
 }
 
-#sidebar a.padding {
+.sidebar a.padding {
     padding: 0 1rem;
 }
 
-#sidebar ul {
+.sidebar ul {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-#sidebar li {
+.sidebar li {
     padding: 0;
 
 }
 
-#sidebar ul.topics {
+.sidebar ul.topics {
     margin-bottom: 2rem;
     padding: 0.5rem 1rem;
 }
 
-#sidebar ul.topics label {
+.sidebar ul.topics label {
     cursor: pointer;
     display: inline;
     height: 1rem;
@@ -913,13 +913,13 @@ header .logo {
 }
 
 
-#sidebar ul.topics li.parent > ul,
-#sidebar ul.topics li.active > ul,
-#sidebar ul.topics li.alwaysopen > ul {
+.sidebar ul.topics li.parent > ul,
+.sidebar ul.topics li.active > ul,
+.sidebar ul.topics li.alwaysopen > ul {
     display: block;
 }
 
-#sidebar ul.topics li.active > a {
+.sidebar ul.topics li.active > a {
     box-sizing: border-box;
     border-radius: 8px;
     --tw-bg-opacity: 0.5;
@@ -928,13 +928,13 @@ header .logo {
 
 
 
-#sidebar ul.topics > li a {
+.sidebar ul.topics > li a {
     font-size: 13px;
     line-height: 1.3rem;
 }
 
 
-#sidebar ul li a {
+.sidebar ul li a {
     padding-left: 1rem;
     padding-right: 1rem;
     display: flex;
@@ -942,7 +942,7 @@ header .logo {
     transition: 0.5s;
 }
 
-#sidebar ul.topics li > a {
+.sidebar ul.topics li > a {
     display: flex;
     padding-left: 1rem;
     padding-right: 1rem;
@@ -953,21 +953,21 @@ header .logo {
     font-weight: 400;
 }
 
-#sidebar ul li a.toggle,
-#sidebar ul li.leaf a {
+.sidebar ul li a.toggle,
+.sidebar ul li.leaf a {
     margin-right: -0.5rem;
     padding-right: 1.5rem;
     border-radius: 8px;
 }
 
-#sidebar ul li a:hover {
+.sidebar ul li a:hover {
     box-sizing: border-box;
     border: 0;
     text-decoration: none;
     background-color: var(--gray-900);
 }
 
-#sidebar ul.topics > li a::first-line {
+.sidebar ul.topics > li a::first-line {
     line-height: 1rem;
 }
 
@@ -1005,14 +1005,14 @@ header .logo {
     pointer-events: none;
 }
 
-#sidebar ul.topics li.parent > a > .menu-title,
-#sidebar ul.topics li.active > a > .menu-title,
-#sidebar ul.topics li.alwaysopen > a > .menu-title {
+.sidebar ul.topics li.parent > a > .menu-title,
+.sidebar ul.topics li.active > a > .menu-title,
+.sidebar ul.topics li.alwaysopen > a > .menu-title {
     font-weight: 400;
     color: var(--green-500);
 }
 
-#sidebar ul li li {
+.sidebar ul li li {
     padding-left: 1rem;
 }
 
@@ -1057,7 +1057,7 @@ header .logo {
 }
 
 /* Breadcrumbs row */
-#breadcrumbs {
+.breadcrumbs {
     grid-area: breadcrumbs;
     display: flex;
     flex-direction: row;
@@ -1072,33 +1072,33 @@ header .logo {
 }
 
 @media screen and (max-width: 768px) {
-    #breadcrumbs {
+    .breadcrumbs {
         z-index: 1;
         white-space: break-spaces;
         margin-top: 1rem;
     }
 }
 
-#breadcrumbs > ol {
+.breadcrumbs > ol {
     margin: 5px 0 0 80px;
     white-space: normal;
 }
 
 @media screen and (max-width: 768px)
 {
-    #breadcrumbs > ol {
+    .breadcrumbs > ol {
         margin: 0;
         padding: 0 20px
     }
 }
 
 
-#breadcrumbs > ol > li {
+.breadcrumbs > ol > li {
     padding: 0;
     display: inline;
 }
 
-#breadcrumbs > ol > li > a {
+.breadcrumbs > ol > li > a {
     font-size: 1rem;
     font-weight: 500;
     color: var(--gray-700);
@@ -1106,11 +1106,11 @@ header .logo {
     background-color: transparent;
 }
 
-#breadcrumbs > ol > li > a:hover {
+.breadcrumbs > ol > li > a:hover {
     color: var(--gray-950);
 }
 
-#breadcrumbs > ol > li > i {
+.breadcrumbs > ol > li > i {
     margin: 0 2px;
     color: var(--gray-700);
     font-size: 14px;
@@ -1224,20 +1224,20 @@ header .logo {
     margin-bottom: 30px;
 }
 
-#TableOfContents {
+.TableOfContents {
     margin-right: 1rem;
 }
 
-#TableOfContents > div {
+.TableOfContents > div {
     margin-bottom: 8px;
 }
 
-#TableOfContents ul {
+.TableOfContents ul {
     list-style: none;
     margin: 0;
 }
 
-#TableOfContents a {
+.TableOfContents a {
     display: inline-block;
     padding: 0.25rem 0.5rem;
     text-decoration: none;
@@ -1246,51 +1246,51 @@ header .logo {
     font-weight: 400;
 }
 
-#TableOfContents a:hover {
+.TableOfContents a:hover {
     border-bottom: none;
 }
 
-#TableOfContents .level-3 > a {
+.TableOfContents .level-3 > a {
     padding-left: 1.25rem;
 }
 
-#TableOfContents .level-4 > a {
+.TableOfContents .level-4 > a {
     padding-left: 2rem;
 }
 
-#TableOfContents .level-5 > a {
+.TableOfContents .level-5 > a {
     padding-left: 2.75rem;
 }
-#TableOfContents .level-6 > a {
+.TableOfContents .level-6 > a {
     padding-left: 3.5rem;
 }
 
-#TableOfContents .is-active > a {
+.TableOfContents .is-active > a {
     color: #222222;
 }
 
-#TableOfContents .level-1:hover,
-#TableOfContents .level-2:hover,
-#TableOfContents .level-3:hover,
-#TableOfContents .level-4:hover, 
-#TableOfContents .level-5:hover,
-#TableOfContents .level-6:hover {
+.TableOfContents .level-1:hover,
+.TableOfContents .level-2:hover,
+.TableOfContents .level-3:hover,
+.TableOfContents .level-4:hover, 
+.TableOfContents .level-5:hover,
+.TableOfContents .level-6:hover {
     font-weight: bold;
     --tw-bg-opacity: 0.2;
     background-color: var(--gray-100);
     border-radius: 4px;
 }
 
-#TableOfContents .is-active {
+.TableOfContents .is-active {
     font-weight: bold;
     background-color: var(--gray-200);
     border-radius: 4px;
 }
 
-#TableOfContents .is-active:hover {
+.TableOfContents .is-active:hover {
     background-color: var(--gray-200);
 }
-#TableOfContents a {
+.TableOfContents a {
     width: 100%;
 }
 /* end Table of contents */
@@ -2085,21 +2085,21 @@ nav.pagination .next {
     color: #130909;
 }
 
-#sidebar ::-webkit-scrollbar {
+.sidebar ::-webkit-scrollbar {
     width: 10px;
 }
 
-#sidebar ::-webkit-scrollbar-thumb {
+.sidebar ::-webkit-scrollbar-thumb {
     background: var(--gray-500);
     width: 6px;
     border-radius: 20px;
 }
 
-#sidebar ::-webkit-scrollbar-thumb:hover {
+.sidebar ::-webkit-scrollbar-thumb:hover {
     background: var(--gray-200);
 }
 
-#sidebar ::-webkit-scrollbar-track {
+.sidebar ::-webkit-scrollbar-track {
     background: var(--gray-950);
 }
 
@@ -2144,7 +2144,7 @@ nav.pagination .next {
     margin-bottom: 4rem;
 }
 
-#notfound-image {
+.notfound-image {
     display: block;
     width: 9rem;
 }

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -2007,6 +2007,7 @@ nav.pagination {
     padding: 0.75rem 1rem 2rem;
     display: flex;
     grid-area: footer;
+    margin-bottom: 5rem;
 }
 
 nav.pagination span {

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -1108,6 +1108,7 @@ header .logo {
 
 .breadcrumbs > ol > li > a:hover {
     color: var(--gray-950);
+    border-bottom: 0;
 }
 
 .breadcrumbs > ol > li > i {

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -501,13 +501,6 @@ function initClickHandlers() {
         $(event.target).toggleClass("collapsed");
         $(event.target).next(".openapi-table").toggleClass("hidden");
     });
-
-    $('#search-by').keypress(
-        function(event){
-          if (event.which == '13') {
-            event.preventDefault();
-          }
-      });
     
 }
 

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -26,7 +26,7 @@ function menuEntryClickListener() {
             return
         }
         updateHistory(event.target.getAttribute('href'))
-        $('#sidebar.mobile').removeClass("active")
+        $('.sidebar.mobile').removeClass("active")
 
     });
 }
@@ -74,7 +74,7 @@ function loadMenu(url) {
 }
 
 function showSidebarHandler() {
-    $("#sidebar").toggleClass("active");
+    $(".sidebar").toggleClass("active");
   }
 
 
@@ -228,7 +228,7 @@ function initArticle(url) {
   internalLinkListener();
   codeShowMoreListener();
   aliazeLinks('article', 'a.link:not([target]), a.card-link, a.header-link');
-  aliazeLinks('#breadcrumbs', 'a')
+  aliazeLinks('.breadcrumbs', 'a')
 }
 
 
@@ -256,7 +256,7 @@ function getAllAnchors() {
     let tocIds = [];
     let headlineIds = [];
     // Exclude headline anchors that are not in the ToC
-    document.querySelectorAll("#TableOfContents a").forEach(e => { tocIds.push(e.getAttribute("href").slice(1)) });
+    document.querySelectorAll(".TableOfContents a").forEach(e => { tocIds.push(e.getAttribute("href").slice(1)) });
     document.querySelector("article").querySelectorAll("h2,h3,h4,h5,h6").forEach(a => { if (tocIds.indexOf(a.id) !== -1) { headlineIds.push(a); } });
     return headlineIds;
 }
@@ -264,7 +264,7 @@ function removeActiveFromAllAnchors() {
   var anchors = getAllAnchors();
   anchors.forEach(anchor => {
       var heading = anchor.getAttribute('id')
-      let oldHRef = document.querySelector('#TableOfContents a[href="#' + heading + '"]');
+      let oldHRef = document.querySelector('.TableOfContents a[href="#' + heading + '"]');
       oldHRef.parentElement.classList.remove('is-active');
   });
 }
@@ -279,11 +279,11 @@ function tocHiglighter() {
     const rect = anchor.getBoundingClientRect();
     const top = rect.top;
     const id = anchor.id;
-    const currentHighlighted = document.querySelector('#TableOfContents .is-active a');
+    const currentHighlighted = document.querySelector('.TableOfContents .is-active a');
     const currentHighlightedHref = currentHighlighted ? currentHighlighted.getAttribute('href') : null;
     if (top < 240 && currentHighlightedHref !== '#' + id) {
       removeActiveFromAllAnchors();
-      const highlightedHref = document.querySelector('#TableOfContents a[href="#' + id + '"]');
+      const highlightedHref = document.querySelector('.TableOfContents a[href="#' + id + '"]');
       highlightedHref.parentElement.classList.add('is-active');
       //highlightedHref.parentElement.scrollIntoView({behavior: "smooth", block: "nearest" });
     }
@@ -407,7 +407,7 @@ function aliazeLinks(parentSelector, linkSelector) {
 }
 
 function setVersionSelector(version) {
-  for(let option of document.getElementById("arangodb-version").options) {
+  for(let option of document.querySelector(".arangodb-version").options) {
     if (option.value == version) {
       option.selected = true;
     }
@@ -435,7 +435,7 @@ function getCurrentVersion() {
 
 function changeVersion() {
     var oldVersion = localStorage.getItem('docs-version');
-    var versionSelector = document.getElementById("arangodb-version");
+    var versionSelector = document.querySelector(".arangodb-version");
     var newVersion  = versionSelector.options[versionSelector.selectedIndex].value;
 
     try {
@@ -566,12 +566,11 @@ window.onload = () => {
     window.history.pushState("popstate", "ArangoDB Documentation", window.location.href);
     trackPageView(document.title, window.location.pathname);
 
-    var iframe =  document.getElementById('menu-iframe');
+    var iframe =  document.querySelector('.menu-iframe');
     var iFrameBody = iframe.contentDocument || iframe.contentWindow.document;
-    content = iFrameBody.getElementById('sidebar');
+    content = iFrameBody.querySelector('.sidebar');
 
-    $("#menu-iframe").replaceWith(content);
-
+    iframe.replaceWith(content);
 
     getCurrentVersion(window.location.href);
     menuEntryClickListener();
@@ -590,9 +589,9 @@ window.onload = () => {
 
     var isMobile = window.innerWidth <= 768;
     if (isMobile) {
-        $('#sidebar').addClass("mobile");
-        $('#sidebar.mobile').removeClass("active");
+        $('.sidebar').addClass("mobile");
+        $('.sidebar.mobile').removeClass("active");
     }
 
-    $('#page-wrapper').css("opacity", "1")
+    $('.page-wrapper').css("opacity", "1")
 }


### PR DESCRIPTION
### Description

This avoids potential clashes between the identifiers used in the layout and the fragment IDs created for the content.
It fixes at least one conflict between the #header styling and the Foxx content with a headline "header":

<img width="1157" height="606" alt="image" src="https://github.com/user-attachments/assets/f6094a97-54dc-4b1c-8cdc-e1e2bec5eda1" />


#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
