### PR TITLE
Move the deferred template call to baseof.html

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/_default/baseof.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/baseof.html
@@ -27,3 +27,9 @@
     {{ if $isProduction }}{{ partialCached "tracking/body-end.html" . }}{{ end -}}
   </body>
 </html>
+{{- /* Trigger validation at the end of the build once */ -}}
+{{ if .IsHome -}}
+  {{ with templates.Defer -}}
+    {{ partial "openapi-validate.html" (dict "key" "global") -}}
+  {{ end -}}
+{{ end -}}

--- a/site/themes/arangodb-docs-theme/layouts/_default/home.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/home.html
@@ -10,8 +10,4 @@
       {{ .Content | safeHTML }}
     </article>
   {{- end -}}
-  {{/* Trigger validation at the end of the build (kind "home" is called once) */ -}}
-  {{ with templates.Defer -}}
-    {{ partial "openapi-validate.html" -}}
-  {{ end -}}
 {{ end -}}


### PR DESCRIPTION
### Description

This is an attempt to fix "can't evaluate field Defer in type interface {}" error on macOS when running the toolchain locally.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
