### PR TITLE
DOC-807 | Move Graph Analytics content into GenAI

### DIFF
--- a/site/content/3.12/about-arangodb/features/platform.md
+++ b/site/content/3.12/about-arangodb/features/platform.md
@@ -38,7 +38,7 @@ deploy and use it, see [The ArangoDB Platform](../../components/platform.md).
   A web-based tool for exploring your graph data with an intuitive interface and
   sophisticated querying capabilities.
 
-- [**Graph Analytics**](../../graphs/graph-analytics.md):
+- [**Graph Analytics**](../../data-science/graph-analytics.md):
   A service that can efficiently load graph data from the core database system
   and run graph algorithms such as PageRank and many more.
 

--- a/site/content/3.12/data-science/_index.md
+++ b/site/content/3.12/data-science/_index.md
@@ -50,6 +50,8 @@ Alongside these components, you also get the following additional features:
 
 - [**Graph Visualizer**](../graphs/graph-visualizer.md): A web-based tool for exploring your graph data with an
   intuitive interface and sophisticated querying capabilities.
+- [**Graph Analytics**](graph-analytics.md): Run graph algorithms such as PageRank
+  on dedicated compute resources.  
 - [**Jupyter notebooks**](notebook-servers.md): Run a Jupyter kernel in the platform for hosting
   interactive notebooks for experimentation and development of applications
   that use ArangoDB as their backend.
@@ -63,14 +65,6 @@ Alongside these components, you also get the following additional features:
   GenAI Suite services and build your own integrations. See the
   [API reference](https://arangoml.github.io/platform-dss-api/GenAI-Service/proto/index.html) documentation
   for more details.
-
-## Other tools and features
-
-The ArangoDB Platform includes the following features independent of the
-GenAI Suite:
-
-- [**Graph Analytics**](../graphs/graph-analytics.md): Run graph algorithms such as PageRank
-  on dedicated compute resources.
 
 ## From graph to AI
 
@@ -106,7 +100,7 @@ Graph analytics can answer questions like _**Who are the most connected persons*
 ArangoDB offers _Graph Analytics Engines_ to run algorithms such as
 connected components, label propagation, and PageRank on your data. This feature
 is available for the ArangoGraph Insights Platform. See 
-[Graph Analytics](../graphs/graph-analytics.md) for details.
+[Graph Analytics](graph-analytics.md) for details.
 
 ### GraphML
 

--- a/site/content/3.12/data-science/graph-analytics.md
+++ b/site/content/3.12/data-science/graph-analytics.md
@@ -3,10 +3,10 @@ title: Graph Analytics
 menuTitle: Graph Analytics
 weight: 115
 description: |
-  ArangoGraph offers Graph Analytics Engines to run graph algorithms on your
-  data separately from your ArangoDB deployments
+  Graph analytics analyzes information networks to extract insights from data
+  relationships using algorithms like PageRank for fraud detection, recommendations, and network analysis
 aliases:
-  - ../data-science/graph-analytics
+  - ../graphs/graph-analytics  
 ---
 {{< tag "ArangoDB Platform" "ArangoGraph" >}}
 

--- a/site/content/3.13/about-arangodb/features/platform.md
+++ b/site/content/3.13/about-arangodb/features/platform.md
@@ -38,7 +38,7 @@ deploy and use it, see [The ArangoDB Platform](../../components/platform.md).
   A web-based tool for exploring your graph data with an intuitive interface and
   sophisticated querying capabilities.
 
-- [**Graph Analytics**](../../graphs/graph-analytics.md):
+- [**Graph Analytics**](../../data-science/graph-analytics.md):
   A service that can efficiently load graph data from the core database system
   and run graph algorithms such as PageRank and many more.
 

--- a/site/content/3.13/data-science/_index.md
+++ b/site/content/3.13/data-science/_index.md
@@ -50,6 +50,8 @@ Alongside these components, you also get the following additional features:
 
 - [**Graph Visualizer**](../graphs/graph-visualizer.md): A web-based tool for exploring your graph data with an
   intuitive interface and sophisticated querying capabilities.
+- [**Graph Analytics**](graph-analytics.md): Run graph algorithms such as PageRank
+  on dedicated compute resources.
 - [**Jupyter notebooks**](notebook-servers.md): Run a Jupyter kernel in the platform for hosting
   interactive notebooks for experimentation and development of applications
   that use ArangoDB as their backend.
@@ -63,14 +65,6 @@ Alongside these components, you also get the following additional features:
   GenAI Suite services and build your own integrations. See the
   [API reference](https://arangoml.github.io/platform-dss-api/GenAI-Service/proto/index.html) documentation
   for more details.
-
-## Other tools and features
-
-The ArangoDB Platform includes the following features independent of the
-GenAI Suite:
-
-- [**Graph Analytics**](../graphs/graph-analytics.md): Run graph algorithms such as PageRank
-  on dedicated compute resources.
 
 ## From graph to AI
 
@@ -106,7 +100,7 @@ Graph analytics can answer questions like _**Who are the most connected persons*
 ArangoDB offers _Graph Analytics Engines_ to run algorithms such as
 connected components, label propagation, and PageRank on your data. This feature
 is available for the ArangoGraph Insights Platform. See 
-[Graph Analytics](../graphs/graph-analytics.md) for details.
+[Graph Analytics](graph-analytics.md) for details.
 
 ### GraphML
 

--- a/site/content/3.13/data-science/graph-analytics.md
+++ b/site/content/3.13/data-science/graph-analytics.md
@@ -3,10 +3,10 @@ title: Graph Analytics
 menuTitle: Graph Analytics
 weight: 115
 description: |
-  ArangoGraph offers Graph Analytics Engines to run graph algorithms on your
-  data separately from your ArangoDB deployments
+  Graph analytics analyzes information networks to extract insights from data
+  relationships using algorithms like PageRank for fraud detection, recommendations, and network analysis
 aliases:
-  - ../data-science/graph-analytics
+  - ../graphs/graph-analytics
 ---
 {{< tag "ArangoDB Platform" "ArangoGraph" >}}
 


### PR DESCRIPTION
### Description

Move Graph Analytics content into GenAI chapter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relocates Graph Analytics docs under Data Science/GenAI, updates all links and references, adds aliases, and refines page descriptions.
> 
> - **Docs restructure**
>   - **Graph Analytics**: Moved from `../graphs/graph-analytics.md` to `../data-science/graph-analytics.md` (3.12, 3.13).
>     - Updated links in `about-arangodb/features/platform.md` and `data-science/_index.md` to `data-science/graph-analytics.md`.
>     - Added alias `../graphs/graph-analytics` in `data-science/graph-analytics.md` (3.12, 3.13) for backwards compatibility.
>     - Replaced "Other tools and features" section by integrating Graph Analytics into the GenAI/Data Science features list.
>     - Refined `description` text on `data-science/graph-analytics.md` to a concise definition and use cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd5fda88f000d94b002f8361aa6425e6d1454d27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->