### PR TITLE
DOC-816 | Deduced vertex collections from named graphs

### DIFF
--- a/site/content/3.12/aql/graphs/traversals.md
+++ b/site/content/3.12/aql/graphs/traversals.md
@@ -346,6 +346,12 @@ Use the [`WITH` statement](../high-level-operations/with.md) to specify the coll
 expect to be involved. This is required for traversals using collection sets
 in cluster deployments.
 
+{{< tip >}}
+From v3.12.6 onward, vertex collections are automatically deduced for graph
+queries using collection sets / anonymous graphs if there is a named graph with
+a matching edge collection in its edge definitions.
+{{< /tio >}}
+
 ## Pruning
 
 You can define stop conditions for graph traversals to return specific data and


### PR DESCRIPTION
### Description

TODO:
- [ ] Clarify discrepancy between single server `--query.require-with` and cluster deployment - the latter also requires the declaration of the traversal start node collection
- [ ] Add detailed description of the automatic inferrence to the traversal and path search pages, possibly make it a separate section everywhere
- [ ] Apply to 3.13

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 3.13: 
