### PR TITLE
DOC-870 | GraphRAG UI: Highlight graph metadata

### DIFF
--- a/site/content/agentic-ai-suite/graphrag/web-interface.md
+++ b/site/content/agentic-ai-suite/graphrag/web-interface.md
@@ -286,8 +286,8 @@ retriever-sourced elements are highlighted in green on the canvas so you can
 immediately see which parts of your Knowledge Graph contributed to the answer.
 A loading overlay is shown on the canvas while the graph data is being fetched.
 
-Each assistant message in the chat includes two canvas action buttons that appear
-when you hover over the message:
+Each assistant message in the chat includes two additional action buttons that appear
+when you hover over the message (alongside the copy button):
 
 | Button | Icon | Behavior |
 |--------|------|----------|
@@ -305,6 +305,6 @@ response before the new results are fetched.
 
 To integrate any service into your own applications,
 go to **Project Settings** and use the copy button next to each service to
-copy its integration endpoint. You cam make `POST` requests to the endpoints
+copy its integration endpoint. You can make `POST` requests to the endpoints
 with your queries, the services accept `JSON` payloads and return structured
 responses for building custom interfaces.

--- a/site/content/agentic-ai-suite/graphrag/web-interface.md
+++ b/site/content/agentic-ai-suite/graphrag/web-interface.md
@@ -278,6 +278,29 @@ In addition to querying the Knowledge Graph, the chat service allows you to do t
   Enabling caching improves response times for repeated queries. Leave it disabled when you need fresh results or when testing changes to your knowledge graph.
 - Toggle **Citations** to show or hide inline citations in responses. For deep search queries, citations are always disabled.
 
+## Graph canvas integration
+
+When the Retriever returns a response, the graph canvas automatically fetches and
+displays the documents and edges that were used to answer your query. These
+retriever-sourced elements are highlighted in green on the canvas so you can
+immediately see which parts of your Knowledge Graph contributed to the answer.
+A loading overlay is shown on the canvas while the graph data is being fetched.
+
+Each assistant message in the chat includes two canvas action buttons that appear
+when you hover over the message:
+
+| Button | Icon | Behavior |
+|--------|------|----------|
+| **Add to canvas** | Hub icon | Fetches the subgraph for that message and merges it into the existing canvas, preserving any nodes already displayed. |
+| **Clear canvas & display subgraph** | Focus icon | Clears the canvas and displays only the subgraph referenced by that message. |
+
+Use **Add to canvas** to build up context across multiple queries. Use **Clear
+canvas & display subgraph** to focus on a single response without the clutter of
+previous results.
+
+Starting a new query automatically clears the green highlights from the previous
+response before the new results are fetched.
+
 ## Integrate the Knowledge Graph chat service into your application
 
 To integrate any service into your own applications,


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Graph canvas integration" details: automatic fetching and rendering of documents/edges from retriever results, green highlighting of retriever-sourced elements, loading overlays, and automatic clearing of prior highlights on new queries.
  * Documented two per-message hover actions: "Add to canvas" (merge subgraph, preserve existing nodes) and "Clear canvas & display subgraph" (show only selected subgraph).
  * Fixed a minor typo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->