### PR TITLE
Don't conditionally load Mermaid support

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,4 +1,3 @@
 <pre class="mermaid">
   {{- .Inner | htmlEscape | safeHTML -}}
 </pre>
-{{ .Page.Store.Set "hasMermaid" true }}

--- a/site/themes/arangodb-docs-theme/layouts/_default/baseof.html
+++ b/site/themes/arangodb-docs-theme/layouts/_default/baseof.html
@@ -28,17 +28,5 @@
     </section>
     {{ partialCached "back-to-top.html" . -}}
     {{ partialCached "search.html" . -}}
-    {{- if .Store.Get "hasMermaid" }}
-    <script type="module">
-      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.esm.min.mjs';
-      mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
-      function renderMermaid() {
-        const nodes = document.querySelectorAll('.mermaid:not([data-processed])');
-        if (nodes.length) mermaid.run({ nodes });
-      }
-      renderMermaid();
-      new MutationObserver(renderMermaid).observe(document.body, { childList: true, subtree: true });
-    </script>
-    {{- end }}
   </body>
 </html>

--- a/site/themes/arangodb-docs-theme/static/js/theme.js
+++ b/site/themes/arangodb-docs-theme/static/js/theme.js
@@ -1,5 +1,29 @@
 var theme = true;
 
+var _mermaidModule = null;
+var _mermaidRendering = false;
+var _mermaidQueued = false;
+
+async function initMermaid() {
+  if (_mermaidRendering) { _mermaidQueued = true; return; }
+  var nodes = document.querySelectorAll('.mermaid:not([data-processed])');
+  if (!nodes.length) return;
+  if (!_mermaidModule) {
+    var mod = await import('https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.esm.min.mjs');
+    _mermaidModule = mod.default;
+    _mermaidModule.initialize({ startOnLoad: false, theme: 'neutral' });
+  }
+  _mermaidRendering = true;
+  try {
+    await _mermaidModule.run({ nodes: nodes });
+  } catch (e) {
+    console.warn('Mermaid rendering error:', e);
+  } finally {
+    _mermaidRendering = false;
+    if (_mermaidQueued) { _mermaidQueued = false; initMermaid(); }
+  }
+}
+
 function closeAllEntries() {
     document.querySelectorAll(".main-nav-ol .expand-nav > input:checked").forEach(el => el.checked = false);
 }
@@ -264,6 +288,7 @@ function initArticle(url) {
   linkToVersionedContent();
   updateActiveNavItem(window.location.pathname, false);
   updateVersionSelector();
+  initMermaid();
 }
 
 


### PR DESCRIPTION
### Description

If you start on a page without Mermaid diagram, the module is never loaded because we dynamically load content and only replace the `<article>`

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Mermaid diagram rendering from template-driven automatic loading to JavaScript-based lazy initialization.
  * Diagrams now render on-demand when articles are loaded or updated in the documentation.
  * Added concurrency control to manage simultaneous rendering requests and improved error handling for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->