### PR TITLE
DOC-886 | Importer service: restructure and latest updates

### DIFF
--- a/site/content/agentic-ai-suite/autograph/reference/orchestration.md
+++ b/site/content/agentic-ai-suite/autograph/reference/orchestration.md
@@ -85,5 +85,5 @@ curl -X POST \
 ## Next Steps
 
 - **[Retriever Setup](../../reference/retriever/)**: Query your built knowledge graphs
-- **[Monitor Results](../../reference/importer/verify-and-explore.md)**: Verify import success
+- **[Monitor Results](../../importer/verify-and-explore.md)**: Verify import success
 - **[Design Guide - Modules to partitions](../design-guide.md#how-modules-become-a-partitioned-knowledge-graph)**: How module names flow into partition IDs

--- a/site/content/agentic-ai-suite/graphrag/_index.md
+++ b/site/content/agentic-ai-suite/graphrag/_index.md
@@ -73,5 +73,5 @@ conceptual understanding.
 - **[GraphRAG Tutorial using integrated Notebook servers](tutorial-notebook.md)**: Follow hands-on examples and implementation guidance via Jupyter Notebooks.
 
 For deeper implementation details, explore the individual services:
-- **[Importer Service](../reference/importer.md)**: Transform documents into knowledge graphs.
+- **[Importer Service](../importer/)**: Transform documents into knowledge graphs.
 - **[Retriever Service](../reference/retriever/_index.md)**: Query and extract insights from your knowledge graphs.

--- a/site/content/agentic-ai-suite/graphrag/technical-overview.md
+++ b/site/content/agentic-ai-suite/graphrag/technical-overview.md
@@ -61,7 +61,7 @@ The web interface guides you through the process of the following:
 
 ### API and Services
 
-The [Importer](../reference/importer.md) and [Retriever](../reference/retriever/_index.md)
+The [Importer](../importer/) and [Retriever](../reference/retriever/_index.md)
 services provide programmatic access to create and manage GraphRAG pipelines,
 and give you access to advanced search methods.
 
@@ -99,7 +99,7 @@ information in a structured graph format, allowing efficient querying and retrie
 3. Store the generated Knowledge Graph in the database for retrieval and reasoning.
 
 For detailed information about the service, see the
-[Importer](../reference/importer/) service documentation.
+[Importer](../importer/) service documentation.
 
 ### Query your Knowledge Graph
 
@@ -146,7 +146,7 @@ OpenAI, OpenRouter, Google Gemini, Anthropic Claude, and any corporate or self-h
 LLM with OpenAI-compatible endpoints.
 
 For detailed configuration examples, see:
-- [Importer - Deployment Options](../reference/importer.md#deployment-options)
+- [Importer - Deployment Options](../importer/#deployment-options)
 - [Retriever - Installation](../reference/retriever/_index.md)
 
 ## Limitations

--- a/site/content/agentic-ai-suite/graphrag/web-interface.md
+++ b/site/content/agentic-ai-suite/graphrag/web-interface.md
@@ -89,7 +89,7 @@ service automatically downloads and loads models from the MLflow registry.
 
 {{< /tabs >}}
 
-See also the [Importer](../reference/importer/) service documentation.
+See also the [Importer](../importer/) service documentation.
 
 ## Update Importer service parameters
 

--- a/site/content/agentic-ai-suite/importer/_index.md
+++ b/site/content/agentic-ai-suite/importer/_index.md
@@ -4,14 +4,18 @@ menuTitle: Importer
 description: >-
   The Importer service helps you transform your text documents into a knowledge graph,
   making it easier to analyze and understand complex information
-weight: 10
+weight: 6
 ---
 ## Overview
 
-The Importer service lets you turn text files into a knowledge graph.
-It supports the following text formats with UTF-8 encoding:
+The Importer service lets you turn documents into a knowledge graph.
+It supports the following formats with UTF-8 encoding:
 - `.txt` (Plain text)
 - `.md` (Markdown)
+- `.pdf` (PDF)
+
+Office files (e.g., `.docx`, `.pptx`) and images are converted to PDF
+first and then processed through the same pipeline.
 
 The Importer takes your text, analyzes it using the configured language model, and
 creates a structured knowledge graph. This graph is then imported into your
@@ -25,7 +29,7 @@ The service supports two operational modes:
 
 {{< tip >}}
 You can also use the GraphRAG Importer service via the
-[Contextual Data Platform web interface](../../graphrag/web-interface.md).
+[Contextual Data Platform web interface](../graphrag/web-interface.md).
 {{< /tip >}}
 
 ## Prerequisites
@@ -34,20 +38,35 @@ Before importing data, you need to create a GraphRAG project. Projects help you
 organize your work and keep your data separate from other projects.
 
 For detailed instructions on creating and managing projects, see the 
-[Projects](../../../platform-suite/control-plane-acp.md#projects) section in
+[Projects](../../platform-suite/control-plane-acp.md#projects) section in
 the Arango Control Plane (ACP) service documentation.
 
 Once you have created a project, you can reference it when deploying the Importer 
 service using the `project_name` field in the service configuration.
 
+{{< warning >}}
+Because `project_name` is used as an ArangoDB collection name prefix,
+it must conform to ArangoDB naming rules:
+- Must start with a letter or underscore.
+- May only contain letters, digits, underscores (`_`), or hyphens (`-`).
+- Must not exceed 256 characters (including suffixes such as `_Documents`).
+
+If `project_name` is not set, the service falls back to `default_project`.
+An invalid name is not validated at startup and causes collection creation to
+fail at runtime.
+{{< /warning >}}
+
 ## Installation
 
-To install and start the Importer service, use the AI service endpoint
-`/v1/graphragimporter`. This endpoint is part of the Arango Control Plane (ACP)
-service, which manages the lifecycle of all AI services in the platform.
+To install and start the Importer service, use the AI service endpoint:
+
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/graphragimporter" >}}
+
+This endpoint is part of the Arango Control Plane (ACP) service, which manages
+the lifecycle of all AI services in the platform.
 
 For detailed instructions on installing, monitoring, and managing the Importer service, 
-see [The Arango Control Plane (ACP) service](../../../platform-suite/control-plane-acp.md)
+see [The Arango Control Plane (ACP) service](../../platform-suite/control-plane-acp.md)
 documentation.
 
 ## Deployment options
@@ -71,7 +90,7 @@ both HTTP and gRPC interfaces for communication.
 Arango's AI Services are fully compatible with OpenAI-compatible APIs, whether
 cloud-based or self-hosted.
 
-Thus, you can connects to cloud-based services like OpenAI's models via the
+Thus, you can connect to cloud-based services like OpenAI's models via the
 OpenAI API or a large array of models (Gemini, Anthropic, publicly hosted
 open-source models, etc.) via the OpenRouter option, as well as private Azure
 endpoints.
@@ -83,7 +102,7 @@ OpenAI-compatible endpoint.
 
 To use the Importer service, follow these steps:
 
-1. [**Create a GraphRAG project**](../../../platform-suite/control-plane-acp.md#creating-a-project):
+1. [**Create a GraphRAG project**](../../platform-suite/control-plane-acp.md#creating-a-project):
    Set up a project to organize your data.
 2. [**Configure your LLM provider**](llm-configuration.md):
    Choose and configure either Triton or OpenAI-compatible APIs.
@@ -96,9 +115,10 @@ To use the Importer service, follow these steps:
 **Additional resources:**
 
 - [**Semantic Units**](semantic-units.md): Process images and multimedia content.
+- [**AutoGraph Integration**](autograph-integration.md): How the Importer works with AutoGraph for automated pipeline builds.
 - [**Parameter Reference**](parameters.md): Complete list of import parameters.
 
 ## API Reference
 
-For detailed API documentation, see the <!-- TODO: New API reference and link -->
-[GraphRAG Importer API Reference](https://arangoml.github.io/platform-dss-api/graphrag_importer/proto/index.html).
+For detailed API documentation, see the
+[GraphRAG Importer API Reference](https://apiref.arango.ai/#graphrag_importer).

--- a/site/content/agentic-ai-suite/importer/autograph-integration.md
+++ b/site/content/agentic-ai-suite/importer/autograph-integration.md
@@ -1,0 +1,133 @@
+---
+title: Integration with AutoGraph
+menuTitle: AutoGraph Integration
+description: >-
+  How the Importer service integrates with AutoGraph for automated, partition-aware knowledge graph builds
+weight: 55
+---
+
+## When to use the Importer standalone vs. with AutoGraph
+
+The Importer supports two distinct usage patterns depending on your needs.
+
+### Standalone Importer (GraphRAG without partitioning)
+
+If you are building a single knowledge graph from your documents and do not
+need multiple partitions or automated domain discovery, use the Importer
+directly. You can call it through:
+
+- The [Contextual Data Platform web interface](../graphrag/web-interface.md),
+  which guides you through configuring and running the Importer step by step.
+- The [Import API](importing-files.md) (`POST /v1/import` or
+  `POST /v1/import-multiple`), which gives you full control over all parameters.
+
+In this mode, you manage the Importer lifecycle yourself: you install it,
+submit import requests, and monitor the results.
+
+### Automated via AutoGraph (multi-partition, strategy-aware builds)
+
+When you need to process large or heterogeneous document collections,
+[AutoGraph](../autograph/) manages the Importer for you. AutoGraph
+automatically discovers knowledge domains in your data, assigns the optimal
+RAG strategy (`full_graphrag` or `vector_rag`) per domain, and spawns
+Importer workers to build partitioned knowledge graphs.
+
+In this mode, you **do not call the Importer directly**. AutoGraph handles
+replica creation, job submission, `partition_id` and `rag_mode` assignment,
+status polling, and teardown.
+
+The rest of this page explains how this automated flow works.
+
+## Three-layer architecture
+
+AutoGraph organizes data across three layers. Each layer has a clear owner
+and purpose:
+
+| Layer | Built by | Named Graph | What it contains |
+|-------|----------|-------------|------------------|
+| **1 - Modules** | You (at import time) | - | Logical groupings of documents (e.g., `"legal"`, `"docs"`, `"support"`) |
+| **2 - Corpus Graph** | AutoGraph | `{project}_CorpusGraph` | Document similarity edges, Leiden clusters (`domains`), RAG strategy profiles (`rags`) |
+| **3 - Knowledge Graph** | Importer | `{project}_kg` | Documents, Chunks, Entities, Communities, Relations |
+
+The Importer builds **Layer 3 only**. All Layer 3 collections carry a
+`partition_id` field so that data from different clusters coexists in the
+same collections.
+
+For full details on Layers 1 and 2, see the
+[AutoGraph Architecture](../autograph/architecture.md) documentation.
+
+## How AutoGraph spawns import jobs
+
+The same module string flows from **files** to **clusters** to **strategies**
+to **Importer partitions**:
+
+1. You [import documents into AutoGraph](../autograph/reference/importing-files.md)
+   with a **module** label (e.g., `"legal"`).
+2. AutoGraph's [corpus build](../autograph/reference/corpus-build.md) clusters
+   documents within each module using Leiden community detection.
+3. The [RAG strategizer](../autograph/reference/rag-strategizer.md) analyzes
+   each cluster and assigns either `FullGraphRAG` or `VectorRAG`.
+4. Each assignment gets a `rag_partition_id` derived from the cluster key.
+   For example, cluster `cluster_legal_0` becomes `legal_0_a` (FullGraphRAG)
+   or `legal_0_b` (VectorRAG).
+5. [Orchestration](../autograph/reference/orchestration.md)
+   (`POST /v1/orchestrate`) spawns Importer worker replicas and submits
+   **one import job per partition**.
+6. Each job payload includes `partition_id` (set to the `rag_partition_id`)
+   and `rag_mode` (set to the assigned strategy).
+
+```mermaid
+flowchart LR
+  module["Module<br><b>legal</b>"]
+
+  module --> cluster0["cluster_legal_0"]
+  module --> cluster1["cluster_legal_1"]
+  module --> cluster2["cluster_legal_2"]
+
+  cluster0 -->|full_graphrag| part0["Partition<br><b>legal_0_a</b>"]
+  cluster1 -->|full_graphrag| part1["Partition<br><b>legal_1_a</b>"]
+  cluster2 -->|vector_rag| part2["Partition<br><b>legal_2_b</b>"]
+
+  part0 --> orch["Orchestration"]
+  part1 --> orch
+  part2 --> orch
+
+  orch --> job0["Importer job 1"]
+  orch --> job1["Importer job 2"]
+  orch --> job2["Importer job 3"]
+```
+
+Under normal operation you **do not call the Importer directly**; AutoGraph
+handles replica creation, job submission, status polling, and teardown. Call
+the Importer yourself only for standalone imports or advanced scenarios
+(e.g., re-running a single partition with custom settings).
+
+## How `partition_id` maps to the Corpus Graph
+
+- AutoGraph's `rag_partition_id` (cluster key + strategy suffix `_a`/`_b`)
+  is passed as `partition_id` in the import request payload.
+- The Importer stores this value on **every** document, chunk, entity,
+  community, and relation in the Knowledge Graph.
+- Multiple partitions coexist in the same ArangoDB collections; filter by
+  `partition_id` when querying.
+- When inspecting Layer 3 data, the `partition_id` traces back to a specific
+  Leiden cluster and its RAG strategy in the Corpus Graph.
+
+When using the Importer **standalone** (without AutoGraph), you can set
+`partition_id` to any string to logically separate different import batches
+within the same collections. See the
+[`partition_id` parameter reference](parameters.md#partition_id) for details.
+
+## Related resources
+
+- **[AutoGraph overview](../autograph/)**: What AutoGraph is and why to use it.
+- **[AutoGraph Architecture](../autograph/architecture.md)**: The three-layer
+  knowledge graph architecture and ArangoDB collections.
+- **[AutoGraph Design Guide](../autograph/design-guide.md)**: How to structure
+  your data with modules and layers.
+- **[Corpus Build](../autograph/reference/corpus-build.md)**: Create and
+  monitor corpus builds for document clustering.
+- **[RAG Strategizer](../autograph/reference/rag-strategizer.md)**: Analyze
+  clusters and assign RAG strategies.
+- **[Orchestration](../autograph/reference/orchestration.md)**: Spawn Importer
+  workers and execute pipeline builds.

--- a/site/content/agentic-ai-suite/importer/importing-files.md
+++ b/site/content/agentic-ai-suite/importer/importing-files.md
@@ -15,11 +15,11 @@ weight: 30
 Before you can import files, make sure you've completed these steps:
 
 1. **Create a GraphRAG project**
-   Learn how to [create and manage projects](../../../platform-suite/control-plane-acp.md#projects).
+   Learn how to [create and manage projects](../../platform-suite/control-plane-acp.md#projects).
 
 2. **Install the Importer service**
    Deploy the service using the `/v1/graphragimporter` endpoint. See
-   [The Arango Control Plane (ACP) service](../../../platform-suite/control-plane-acp.md)
+   [The Arango Control Plane (ACP) service](../../platform-suite/control-plane-acp.md)
    documentation for installation instructions.
 
 3. **Configure your LLM provider**
@@ -27,6 +27,11 @@ Before you can import files, make sure you've completed these steps:
 
 Once you've completed these steps, you're ready to import documents to build 
 your Knowledge Graph using either single file import or multi-file import.
+
+{{< info >}}
+Platform routes require authentication. Include a standard `Authorization`
+header (e.g., `Bearer <token>`) on all import requests.
+{{< /info >}}
 
 ## Choosing a RAG Mode
 
@@ -46,9 +51,7 @@ Use single file import when you want to process one document at a time. This is
 ideal for testing, small documents, or when you need immediate feedback without 
 streaming progress updates.
 
-```
-POST /v1/import
-```
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import" >}}
 
 ### Basic example
 
@@ -57,8 +60,9 @@ POST /v1/import
 base64_content=$(base64 -i your_document.txt)
 
 # Send to the Importer service
-curl -X POST https://<your-platform-url>/v1/import \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
     "file_content": "'$base64_content'",
     "file_name": "your_document.txt"
@@ -68,14 +72,15 @@ curl -X POST https://<your-platform-url>/v1/import \
 ### Example with common parameters
 
 ```bash
-curl -X POST https://<your-platform-url>/v1/import \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
     "file_content": "'$base64_content'",
     "file_name": "your_document.txt",
     "batch_size": 1000,
-    "chunk_token_size": 1200,
-    "chunk_overlap_token_size": 100,
+    "chunk_token_size": 1024,
+    "chunk_overlap_token_size": 128,
     "entity_types": ["person", "organization", "location", "event"],
     "relationship_types": ["WORKS_FOR", "LOCATED_IN", "PARTICIPATES_IN"],
     "enable_chunk_embeddings": false,
@@ -83,8 +88,6 @@ curl -X POST https://<your-platform-url>/v1/import \
     "enable_community_embeddings": true
   }'
 ```
-
-Replace `<your-platform-url>` with your Arango Contextual Data Platform URL.
 
 The service will:
 - Process the document using the configured LLM model.
@@ -100,16 +103,14 @@ Use multi-file import when you need to process multiple documents into a single
 Knowledge Graph. This API provides streaming progress updates, making it 
 ideal for batch processing and long-running imports where you need to track progress.
 
-```
-POST /v1/import-multiple
-```
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple" >}}
 
 ### Basic example
 
 ```bash
-# Create JSON payload with multiple files
-curl -X POST https://<your-platform-url>/v1/import-multiple \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
     "files": [
       {
@@ -124,16 +125,14 @@ curl -X POST https://<your-platform-url>/v1/import-multiple \
       }
     ],
     "batch_size": 1000,
-    "chunk_token_size": 1200,
-    "chunk_overlap_token_size": 100,
+    "chunk_token_size": 1024,
+    "chunk_overlap_token_size": 128,
     "entity_types": ["person", "organization", "location", "event"],
     "enable_chunk_embeddings": true,
     "enable_community_embeddings": true,
     "vector_index_metric": "cosine"
   }'
 ```
-
-Replace `<your-platform-url>` with your Arango Contextual Data Platform URL.
 
 For detailed information about all available parameters, see the [Import Parameters Reference](parameters.md).
 
@@ -142,8 +141,9 @@ For detailed information about all available parameters, see the [Import Paramet
 For faster processing when you only need semantic search over document chunks:
 
 ```bash
-curl -X POST https://<your-platform-url>/v1/import-multiple \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
     "files": [
       {
@@ -159,8 +159,8 @@ curl -X POST https://<your-platform-url>/v1/import-multiple \
     ],
     "rag_mode": "vector_rag",
     "batch_size": 1000,
-    "chunk_token_size": 1200,
-    "chunk_overlap_token_size": 100,
+    "chunk_token_size": 1024,
+    "chunk_overlap_token_size": 128,
     "vector_index_metric": "cosine"
   }'
 ```
@@ -193,8 +193,8 @@ This comprehensive example demonstrates all available import parameters for the 
   "enable_chunk_embeddings": true,
   "enable_edge_embeddings": true,
   "enable_community_embeddings": true,
-  "chunk_token_size": 1200,
-  "chunk_overlap_token_size": 100,
+  "chunk_token_size": 1024,
+  "chunk_overlap_token_size": 128,
   "chunk_min_token_size": 50,
   "chunk_custom_separators": [
     "\n\n",
@@ -292,7 +292,7 @@ data: {"type": "IMPORT_PROGRESS_TYPE_COMPLETED", "message": "Import completed su
 Use curl to view the raw SSE stream as it arrives:
 
 ```bash
-curl -X POST https://<your-platform-url>/v1/import-multiple \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   --no-buffer \
@@ -319,7 +319,7 @@ When using Python, you must parse the SSE format and strip the `data: ` prefix:
 import requests
 import json
 
-url = "https://<your-platform-url>/v1/import-multiple"
+url = "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple"
 payload = {
     "files": [
         {
@@ -334,7 +334,7 @@ payload = {
         }
     ],
     "batch_size": 1000,
-    "chunk_token_size": 1200,
+    "chunk_token_size": 1024,
     "enable_chunk_embeddings": True,
     "enable_community_embeddings": True,
     "vector_index_metric": "cosine"
@@ -376,6 +376,29 @@ for line in response.iter_lines():
             # Skip malformed lines
             continue
 ```
+
+## Job Management and Health
+
+The Importer service provides additional endpoints for monitoring import jobs
+and checking service health.
+
+### Check job status
+
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/jobs/{job_id}" >}}
+
+Returns the current status of a specific import job.
+
+### List all jobs
+
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/jobs" >}}
+
+Returns a list of all import jobs and their statuses.
+
+### Health check
+
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/health" >}}
+
+Returns the health status of the Importer service.
 
 ## Next Steps
 

--- a/site/content/agentic-ai-suite/importer/llm-configuration.md
+++ b/site/content/agentic-ai-suite/importer/llm-configuration.md
@@ -32,7 +32,7 @@ Set the `chat_api_url` and `embedding_api_url` to point to your provider's endpo
 {
   "env": {
     "db_name": "your_database_name",
-    "genai_project_name": "your_project_name",
+    "project_name": "your_project_name",
     "chat_api_provider": "openai",
     "chat_api_url": "https://api.openai.com/v1",
     "embedding_api_provider": "openai",
@@ -48,7 +48,7 @@ Set the `chat_api_url` and `embedding_api_url` to point to your provider's endpo
 
 Where:
 - `db_name`: Name of the ArangoDB database where the knowledge graph will be stored
-- `genai_project_name`: The project name created via the
+- `project_name`: The project name created via the
    [web interface](../graphrag/web-interface.md#create-a-graphrag-project) or
   [Project API](../../platform-suite/control-plane-acp.md#creating-a-project).
   This name is used as a prefix for all ArangoDB collections (for example, a
@@ -98,12 +98,12 @@ different URLs in `chat_api_url` and `embedding_api_url`.
 {
   "env": {
     "db_name": "your_database_name",
-    "genai_project_name": "your_project_name",
+    "project_name": "your_project_name",
     "chat_api_provider": "openai",
     "embedding_api_provider": "openai",
     "chat_api_url": "https://openrouter.ai/api/v1",
     "embedding_api_url": "https://api.openai.com/v1",
-    "chat_model": "mistral-nemo",
+    "chat_model": "mistralai/mistral-nemo",
     "embedding_model": "text-embedding-3-small",
     "chat_api_key": "your_openrouter_api_key",
     "embedding_api_key": "your_openai_api_key",
@@ -114,7 +114,7 @@ different URLs in `chat_api_url` and `embedding_api_url`.
 
 Where:
 - `db_name`: Name of the ArangoDB database where the knowledge graph is stored
-- `genai_project_name`: The project name created via the
+- `project_name`: The project name created via the
   [web interface](../graphrag/web-interface.md#create-a-graphrag-project) or
   [Project API](../../platform-suite/control-plane-acp.md#creating-a-project).
   This name is used as a prefix for all ArangoDB collections (for example, a
@@ -147,7 +147,7 @@ service using the below configuration:
 {
   "env": {
     "db_name": "your_database_name",
-    "genai_project_name": "your_project_name",
+    "project_name": "your_project_name",
     "chat_api_provider": "triton",
     "embedding_api_provider": "triton",
     "chat_api_url": "your-arangodb-llm-host-url",
@@ -160,7 +160,7 @@ service using the below configuration:
 
 Where:
 - `db_name`: Name of the ArangoDB database where the knowledge graph will be stored
-- `genai_project_name`: The project name created via the
+- `project_name`: The project name created via the
   [web interface](../graphrag/web-interface.md#create-a-graphrag-project) or
   [Project API](../../platform-suite/control-plane-acp.md#creating-a-project).
   This name is used as a prefix for all ArangoDB collections (for example, a

--- a/site/content/agentic-ai-suite/importer/llm-configuration.md
+++ b/site/content/agentic-ai-suite/importer/llm-configuration.md
@@ -49,8 +49,8 @@ Set the `chat_api_url` and `embedding_api_url` to point to your provider's endpo
 Where:
 - `db_name`: Name of the ArangoDB database where the knowledge graph will be stored
 - `genai_project_name`: The project name created via the
-   [web interface](../../graphrag/web-interface.md#create-a-graphrag-project) or
-  [Project API](../../../platform-suite/control-plane-acp.md#creating-a-project).
+   [web interface](../graphrag/web-interface.md#create-a-graphrag-project) or
+  [Project API](../../platform-suite/control-plane-acp.md#creating-a-project).
   This name is used as a prefix for all ArangoDB collections (for example, a
   project named `docs` creates `docs_Documents`, `docs_Chunks`, etc.)
 - `chat_api_provider`: Set to `"openai"` for any OpenAI-compatible API
@@ -68,8 +68,15 @@ Where:
 
 {{< info >}}
 When using the official OpenAI API, the service defaults to `gpt-4o` and 
-`text-embedding-3-small` models.
+`text-embedding-3-small` models. When an OpenRouter URL is detected, the
+chat model defaults to `mistralai/mistral-nemo`.
 {{< /info >}}
+
+{{< tip >}}
+Instead of inline API keys, you can use `chat_secret_profile_id` and
+`embedding_secret_profile_id` when your platform supports secret profiles
+for the Importer install.
+{{< /tip >}}
 
 ### Using different OpenAI-compatible services
 
@@ -88,28 +95,28 @@ different URLs in `chat_api_url` and `embedding_api_url`.
 **Example using OpenRouter for chat and OpenAI for embedding:**
 
 ```json
-    {
-      "env": {
-        "db_name": "your_database_name",
-        "genai_project_name": "your_project_name",
-        "chat_api_provider": "openai",
-        "embedding_api_provider": "openai",
-        "chat_api_url": "https://openrouter.ai/api/v1",
-        "embedding_api_url": "https://api.openai.com/v1",
-        "chat_model": "mistral-nemo",
-        "embedding_model": "text-embedding-3-small",
-        "chat_api_key": "your_openrouter_api_key",
-        "embedding_api_key": "your_openai_api_key",
-        "embedding_dim": "512"
-      }
-    }
+{
+  "env": {
+    "db_name": "your_database_name",
+    "genai_project_name": "your_project_name",
+    "chat_api_provider": "openai",
+    "embedding_api_provider": "openai",
+    "chat_api_url": "https://openrouter.ai/api/v1",
+    "embedding_api_url": "https://api.openai.com/v1",
+    "chat_model": "mistral-nemo",
+    "embedding_model": "text-embedding-3-small",
+    "chat_api_key": "your_openrouter_api_key",
+    "embedding_api_key": "your_openai_api_key",
+    "embedding_dim": "512"
+  }
+}
 ```
 
 Where:
 - `db_name`: Name of the ArangoDB database where the knowledge graph is stored
 - `genai_project_name`: The project name created via the
-  [web interface](../../graphrag/web-interface.md#create-a-graphrag-project) or
-  [Project API](../../../platform-suite/control-plane-acp.md#creating-a-project).
+  [web interface](../graphrag/web-interface.md#create-a-graphrag-project) or
+  [Project API](../../platform-suite/control-plane-acp.md#creating-a-project).
   This name is used as a prefix for all ArangoDB collections (for example, a
   project named `docs` creates `docs_Documents`, `docs_Chunks`, etc.)
 - `chat_api_provider`: Set to `"openai"` for any OpenAI-compatible API
@@ -130,8 +137,8 @@ Where:
 The first step is to install the LLM Host service with the LLM and
 embedding models of your choice. The setup will use the 
 Triton Inference Server and MLflow at the backend. 
-For more details, please refer to the [Triton Inference Server](../triton-inference-server.md)
-and [MLflow](../mlflow.md) documentation.
+For more details, please refer to the [Triton Inference Server](../reference/triton-inference-server.md)
+and [MLflow](../reference/mlflow.md) documentation.
 
 Once the `llmhost` service is up-and-running, then you can start the Importer
 service using the below configuration:
@@ -154,8 +161,8 @@ service using the below configuration:
 Where:
 - `db_name`: Name of the ArangoDB database where the knowledge graph will be stored
 - `genai_project_name`: The project name created via the
-  [web interface](../../graphrag/web-interface.md#create-a-graphrag-project) or
-  [Project API](../../../platform-suite/control-plane-acp.md#creating-a-project).
+  [web interface](../graphrag/web-interface.md#create-a-graphrag-project) or
+  [Project API](../../platform-suite/control-plane-acp.md#creating-a-project).
   This name is used as a prefix for all ArangoDB collections (for example, a
   project named `docs` creates `docs_Documents`, `docs_Chunks`, etc.)
 - `chat_api_provider`: Specifies which LLM provider to use for language model services

--- a/site/content/agentic-ai-suite/importer/parameters.md
+++ b/site/content/agentic-ai-suite/importer/parameters.md
@@ -22,12 +22,16 @@ Parameters differ between single file and multi-file import:
 
 ### Single File Import
 
-- `file_content` (required, or use `file_url`): Direct file content as base64-encoded string.
-- `file_url` (required, or use `file_content`): URL to download the file from.
+- `file_content` (required, or use `file_url` / `file_id`): Direct file content as base64-encoded string.
+- `file_url` (required, or use `file_content` / `file_id`): URL to download the file from.
+- `file_id` (required, or use `file_content` / `file_url`): RAG file ID from
+  [File Manager](../../platform-suite/file-manager/). When provided, the file
+  is fetched by ID and `file_content` / `file_url` are ignored.
 - `file_name` (required): Original filename with extension.
 
 {{< tip >}}
-For single file import, you can use either `file_content` or `file_url`, but not both in the same request.
+For single file import, provide exactly one of `file_content`, `file_url`, or
+`file_id`.
 {{< /tip >}}
 
 **Example with direct file content:**
@@ -50,13 +54,20 @@ For single file import, you can use either `file_content` or `file_url`, but not
 
 ### Multi-File Import
 
+You can provide files inline using the `files` array, or reference files
+already uploaded to [File Manager](../../platform-suite/file-manager/) using
+`file_ids`. When `file_ids` is provided, files are fetched by ID and the
+`files` array is ignored.
+
+- `file_ids` (required, or use `files`): An array of RAG file IDs from File Manager.
+
 Each file in the `files` array requires:
 
 - `name` (required): Original filename with extension.
 - `content` (required): File content as base64-encoded bytes.
 - `citable_url` (optional): URL to be cited in inline citations. This URL is stored in
   the document metadata and used at retrieval. When querying your knowledge graph, whether
-  citations are displayed is controlled by the [`show_citations`](../retriever/parameters.md#show_citations) parameter.
+  citations are displayed is controlled by the [`show_citations`](../reference/retriever/parameters.md#show_citations) parameter.
 
 **Example:**
 
@@ -101,13 +112,14 @@ When using `"vector_rag"` mode, chunk embeddings are automatically enabled regar
 
 These parameters control how documents are split into smaller chunks for processing.
 
-- `chunk_token_size`: Maximum tokens per chunk. The default value is `1200`.
+- `chunk_token_size`: Maximum tokens per chunk. The default value is `1024`.
 - `chunk_overlap_token_size`: Number of overlapping tokens between consecutive
-  chunks. The default value is `100`.
-- `chunk_min_token_size`: Minimum tokens per chunk (optional).
+  chunks. The default value is `128`.
+- `chunk_min_token_size`: Minimum tokens per chunk. Chunks smaller than this are
+  merged with adjacent chunks. The default value is `64`.
 - `chunk_custom_separators`: Custom separators for chunking (optional, e.g., `["\n\n", "\n", " "]`).
 - `preserve_chunk_separator`: Whether to preserve separator characters in chunks
-  (default: `false`).
+  (default: `true`).
 - `ignore_chunk_token_size`: If `true`, chunks are split only by separators without
   enforcing token size limits. When enabled, `chunk_token_size` and `chunk_overlap_token_size`
   are ignored (default: `false`).
@@ -116,11 +128,11 @@ These parameters control how documents are split into smaller chunks for process
 
 ```json
 {
-  "chunk_token_size": 1200,
-  "chunk_overlap_token_size": 100,
-  "chunk_min_token_size": 50,
+  "chunk_token_size": 1024,
+  "chunk_overlap_token_size": 128,
+  "chunk_min_token_size": 64,
   "chunk_custom_separators": ["\n\n", "\n", " "],
-  "preserve_chunk_separator": false,
+  "preserve_chunk_separator": true,
   "ignore_chunk_token_size": false
 }
 ```
@@ -143,8 +155,10 @@ Use `ignore_chunk_token_size: true` when you want pure separator-based chunking.
 
 These parameters define what entities and relationships to extract from your documents.
 
-- `entity_types`: Entity types to extract from the document (e.g., `["person", "organization", "geo", "event"]`).
+- `entity_types`: Entity types to extract from the document. The default value is
+  `["person", "organization", "geo", "event"]`.
 - `relationship_types`: Relationship types to extract (e.g., `["RELATED_TO", "PART_OF", "USES"]`).
+  If not provided, relationships are extracted based on the LLM's judgment.
 - `enable_strict_types`: Enable strict filtering of entities and relationships from the specified types (default: `false`).
 - `entity_extract_max_gleaning`: Maximum number of extraction iterations (default: `1`).
 
@@ -165,28 +179,53 @@ Entity and relationship extraction is only performed in `"full_graphrag"` mode. 
 
 ## Custom Prompts
 
-You can customize the prompts used for entity extraction, relationship extraction, and community report generation. This is an advanced feature for domain-specific customization.
+You can customize the prompts used for entity extraction, community report
+generation, and other processing steps. This is an advanced feature for
+domain-specific customization.
 
-- `custom_prompts`: A dictionary mapping prompt names to custom prompt text. When provided, custom prompts override the default prompts. If empty or not provided, default prompts are used.
+- `custom_prompts`: A dictionary mapping prompt names to custom prompt text.
+  When provided, custom prompts override the default prompts. Only the prompts
+  you specify are overridden; all others use their defaults. If empty or not
+  provided, default prompts are used.
 
 Available prompt keys:
-- `"entity_extraction"`: Prompt for extracting entities from text chunks
-- `"entity_relationship"`: Prompt for extracting relationships between entities
-- `"community_report"`: Prompt for generating community summary reports
+- `"entity_extraction"`: Prompt for extracting entities and relationships from text chunks.
+- `"community_report"`: Prompt for generating community summary reports.
+- `"claim_extraction"`: Prompt for extracting claims against entities.
+- `"summarize_entity_descriptions"`: Prompt for combining multiple entity descriptions into one.
+- `"entity_continue_extraction"`: Follow-up prompt when entities may have been missed.
+- `"entity_if_loop_extraction"`: Prompt to determine if additional extraction iterations are needed.
+
+**Template variables:**
+
+Custom prompts support the following template variables that are automatically
+filled at runtime:
+
+- `{entity_types}`: Comma-separated list of entity types.
+- `{relationship_types}`: Comma-separated list of relationship types.
+- `{relationship_type_instruction}`: Dynamic instruction about relationship types.
+- `{input_text}`: The text chunk being processed.
+- `{tuple_delimiter}`: Field separator (default: `<|>`).
+- `{record_delimiter}`: Record separator (default: `##`).
+- `{completion_delimiter}`: End marker (default: `<|COMPLETE|>`).
 
 **Example:**
 
 ```json
 {
   "custom_prompts": {
-    "entity_extraction": "Extract technical entities including: software libraries, programming languages, APIs, and architectural components. For each entity provide: name, type, and a brief description.",
-    "community_report": "Generate a technical summary focusing on: 1) Key technologies and their relationships, 2) Architectural patterns, 3) Integration points. Provide 5-7 key insights."
+    "entity_extraction": "Extract technical entities including: software libraries, programming languages, APIs, and architectural components. For each entity provide: name, type, and a brief description.\n\nEntity_types: {entity_types}\nRelationship_types: {relationship_types}\nText: {input_text}\nOutput:",
+    "community_report": "Generate a technical summary focusing on: 1) Key technologies and their relationships, 2) Architectural patterns, 3) Integration points. Provide 5-7 key insights.\n\nText:\n{input_text}\nOutput:"
   }
 }
 ```
 
 {{< warning >}}
-Custom prompts are an advanced feature. Poorly designed prompts may result in lower quality entity extraction or community reports. Use the default prompts unless you have specific domain requirements.
+Custom prompts are an advanced feature. Poorly designed prompts may result in
+lower quality entity extraction or community reports. Your custom prompt must
+include the required template variables (e.g., `{input_text}`, `{entity_types}`,
+`{tuple_delimiter}`) for the system to function correctly. Use the default
+prompts unless you have specific domain requirements.
 {{< /warning >}}
 
 ## Embedding Parameters
@@ -230,7 +269,7 @@ These parameters configure the vector indexes used for semantic search and simil
 ```
 
 {{< info >}}
-Vector index parameters apply to all embedding fields in your knowledge graph (chunks, edges, entities, and communities). For more details on ArangoDB vector indexes, see the [Vector Search](../../../arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md) documentation.
+Vector index parameters apply to all embedding fields in your knowledge graph (chunks, edges, entities, and communities). For more details on ArangoDB vector indexes, see the [Vector Search](../../arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md) documentation.
 {{< /info >}}
 
 ## Semantic Units and Image Processing
@@ -238,11 +277,14 @@ Vector index parameters apply to all embedding fields in your knowledge graph (c
 These parameters enable extraction of images and multimedia references. For detailed 
 information, see the [Semantic Units guide](semantic-units.md).
 
-- `enable_semantic_units`: Enable semantic unit processing (extracts web URLs and image references).
-- `process_images`: Process storage URLs like base64/S3 links (requires `enable_semantic_units=true`).
-- `store_image_data`: Store actual image data for storage URLs (requires `process_images=true`).
+- `enable_semantic_units`: Enable semantic unit processing (extracts web URLs and image references). Default: `false`.
+- `process_images`: Process storage-style URLs like base64/S3/FileManager artifact URLs (requires `enable_semantic_units=true`). Default: `false`.
+- `store_image_data`: Store actual image data for storage-style URLs (requires `process_images=true`). Default: `false`.
+- `enable_semantic_unit_embeddings`: Generate vector embeddings for semantic units (requires `enable_semantic_units=true`). Default: `false`.
+- `crop_images`: Extract images from documents and include markdown references. Default: `false`.
+- `store_images_to_s3`: Upload extracted images via sidecar as FileManager artifacts and replace local paths with FileManager download URLs. Default: `false`.
 
-These parameters are hierarchical - each requires the previous one to be enabled.
+The first three parameters are hierarchical; each requires the previous one to be enabled.
 
 **Example:**
 
@@ -276,7 +318,7 @@ These parameters configure ArangoDB graph features for distributed deployments.
 
 {{< info >}}
 These parameters are primarily used for distributed ArangoDB deployments. 
-Consult the [ArangoDB SmartGraphs documentation](../../../arangodb/3.12/graphs/smartgraphs/_index.md) 
+Consult the [ArangoDB SmartGraphs documentation](../../arangodb/3.12/graphs/smartgraphs/_index.md) 
 for more details.
 {{< /info >}}
 
@@ -300,22 +342,9 @@ The `partition_id` parameter enables semantic sharding and horizontal scaling by
 
 **Usage patterns:**
 
-1. **With Autograph**: Use Autograph-generated `rag_partition_id` values (format: `{cluster_index}_{a|b}`) to group documents by semantic similarity and RAG strategy
+1. **With AutoGraph**: Use AutoGraph-generated `rag_partition_id` values (format: `{cluster_index}_{a|b}`) to group documents by semantic similarity and RAG strategy
 2. **Manual partitioning**: Define your own partition scheme based on domain, project, or tenant
 3. **Auto-generated**: If not specified, a random partition ID is generated
-
-**Example:**
-
-```json
-{
-  "partition_id": "0_a",
-  "files": [...]
-}
-```
-
-{{< tip >}}
-When using Autograph for corpus analysis, use the `rag_partition_id` values from the strategizer results as your `partition_id` values when calling the Importer. This ensures documents from the same semantic cluster are stored together, enabling efficient two-stage retrieval.
-{{< /tip >}}
 
 **Example:**
 
@@ -326,6 +355,10 @@ When using Autograph for corpus analysis, use the `rag_partition_id` values from
   "batch_size": 1000
 }
 ```
+
+{{< tip >}}
+When using AutoGraph for corpus analysis, use the `rag_partition_id` values from the strategizer results as your `partition_id` values when calling the Importer. This ensures documents from the same semantic cluster are stored together, enabling efficient two-stage retrieval.
+{{< /tip >}}
 
 ## Examples
 
@@ -338,8 +371,8 @@ This example uses full GraphRAG mode with entity extraction, chunking, and embed
   "file_content": "base64_encoded_content",
   "file_name": "document.txt",
   "rag_mode": "full_graphrag",
-  "chunk_token_size": 1200,
-  "chunk_overlap_token_size": 100,
+  "chunk_token_size": 1024,
+  "chunk_overlap_token_size": 128,
   "entity_types": ["person", "organization", "location", "event"],
   "relationship_types": ["WORKS_FOR", "LOCATED_IN", "PARTICIPATES_IN"],
   "enable_chunk_embeddings": false,
@@ -357,8 +390,8 @@ This example uses vector RAG mode for fast, simple semantic search without entit
   "file_content": "base64_encoded_content",
   "file_name": "document.txt",
   "rag_mode": "vector_rag",
-  "chunk_token_size": 1200,
-  "chunk_overlap_token_size": 100,
+  "chunk_token_size": 1024,
+  "chunk_overlap_token_size": 128,
   "batch_size": 1000
 }
 ```
@@ -394,5 +427,5 @@ For advanced use cases, this configuration demonstrates custom prompts, separato
 
 ## API Reference
 
-For detailed API documentation, see the <!-- TODO: New API reference and link -->
-[GraphRAG Importer API Reference](https://arangoml.github.io/platform-dss-api/graphrag_importer/proto/index.html).
+For detailed API documentation, see the
+[GraphRAG Importer API Reference](https://apiref.arango.ai/#graphrag_importer).

--- a/site/content/agentic-ai-suite/importer/semantic-units.md
+++ b/site/content/agentic-ai-suite/importer/semantic-units.md
@@ -42,10 +42,10 @@ The default value is `false`.
 
 ### `process_images` 
 
-- **Purpose**: Enables processing of storage URLs (base64/S3 images).
+- **Purpose**: Enables processing of storage-style URLs (base64/S3/FileManager artifact URLs).
 - **Functionality**:
   - When `false`: Only processes web URLs (https://, http://).
-  - When `true`: Processes both web URLs AND storage URLs (base64/S3).
+  - When `true`: Processes both web URLs AND storage-style URLs (base64/S3/FileManager artifact URLs).
 - **Requirements**: `enable_semantic_units` must be `true`.
 - **Use Cases**:
   - Document analysis with embedded base64 images.
@@ -56,10 +56,10 @@ The default value is `false` and requires `enable_semantic_units` to be set to `
 
 ### `store_image_data`
 
-- **Purpose**: Controls whether actual image data is stored for storage URLs.
+- **Purpose**: Controls whether actual image data is stored for storage-style URLs.
 - **Functionality**:
   - For web URLs: No effect (always stores only metadata).
-  - For storage URLs: When `true`, stores the actual image data in the `image_data` field.
+  - For storage-style URLs: When `true`, stores the actual image data in the `image_data` field.
 - **Requirements**: `process_images` must be `true`.
 - **Use Cases**:
   - Offline access to base64-encoded images.
@@ -123,12 +123,13 @@ In this example, the Importer extracts all image references and stores complete 
 Here's a complete import request with semantic units enabled alongside other import parameters:
 
 ```bash
-curl -X POST https://<your-platform-url>/v1/import \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
     "file_content": "'$base64_content'",
     "file_name": "document.md",
-    "chunk_token_size": 1200,
+    "chunk_token_size": 1024,
     "entity_types": ["person", "organization", "technology"],
     "enable_semantic_units": true,
     "process_images": true,
@@ -136,7 +137,7 @@ curl -X POST https://<your-platform-url>/v1/import \
   }'
 ```
 
-In this example, the Importer processes the markdown document by extracting entities (person, organization, technology), chunking the text into 1200-token segments, and extracting all image references (web URLs and storage URLs). The resulting Knowledge Graph includes entity nodes, relationships, and a `SemanticUnits` collection containing image metadata without storing the actual image data.
+In this example, the Importer processes the markdown document by extracting entities (person, organization, technology), chunking the text into 1024-token segments, and extracting all image references (web URLs and storage URLs). The resulting Knowledge Graph includes entity nodes, relationships, and a `SemanticUnits` collection containing image metadata without storing the actual image data.
 
 ## Supported Content Types
 
@@ -145,6 +146,7 @@ The semantic units feature supports:
 - **Web URLs**: `https://example.com/image.jpg`
 - **Base64 Images**: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==`
 - **S3 URLs**: `s3://bucket/path/image.jpg`
+- **FileManager artifact URLs**: `/_platform/filemanager/_db/{db}/rag-input/{file_id}/download?version={n}`
 - **Markdown Image Syntax**: `![Alt text](https://example.com/image.jpg)`
 
 ## Performance Considerations

--- a/site/content/agentic-ai-suite/importer/verify-and-explore.md
+++ b/site/content/agentic-ai-suite/importer/verify-and-explore.md
@@ -19,9 +19,7 @@ multiple methods.
 
 You can verify the state of the import process via the following endpoint:
 
-```
-GET /_platform/acp/v1/project_by_name/<your_project>
-```
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/project_by_name/{project_name}" >}}
 
 For example, the `status` object found within `importerServices` may contain the following
 properties:
@@ -103,20 +101,20 @@ retrieval. Single file imports do not include these fields.
 ### Communities Collection
 
 - **Collection type**: Vertex collection.
-- **Purpose**: Stores thematic clusters of related entities that form meaningful
-  communities within your documents. Each community represents a cohesive group
-  of concepts, characters, or themes that are closely related and interact with
-  each other. These communities help identify and analyze the main narrative
-  threads, character relationships, and thematic elements in your documents.
+- **Purpose**: Stores clusters of related entities that form meaningful
+  communities within your documents. Each community represents a group of
+  entities (e.g., people, organizations, locations) that are closely related.
+  Communities help you understand the key topics, entity relationships, and
+  thematic structure of your data.
 - **Key Fields**:
   - `_key`: Unique identifier for the community.
-  - `title`: Cluster ID to which this community belongs to.
+  - `title`: Cluster ID to which this community belongs.
   - `report_string`: A detailed markdown-formatted analysis that explains the
     community's theme, key relationships, and significance. This includes
     sections on main characters, their roles, relationships, and the impact of key events or locations.
   - `report_json`: Structured data containing:
     - `title`: The main theme or focus of the community.
-    - `summary`: A concise overview of the community's central narrative.
+    - `summary`: A concise overview of the community's central topic.
     - `rating`: A numerical score indicating the community's significance (the higher, the better).
     - `rating_explanation`: Justification for the rating.
     - `findings`: An array of detailed analyses, each containing a summary and explanation of key aspects.
@@ -126,11 +124,11 @@ retrieval. Single file imports do not include these fields.
   - `embedding`: Vector representation of the community for similarity search (when `enable_community_embeddings` is `true`).
   - `partition_id`: The partition the document belongs to.
 - **Usage**: Enables you to:
-  - Identify and analyze major narrative threads and themes.
-  - Understand complex relationships between characters and concepts.
-  - Track the significance and impact of different story elements.
-  - Navigate through hierarchical relationships between themes.
-  - Discover patterns and recurring elements in your documents.
+  - Identify and analyze major topics and themes in your data.
+  - Understand complex relationships between entities.
+  - Assess the significance of different entity groups via ratings.
+  - Navigate hierarchical community structures (communities and sub-communities).
+  - Discover recurring patterns across your documents.
 
 ### Relations Collection
 
@@ -157,10 +155,15 @@ retrieval. Single file imports do not include these fields.
 - **Key Fields**:
   - `_key`: Unique identifier for the semantic unit.
   - `type`: Type of semantic unit (always "image" for image references).
-  - `image_url`: URL or reference to the image/web resource.
-  - `is_storage_url`: Boolean indicating if the URL is a storage URL (base64/S3) or web URL.
+  - `image_url`: URL or reference to the image/web resource. For extracted
+    uploaded images, this is stored as a FileManager download path
+    (e.g., `/_platform/filemanager/_db/{db}/rag-input/{file_id}/download?version={n}`).
+  - `is_storage_url`: Boolean indicating if the URL is a storage-style URL
+    (e.g., base64/S3/FileManager artifact URL) or a normal web URL.
   - `import_number`: Import batch number for tracking.
   - `source_chunk_id`: Reference to the chunk where this semantic unit was found.
+  - `description`: Description of the semantic unit (surrounding text or AI-generated).
+  - `embedding`: Vector embedding representation (when `enable_semantic_unit_embeddings` is `true`).
 
 {{< info >}}
 Learn more about semantic units in the [Semantic Units guide](semantic-units.md).
@@ -174,23 +177,32 @@ The system creates several types of relationships between nodes:
 2. **MENTIONED_IN**: Connects entities to the chunks where they are mentioned.
 3. **RELATED_TO**: Shows relationships between different entities.
 4. **IN_COMMUNITY**: Associates entities with their community groups.
+5. **SUB_COMMUNITY_OF**: Relates a sub-community to its parent community in the hierarchy.
 
 ### Relationship Diagram
 
-```
-Document
-  └─[PART_OF]─> Chunk
-                  └─[MENTIONED_IN]─> Entity
-                                       ├─[RELATED_TO]─> Entity
-                                       └─[IN_COMMUNITY]─> Community
+```mermaid
+graph LR
+  Document -->|PART_OF| Chunk
+  Chunk -->|MENTIONED_IN| Entity
+  Entity -->|RELATED_TO| Entity2["Entity"]
+  Entity -->|IN_COMMUNITY| Community
+  Community -->|SUB_COMMUNITY_OF| Community2["Community"]
 ```
 
 ## Vector Search Capabilities
 
-The system automatically creates vector indexes on the `embedding` field in collections where embeddings are enabled (Entities, Chunks, Edges, and Communities), enabling:
+The system automatically creates vector indexes on the `embedding` field for
+collections enabled by the import mode and request flags:
+- **Entities**: When the selected `rag_mode` imports entities (e.g., `full_graphrag`).
+- **Chunks**: When chunk embeddings are enabled (`enable_chunk_embeddings=true` in `full_graphrag`; always on in `vector_rag`).
+- **SemanticUnits**: When `enable_semantic_unit_embeddings=true`.
+- **Relations**: When `enable_edge_embeddings=true` and the selected `rag_mode` imports relations.
+
+These indexes enable:
 - Semantic similarity search
 - Nearest neighbor queries
-- Efficient vector-based retrieval
+- Efficient vector-based retrieval across multiple collection types
 
 These vector indexes are automatically configured and optimized for the embedding model 
 you selected during [LLM configuration](llm-configuration.md). You can customize the vector 
@@ -202,8 +214,7 @@ for more details.
 
 Now that you've successfully imported and verified your knowledge graph:
 
-- **Query your data**: Use the [Retriever service](../retriever.md) to perform semantic search and retrieval
-- **Visualize relationships**: Explore your graph using the [Graph Visualizer](../../../platform-suite/graph-visualizer.md)
+- **Query your data**: Use the [Retriever service](../reference/retriever/) to perform semantic search and retrieval
+- **Visualize relationships**: Explore your graph using the [Graph Visualizer](../../platform-suite/graph-visualizer.md)
 - **Import more documents**: Return to the [Import Files guide](importing-files.md) to add more data
 - **Optimize parameters**: Review the [Parameters guide](parameters.md) to fine-tune your imports
-

--- a/site/content/agentic-ai-suite/reference/retriever/_index.md
+++ b/site/content/agentic-ai-suite/reference/retriever/_index.md
@@ -56,7 +56,7 @@ Before using the Retriever service, you need to:
    managing projects, see the [Projects](../../../platform-suite/control-plane-acp.md#projects)
    section in the Arango Control Plane (ACP) service documentation.
 
-2. **Import data** - Use the [Importer](../importer/) service to transform your 
+2. **Import data** - Use the [Importer](../../importer/) service to transform your 
    text documents into a knowledge graph stored in ArangoDB.
 
 ## Installation
@@ -99,7 +99,7 @@ To use the Retriever service, follow these steps:
 
 1. [**Create a GraphRAG project**](../../../platform-suite/control-plane-acp.md#creating-a-project):
    Set up a project to organize your data.
-2. [**Import data**](../importer/):
+2. [**Import data**](../../importer/):
    Build your knowledge graph using the Importer service.
 3. [**Configure your LLM provider**](llm-configuration.md):
    Choose and configure either Triton or OpenAI-compatible APIs.

--- a/site/content/agentic-ai-suite/reference/retriever/parameters.md
+++ b/site/content/agentic-ai-suite/reference/retriever/parameters.md
@@ -74,7 +74,7 @@ Whether to show inline citations in the response.
 - **Description**:
   - When `true` (default): Citations appear inline as `[X]` in the response.
   - When `false`: All `[CITE:X]` patterns are stripped from the response.
-  - This parameter controls displaying citations only. The actual citation URL metadata is set via [`citable_url`](../importer/parameters.md#file-source-parameters) at import time.
+  - This parameter controls displaying citations only. The actual citation URL metadata is set via [`citable_url`](../../importer/parameters.md#file-source-parameters) at import time.
 
 {{< warning >}}
 For deep search queries (`use_llm_planner=true`), citations are always disabled

--- a/site/content/platform-suite/control-plane-acp.md
+++ b/site/content/platform-suite/control-plane-acp.md
@@ -57,7 +57,7 @@ The following example shows a complete request body with all available options:
   they can be used.
 
 The parameters required for the deployment of each service are defined in the
-corresponding service documentation. See [Importer](../agentic-ai-suite/reference/importer/_index.md)
+corresponding service documentation. See [Importer](../agentic-ai-suite/importer/_index.md)
 and [Retriever](../agentic-ai-suite/reference/retriever/_index.md).
 
 ## Projects
@@ -181,7 +181,7 @@ documentation.
 ## Complete Service lifecycle example
 
 The example below shows how to install, monitor, and uninstall the
-[Importer](../agentic-ai-suite/reference/importer/_index.md) service.
+[Importer](../agentic-ai-suite/importer/_index.md) service.
 
 ### Step 1: Installing the service
 


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added AutoGraph integration guide for partition-aware imports and orchestration.
  * Reorganized Importer docs, updated many navigation/link targets, and adjusted page weights.
  * Added .pdf support and clarified file/image handling and storage-style URLs.
  * Renamed LLM env field to project_name and clarified model defaults and secret-profile usage.
  * Added auth requirement (Bearer token) and updated example endpoints.
  * Introduced job management and health endpoints; adjusted chunking defaults and parameter docs.
  * Enhanced community/relations and semantic unit descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->