### PR TITLE
DOC-874 | Platform install details and new Platform CLI tool features

### DIFF
--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -45,7 +45,7 @@ described below.
 ## Activate a deployment
 
 1. Download the Arango Contextual Data Platform CLI tool `arangodb_operator_platform` from
-   <https://github.com/arangodb/kube-arangodb/releases>.
+   <https://github.com/arangodb/kube-arangodb/releases/latest>.
    It is available for Linux, macOS, and Windows for the x86-64 as well as 64-bit ARM
    architecture (e.g. `arangodb_operator_platform_linux_amd64`).
 
@@ -83,7 +83,7 @@ described below.
 ## Generate a license key
 
 1. Download the Arango Contextual Data Platform CLI tool `arangodb_operator_platform` from
-   <https://github.com/arangodb/kube-arangodb/releases>.
+   <https://github.com/arangodb/kube-arangodb/releases/latest>.
    It is available for Linux, macOS, and Windows for the x86-64 as well as 64-bit ARM
    architecture (e.g. `arangodb_operator_platform_linux_amd64`).
 

--- a/site/content/arangodb/4.0/operations/administration/license-management.md
+++ b/site/content/arangodb/4.0/operations/administration/license-management.md
@@ -47,7 +47,7 @@ described below.
 ## Activate a deployment
 
 1. Download the Arango Contextual Data Platform CLI tool `arangodb_operator_platform` from
-   <https://github.com/arangodb/kube-arangodb/releases>.
+   <https://github.com/arangodb/kube-arangodb/releases/latest>.
    It is available for Linux, macOS, and Windows for the x86-64 as well as 64-bit ARM
    architecture (e.g. `arangodb_operator_platform_linux_amd64`).
 
@@ -85,7 +85,7 @@ described below.
 ## Generate a license key
 
 1. Download the Arango Contextual Data Platform CLI tool `arangodb_operator_platform` from
-   <https://github.com/arangodb/kube-arangodb/releases>.
+   <https://github.com/arangodb/kube-arangodb/releases/latest>.
    It is available for Linux, macOS, and Windows for the x86-64 as well as 64-bit ARM
    architecture (e.g. `arangodb_operator_platform_linux_amd64`).
 

--- a/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
+++ b/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
@@ -13,10 +13,12 @@ the offline and the online environment at different steps, but mainly from the
 online to offline system and only small amounts from the offline to the online
 system (for the licensing).
 
+{{< tip >}}
 What needs to be done in which environment is indicated by each step:
 
 - **Air-gapped system**: The offline environment.
 - **Internet-connected system**: The online environment.
+{{< /tip >}}
 
 ## Step 1: Download the installation files and information
 

--- a/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
+++ b/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
@@ -50,14 +50,14 @@ system before the setup.
   platform package yourself by exporting from Arango's container registry.
 
 - Download the latest enterprise version of the ArangoDB Kubernetes Operator
-  `kube-arangodb` from <https://github.com/arangodb/kube-arangodb/releases>.
+  `kube-arangodb` from <https://github.com/arangodb/kube-arangodb/releases/latest>.
 
   Look for the file called `kube-arangodb-enterprise-x.x.x.tgz` (where `x.x.x`
   is the version number). It is the operator for x86-64 CPUs.
   You may need to click **Show all # assets** to reveal all files. 
 
 - Download the Arango Contextual Data Platform CLI tool `arangodb_operator_platform` from
-  <https://github.com/arangodb/kube-arangodb/releases>.
+  <https://github.com/arangodb/kube-arangodb/releases/latest>.
   It is available for Linux, macOS, and Windows for the x86-64 as well as 64-bit ARM
   architecture, for example:
   

--- a/site/content/contextual-data-platform/install-and-upgrade/online-setup.md
+++ b/site/content/contextual-data-platform/install-and-upgrade/online-setup.md
@@ -86,7 +86,7 @@ deployments and the Contextual Data Platform. It watches for custom resources an
 the necessary Kubernetes resources.
 
 You can find the latest release on GitHub:
-<https://github.com/arangodb/kube-arangodb/releases/>
+<https://github.com/arangodb/kube-arangodb/releases/latest/>
 
 Make sure set the the options as shown below to enable webhooks, certificates,
 the gateway feature, and machine learning:
@@ -205,7 +205,7 @@ eventually see pods with the following names with a status of `Running`:
 ## Step 6: Get the Contextual Data Platform CLI tool
 
 Download the Arango Contextual Data Platform CLI tool `arangodb_operator_platform` from
-<https://github.com/arangodb/kube-arangodb/releases>.
+<https://github.com/arangodb/kube-arangodb/releases/latest>.
 It is available for Linux, macOS, and Windows for the x86-64 as well as 64-bit ARM
 architecture (e.g. `arangodb_operator_platform_linux_amd64`).
 

--- a/site/content/contextual-data-platform/install-and-upgrade/online-setup.md
+++ b/site/content/contextual-data-platform/install-and-upgrade/online-setup.md
@@ -219,7 +219,8 @@ the Platform's Kubernetes services.
 ## Step 7: Install the Contextual Data Platform package
 
 Install the package using the package configuration you received from the
-Arango team (`platform.yaml`).
+Arango team (`platform.yaml`). This requires license credentials and internet
+access to `*.license.arango.ai`.
 
 The package installation creates and enables various services, including
 the unified web interface of the Contextual Data Platform.

--- a/site/content/contextual-data-platform/install-and-upgrade/online-setup.md
+++ b/site/content/contextual-data-platform/install-and-upgrade/online-setup.md
@@ -230,6 +230,8 @@ with the actual license credentials and `./platform.yaml` with the path to the
 package configuration file. The platform name (`deployment-example`) needs to
 match the name as specified in the `ArangoDeployment` configuration.
 
+<!-- TODO: There is --license.client.discover now, which defaults to true and tries to get the credentials from the ArangoDeployment - does this indirectly fetch the Kubernetes secret? -->
+
 ```sh
 arangodb_operator_platform --namespace arango package install \
   --license.client.id "<license-client-id>" \


### PR DESCRIPTION
### Description

- [x] Link to latest kube-arangodb release
- [x] Make it harder to miss the explanation of the tags for offline setup
- [x] Mention license subdomain that needs to be reachable also for online setup
- [ ] Mention `chmod +x` for platform CLI tool as well as Apple un-quarantining for online setup (see offline setup)
- [ ] Mention `license check` for testing the connection?
- [ ] Mention `--arango.insecure` where the `license activate` command is shown (and make sure the auth options are described or linked, too)
- [ ] Mention `--license.proxy`?
- [ ] Describe how `--license.client.discover` works
- [ ] Describe the new `package copy`
- [ ] Describe the new `package chart`
- [ ] Describe the new `package dump`?
- [ ] Describe the new `package merge`?
- [ ] Mention `--registry.docker.credentials`, `--registry.docker.insecure`, `--registry.proxy`?

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 
