### PR TITLE
README: Add details about local example generation & changing stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ The output files will be written to `site/public/`.
 
 **Configuration**
 
-The toolchain container needs to be set up via config file in `toolchain/docker/config.yaml`:
+The toolchain container needs to be set up via config file in
+[`toolchain/docker/config.yaml`](toolchain/docker/config.yaml):
 
 ```yaml
 generators:   # Generators to trigger - empty string defaults to all generators
@@ -216,19 +217,33 @@ servers:      # Array to define arangodb servers to be used by the toolchain
 
 The generators entry is a space-separated string.
 
-If `metrics`, `error-codes`, or `exit-coddes` is in the `generators` string,
-the following environment variable has to be exported:
+If `metrics`, `error-codes`, or `exit-codes` is in the `generators` string,
+the following environment variable has to be exported to point to a working copy
+of the [`arangodb/arangodb`](https://github.com/arangodb/arangodb) repository:
 
 ```sh
-export ARANGODB_SRC_{VERSION}=path/to/arangodb/source
+export ARANGODB_SRC_{VERSION}=path/to/arangodb  # Bash
+set -xg ARANGODB_SRC_{VERSION} path/to/arangodb # Fish
 ```
 
-Substitute `{VERSION}` with a version number like `3_11`.
+Substitute `{VERSION}` with a version number like `3_12`.
 
 On Windows using PowerShell, use a Unix-like path:
 
 ```powershell
-$Env:ARANGODB_SRC_3_11 = "/Drive/path/to/arangodb"
+$Env:ARANGODB_SRC_{VERSION} = "/Drive/path/to/arangodb"
+```
+
+As long as `toolchain/docker/config.yaml` is unmodified and has the original
+placeholders like `generators: ${GENERATORS}`, you can also use environment
+variables to configure the build:
+
+```sh
+export GENERATORS="examples options optimizer"
+export ARANGODB_BRANCH_3_12="arangodb/enterprise:3.12.9"
+export ARANGODB_SRC_3_12="path/to/arangodb"
+export ARANGODB_BRANCH_4_0="arangodb/enterprise-preview:4.0-nightly"
+export ARANGODB_SRC_4_0="path/to/arangodb2"
 ```
 
 **Configuration example**

--- a/README.md
+++ b/README.md
@@ -1213,7 +1213,7 @@ The work-in-progress versions of the ArangoDB documentation need to have
 `inDevelopment` set to `true`. Make sure to change it to `false` for the former
 devel version when it becomes the new stable version.
 
-The final configuration would then look lik this:
+The final configuration would then look like this:
 
 ```yaml
 /arangodb/:

--- a/README.md
+++ b/README.md
@@ -249,12 +249,12 @@ export ARANGODB_SRC_4_0="path/to/arangodb2"
 **Configuration example**
 
 ```yaml
-generators: examples oasisctl options optimizer
+generators: examples options optimizer
 servers:
-  - image: arangodb/enterprise-preview:3.11-nightly
-    version: "3.11"
-  - image: arangodb/enterprise-preview:devel-nightly
+  - image: arangodb/enterprise:3.12.9
     version: "3.12"
+  - image: arangodb/enterprise-preview:4.0-nightly
+    version: "4.0"
 ```
 
 **Run the toolchain**
@@ -1177,20 +1177,28 @@ For example, if the current stable version is 3.11 and the devel version is 3.12
 the `site/data/versions.yaml` file may look like this:
 
 ```yaml
-- name: "4.0"
-  version: "4.0.0"
-  alias: "4.0"
-  deprecated: false
+/arangodb/:
 
-- name: "3.12"
-  version: "3.12.0"
-  alias: "devel"
-  deprecated: false
+  - name: "4.0"
+    version: "4.0.0"
+    alias: "4.0"
+    deprecated: false
+    inDevelopment: true
+    allowedAPIVersions: [v1, experimental]
 
-- name: "3.11"
-  version: "3.11.4"
-  alias: "stable"
-  deprecated: false
+  - name: "3.12"
+    version: "3.12.9"
+    alias: "devel"
+    deprecated: false
+    inDevelopment: true
+    allowedAPIVersions: [v0, experimental]
+
+  - name: "3.11"
+    version: "3.11.14"
+    alias: "stable"
+    deprecated: false
+    inDevelopment: false
+    allowedAPIVersions: [v0]
 ```
 
 To make 3.12 the new stable version, you need to set `alias` to `"stable"` for
@@ -1200,23 +1208,36 @@ changed. In this example, it is the 3.11 entry where you need to change `alias`
 to the version `name`, which is `"3.11"` in this case. Finally, you need to
 re-assign the `"devel"` alias to the version that comes after the new stable
 version. In this example, you need to adjust the `alias` of the 4.0 entry.
+
+The work-in-progress versions of the ArangoDB documentation need to have
+`inDevelopment` set to `true`. Make sure to change it to `false` for the former
+devel version when it becomes the new stable version.
+
 The final configuration would then look lik this:
 
 ```yaml
-- name: "4.0"
-  version: "4.0.0"
-  alias: "devel"   # was "4.0"
-  deprecated: false
+/arangodb/:
 
-- name: "3.12"
-  version: "3.12.0"
-  alias: "stable"  # was "devel"
-  deprecated: false
+  - name: "4.0"
+    version: "4.0.0"
+    alias: "devel" # was "4.0"
+    deprecated: false
+    inDevelopment: true
+    allowedAPIVersions: [v1, experimental]
 
-- name: "3.11"
-  version: "3.11.4"
-  alias: "3.11"    # was "stable"
-  deprecated: false
+  - name: "3.12"
+    version: "3.12.9"
+    alias: "stable" # was "devel"
+    deprecated: false
+    inDevelopment: false # was true
+    allowedAPIVersions: [v0, experimental]
+
+  - name: "3.11"
+    version: "3.11.14"
+    alias: "3.11" # was "stable"
+    deprecated: false
+    inDevelopment: false
+    allowedAPIVersions: [v0]
 ```
 
 ### Add a new arangosh example


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected generator name to "exit-codes" and removed "oasisctl" from generators examples.
  * Clarified ArangoDB source setup and added shell-specific commands for setting source env vars.
  * Showed how env vars work with toolchain/docker placeholders (e.g., GENERATORS, ARANGODB_BRANCH_*, ARANGODB_SRC_*).
  * Updated server Docker image/version examples and shifted version examples from 3_11 to 3_12.
  * Rewrote version config examples to use an /arangodb/ mapping and added inDevelopment and allowedAPIVersions fields, plus guidance for switching stable/development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->