### PR TITLE
DOC-856 | Secret Manager

### DIFF
--- a/site/content/agentic-ai-suite/_index.md
+++ b/site/content/agentic-ai-suite/_index.md
@@ -49,9 +49,8 @@ Alongside these components, you also get the following additional features:
 - [**MLflow integration**](reference/mlflow.md): Use the popular MLflow as a
   model registry for private LLMs or to run machine learning experiments.
 - **Application Programming Interfaces (APIs)**: Use the underlying APIs of the
-  Agentic AI Suite and build your own integrations. See the <!-- TODO: New API reference and link -->
-  [Protocol Documentation](https://arangoml.github.io/platform-dss-api/GenAI-Service/proto/index.html)
-  for more details.
+  Agentic AI Suite and build your own integrations. See the
+  [API Reference](https://apiref.arango.ai/) for more details.
 
 ## Sample datasets
 

--- a/site/content/agentic-ai-suite/graph-analytics/api.md
+++ b/site/content/agentic-ai-suite/graph-analytics/api.md
@@ -509,7 +509,8 @@ You can check the progress of operations and check if errors occurred.
 You can submit jobs concurrently and they also run concurrently.
 
 You can find the API reference documentation with detailed descriptions of the
-request and response data structures at <https://arangodb.github.io/graph-analytics>.
+request and response data structures at
+<https://apiref.arango.ai/arangodb-gral/v1.1.7/html/index.html>.
 
 Request and response payloads are JSON-encoded in the engine API.
 

--- a/site/content/agentic-ai-suite/graph-analytics/api.md
+++ b/site/content/agentic-ai-suite/graph-analytics/api.md
@@ -510,7 +510,7 @@ You can submit jobs concurrently and they also run concurrently.
 
 You can find the API reference documentation with detailed descriptions of the
 request and response data structures at
-<https://apiref.arango.ai/arangodb-gral/v1.1.7/html/index.html>.
+<https://apiref.arango.ai/#gral>.
 
 Request and response payloads are JSON-encoded in the engine API.
 

--- a/site/content/agentic-ai-suite/graphrag/web-interface.md
+++ b/site/content/agentic-ai-suite/graphrag/web-interface.md
@@ -57,8 +57,9 @@ configure and start a new importer service job. Follow the steps below.
 {{< tab "OpenAI" >}}
 1. Select **OpenAI** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
-   the service is using **O4 Mini**.
-3. Enter your **OpenAI API Key**.
+   the service is using **GPT-4o**.
+3. Enter your **OpenAI API Key**, or click the key icon to select a secret
+   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Start importer service** button.
 {{< /tab >}}
 
@@ -66,8 +67,10 @@ configure and start a new importer service job. Follow the steps below.
 1. Select **OpenRouter** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
    the service uses **Mistral AI - Mistral Nemo**.
-3. Enter your **OpenAI API Key**.
-4. Enter your **OpenRouter API Key**.
+3. Enter your **OpenAI API Key**, or click the key icon to select a secret
+   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+4. Enter your **OpenRouter API Key**, or click the key icon to select a secret
+   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 5. Click the **Start importer service** button.
 
 {{< info >}}
@@ -82,7 +85,10 @@ via OpenRouter while OpenAI is used for the embedding model.
 3. Click the **Start importer service** button.
 
 {{< info >}}
-Note that you must first register your model in MLflow. The [Triton LLM Host](../reference/triton-inference-server.md)
+The **Triton** option only appears in the **LLM API Provider** dropdown if a
+Triton Inference Server is deployed in your cluster.
+
+You must first register your model in MLflow. The [Triton LLM Host](../reference/triton-inference-server.md)
 service automatically downloads and loads models from the MLflow registry.
 {{< /info >}}
 {{< /tab >}}
@@ -103,6 +109,8 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Importer** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, or **OpenAI API Key** as needed.
+   For the API key, you can type a new value or click the key icon to select a
+   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update importer service** button to apply the changes.
 {{< /tab >}}
 
@@ -110,6 +118,8 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Importer** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, **OpenAI API Key**, or **OpenRouter API Key** as needed.
+   For each API key, you can type a new value or click the key icon to select a
+   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update importer service** button to apply the changes.
 {{< /tab >}}
 
@@ -118,6 +128,11 @@ provider combination, or if your API key has changed or expired.
 2. In the **Importer** section, click **Edit service**.
 3. Update the **LLM API Provider** or **Model** as needed.
 4. Click the **Update importer service** button to apply the changes.
+
+{{< info >}}
+The **Triton** option is only available when a Triton Inference Server is
+deployed in your cluster.
+{{< /info >}}
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -201,8 +216,9 @@ the generated Knowledge Graph. To configure the retriever service, open the
 {{< tab "OpenAI" >}}
 1. Select **OpenAI** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
-   the service uses **O4 Mini**.
-3. Enter your **OpenAI API Key**.
+   the service uses **GPT-4o**.
+3. Enter your **OpenAI API Key**, or click the key icon to select a secret
+   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Start retriever service** button.
 {{< /tab >}}
 
@@ -210,7 +226,8 @@ the generated Knowledge Graph. To configure the retriever service, open the
 1. Select **OpenRouter** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
    the service uses **Mistral AI - Mistral Nemo**.
-3. Enter your **OpenRouter API Key**.
+3. Enter your **OpenRouter API Key**, or click the key icon to select a secret
+   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Start retriever service** button.
 
 {{< info >}}
@@ -225,7 +242,10 @@ is used for the embedding model.
 3. Click the **Start retriever service** button.
 
 {{< info >}}
-Note that you must first register your model in MLflow. The [Triton LLM Host](../reference/triton-inference-server.md)
+The **Triton** option only appears in the **LLM API Provider** dropdown if a
+Triton Inference Server is deployed in your cluster.
+
+You must first register your model in MLflow. The [Triton LLM Host](../reference/triton-inference-server.md)
 service automatically downloads and loads models from the MLflow registry.
 {{< /info >}}
 {{< /tab >}}
@@ -246,6 +266,8 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Retriever** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, or **OpenAI API Key** as needed.
+   For the API key, you can type a new value or click the key icon to select a
+   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update retriever service** button to apply the changes.
 {{< /tab >}}
 
@@ -253,6 +275,8 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Retriever** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, or **OpenRouter API Key** as needed.
+   For the API key, you can type a new value or click the key icon to select a
+   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update retriever service** button to apply the changes.
 {{< /tab >}}
 
@@ -261,6 +285,11 @@ provider combination, or if your API key has changed or expired.
 2. In the **Retriever** section, click **Edit service**.
 3. Update the **LLM API Provider** or **Model** as needed.
 4. Click the **Update retriever service** button to apply the changes.
+
+{{< info >}}
+The **Triton** option is only available when a Triton Inference Server is
+deployed in your cluster.
+{{< /info >}}
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/site/content/platform-suite/control-plane-acp.md
+++ b/site/content/platform-suite/control-plane-acp.md
@@ -295,5 +295,5 @@ Bearer token, the request fails.
 
 ## API Reference
 
-For detailed API documentation, see the <!-- TODO: New API reference and link -->
-[Arango Control Plane service Protocol Documentation](https://arangoml.github.io/platform-dss-api/GenAI-Service/proto/index.html).
+For detailed API documentation, see the
+[Arango Control Plane service API Reference](https://apiref.arango.ai/arango-control-plane/v0.0.18/html/index.html).

--- a/site/content/platform-suite/control-plane-acp.md
+++ b/site/content/platform-suite/control-plane-acp.md
@@ -296,4 +296,4 @@ Bearer token, the request fails.
 ## API Reference
 
 For detailed API documentation, see the
-[Arango Control Plane service API Reference](https://apiref.arango.ai/arango-control-plane/v0.0.18/html/index.html).
+[Arango Control Plane service API Reference](https://apiref.arango.ai/#genai-service).

--- a/site/content/platform-suite/secrets-manager.md
+++ b/site/content/platform-suite/secrets-manager.md
@@ -36,18 +36,20 @@ sidecar container for metadata that runs in the pod of the service. <!-- TODO: D
 
 1. In the main navigation of the Arango Contextual Data Platform web interface, go to the
    **Control Panel** ({{< icon "settings" >}}).
-2. Click **Secrets Manager** in the navigation.
-3. Click **Add Secret**.
-4. Enter a **Name** to later reference the secret.
-5. Select a **Type** from the provided list.
-5. Enter the **Secret Value** (API key, password, or similar).
-6. Optionally specify additional metadata.
-   You can enter a **Provider** and a **Description**.
+2. Click **Secrets** in the navigation.
+3. Click **Add secret** in the top-right corner.
+4. In the **Create Secret** dialog, enter a **Name** to later reference the secret.
+5. The **Type** is fixed to `API_KEY` (generic API keys and tokens) for secrets
+   created via the web interface. Other types can be created via the API.
+6. Enter the sensitive information (API key, password, or similar) into the
+   **Secret Data** field. Click the eye icon to show or hide the value.
+7. Optionally enter a **Description** to help identify the secret.
+8. Click **Create**.
 
 ### Edit a secret
 
 1. In the main navigation, go to the **Control Panel** ({{< icon "settings" >}}).
-2. Click **Secrets Manager** in the navigation.
+2. Click **Secrets** in the navigation.
 3. In the **Actions** column, click the edit icon ({{< icon "edit-square" >}}).
 4. Adjust the information. To edit the **Secret Value**, click the toggle next to
    the label and then enter the new value.
@@ -56,7 +58,7 @@ sidecar container for metadata that runs in the pod of the service. <!-- TODO: D
 ### Delete a secret
 
 1. Go to the **Control Panel** ({{< icon "settings" >}}).
-2. Click **Secrets Manager** in the navigation.
+2. Click **Secrets** in the navigation.
 3. Delete one or multiple secrets:
    - In the **Actions** column, click the remove icon ({{< icon "delete" >}})
      and confirm by clicking **Delete**.
@@ -67,11 +69,13 @@ sidecar container for metadata that runs in the pod of the service. <!-- TODO: D
 ### Import secrets
 
 1. Go to the **Control Panel** ({{< icon "settings" >}}).
-2. Click **Secrets Manager** in the navigation.
+2. Click **Secrets** in the navigation.
 3. Click the **Import** button in the top-right corner.
-4. You can **Paste JSON** from the clipboard or go to the **Upload File**
-   tab to select or drop a JSON file. You can inspect and edit the uploaded
-   data in the **Paste JSON** tab.
+4. In the **Import Secrets** dialog, you can **Paste JSON** from the clipboard
+   or go to the **Upload File** tab to select or drop a `.json` file. The file
+   must contain a JSON array of secret profiles. You can inspect and edit
+   uploaded data in the **Paste JSON** tab. Click **Load sample** to insert
+   an example payload.
 5. Click **Validate & Preview**. Fix missing fields or syntax errors if necessary.
 6. Verify the data. You can remove ({{< icon "delete" >}}) individual rows to
    exclude secrets from the import.
@@ -79,7 +83,10 @@ sidecar container for metadata that runs in the pod of the service. <!-- TODO: D
 
 ## API
 
-<!-- TODO: Link to reference docs -->
+The Secrets Manager endpoints are part of the
+[Arango Control Plane (ACP) API](https://apiref.arango.ai/arango-control-plane/v0.0.18/html/index.html).
+See the reference for the full request and response schemas of the
+`/v1/secrets`, `/v1/secrets_batch`, and `/v1/secret_types` endpoints.
 
 ### How to use the secrets manager API
 

--- a/site/content/platform-suite/secrets-manager.md
+++ b/site/content/platform-suite/secrets-manager.md
@@ -122,3 +122,32 @@ You can list the existing secret objects (but without the sensitive secrets
 themselves):
 
 {{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/secrets" >}}
+
+To retrieve a specific secret object by its profile ID:
+
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/secrets/{profile_id}" >}}
+
+To replace an existing secret with a new one, use the following endpoint.
+The request body must include all attributes of the secret:
+
+{{< endpoint "PUT" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/secrets/{profile_id}" >}}
+
+To update only specific attributes of an existing secret, use the following
+endpoint. The request body only needs to include the attributes you want to
+change:
+
+{{< endpoint "PATCH" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/secrets/{profile_id}" >}}
+
+To delete a single secret by its profile ID:
+
+{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/secrets/{profile_id}" >}}
+
+To create multiple secrets in a single request, use the batch endpoint.
+The request body must be a JSON array of secret objects:
+
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/secrets_batch" >}}
+
+To delete multiple secrets in a single request, use the batch delete endpoint.
+The request body must include the list of profile IDs to delete:
+
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/secrets_batch/delete" >}}

--- a/site/content/platform-suite/secrets-manager.md
+++ b/site/content/platform-suite/secrets-manager.md
@@ -84,7 +84,7 @@ sidecar container for metadata that runs in the pod of the service. <!-- TODO: D
 ## API
 
 The Secrets Manager endpoints are part of the
-[Arango Control Plane (ACP) API](https://apiref.arango.ai/arango-control-plane/v0.0.18/html/index.html).
+[Arango Control Plane (ACP) API](https://apiref.arango.ai/#genai-service).
 See the reference for the full request and response schemas of the
 `/v1/secrets`, `/v1/secrets_batch`, and `/v1/secret_types` endpoints.
 


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API reference links to explicit, versioned apiref.arango.ai references across platform and agentic AI docs
  * Changed default GraphRAG model from O4 Mini to GPT-4o
  * Added secret selection via key icon (Secrets area) for OpenAI/OpenRouter API key entry and update flows
  * Clarified Triton visibility requirement (appears only when Triton Inference Server is deployed)
  * Refined Secrets create/edit/delete/import workflows and expanded Secrets API guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->