### PR TITLE
DOC-902 | New user-friendly license activation

### DIFF
--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -18,7 +18,7 @@ deployment has internet access:
 
 | Your deployment | How to license it | Run the Platform CLI tool? |
 |---|---|---|
-| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool. | **Yes** — you run `arangodb_operator_platform` |
+| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool (recommended for unattended renewal) or the [License Activation web UI](https://activate.license.arango.ai/) in **Managed** mode (one-off). | **Optional** — only if you use the Platform CLI tool |
 | **Standalone ArangoDB**, offline / air-gapped | [Generate a license key](#generate-a-license-key) on a separate internet-connected machine, then [apply it](#apply-a-license-key) via arangosh, the Web UI, or the HTTP API. | **Yes** — on the internet-connected machine only |
 | **Kubernetes with internet access** (incl. Contextual Data Platform) | Create a Kubernetes secret with your client ID and client secret. The [ArangoDB Kubernetes Operator (kube-arangodb)](https://github.com/arangodb/kube-arangodb) activates the deployment and renews the license automatically. | **No** — the operator does everything |
 | **Air-gapped Kubernetes** (no internet access) | Generate a license key on a separate internet-connected machine, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes** — on the internet-connected machine only |
@@ -58,6 +58,22 @@ ArangoDB endpoint over the network, including from inside a container
 you use only for license generation.
 {{< /info >}}
 
+{{< tip >}}
+The [License Activation web UI](https://activate.license.arango.ai/) is a
+graphical alternative to the Platform CLI tool. It supports two modes:
+
+- **Inventory** — upload an `inventory.json` file produced by
+  `arangodb_operator_platform license inventory`. Recommended for offline /
+  air-gapped flows.
+- **Managed** — provide just the deployment ID. Skips the inventory step;
+  suited to one-off activation of an online deployment.
+
+See the **Web UI** entries in
+[Activate a deployment](#license-activation-web-ui-managed-mode),
+[Generate a license key](#generate-a-license-key), and the
+[container walkthrough](#walkthrough-generate-a-key-in-a-container).
+{{< /tip >}}
+
 ## License methods summary
 
 - **Activate a deployment** (from v3.12.6 onward):\
@@ -80,7 +96,14 @@ you use only for license generation.
 
 ## Activate a deployment
 
-### Standalone deployment (Platform CLI)
+### Standalone deployment
+
+You can activate a standalone deployment with the Platform CLI tool or with
+the License Activation web UI. The CLI is the recommended option for ongoing
+operation because it can re-activate the deployment automatically on a fixed
+interval. The web UI is a quick, graphical alternative for one-off activation.
+
+#### Platform CLI tool
 
 1. Download the Platform CLI tool `arangodb_operator_platform` from
    <https://github.com/arangodb/kube-arangodb/releases>.
@@ -141,6 +164,35 @@ you use only for license generation.
    (for example a systemd unit with `Restart=always`, a container
    with a restart policy, or Kubernetes) so renewals resume automatically
    if the process exits unexpectedly.
+
+#### License Activation web UI (Managed mode)
+
+The web UI generates a license key for a deployment without running the
+Platform CLI tool. It is suited to one-off activation; for unattended renewal,
+use the CLI's `--license.interval` instead.
+
+1. Get the deployment ID from a running ArangoDB instance:
+
+   ```sh
+   # User credentials (-u username:password)
+   curl -u root: http://localhost:8529/_admin/deployment/id
+
+   # Example result:
+   # {"id":"6172616e-676f-4000-0000-05c958168340"}
+   ```
+
+2. Open <https://activate.license.arango.ai/>.
+3. Enter your **License Client ID** and **License Client Secret**.
+4. Select **Managed — Deployment ID only** and paste the deployment ID.
+5. Optionally enable **Custom TTL** to override the default license duration.
+6. Click **Activate** and copy the generated license key.
+7. Apply the license key to ArangoDB using one of the interfaces in
+   [Apply a license key](#apply-a-license-key) — for example `arangosh` or
+   the Web interface.
+
+Repeat this procedure when the license is close to expiry. If you want
+unattended renewal, use the [Platform CLI tool](#platform-cli-tool) with
+`--license.interval` instead.
 
 ### Kubernetes-managed deployment
 
@@ -234,8 +286,36 @@ configuration options that let you tune TTL and grace periods.
    # {"id":"6172616e-676f-4000-0000-05c958168340"}
    ```
 
-4. Generate the license key using the deployment ID, the inventory file, and the
-   license credentials, and write it to a file:
+4. Generate the license key using the deployment ID, the inventory file, and
+   the license credentials. You can do this with the License Activation web UI
+   or with the Platform CLI tool — both produce an equivalent license key.
+
+   {{< tabs "generate-license-key" >}}
+
+   {{< tab "Web UI" >}}
+   1. Open <https://activate.license.arango.ai/>.
+   2. Enter your **License Client ID** and **License Client Secret**.
+   3. Choose how to identify the deployment:
+      - **Inventory** (default): drop the `inventory.json` file into the upload
+        area, or click to select it. Captures the full deployment shape and is
+        recommended for offline / air-gapped environments.
+      - **Managed — Deployment ID only**: enter the deployment ID directly.
+        The license server tracks the deployment state; no inventory file is
+        needed. Use this when you want a one-off key for a known online
+        deployment without running `license inventory`.
+   4. Optionally enable **Custom TTL** to override the default license duration.
+      Accepts values like `24h`, `168h`, `7d`, or `3600s`.
+   5. Click **Activate** and copy the generated license key.
+
+   The web UI is a convenient alternative for users who would otherwise run
+   `arangodb_operator_platform license generate`. Inventory mode still requires
+   the Platform CLI tool to produce the inventory file in the previous step;
+   Managed mode skips that step entirely.
+   {{< /tab >}}
+
+   {{< tab "Platform CLI" >}}
+   Run the Platform CLI tool with the deployment ID, the inventory file, and
+   the license credentials, and write the key to a file:
 
    ```sh
    arangodb_operator_platform license generate \
@@ -245,6 +325,9 @@ configuration options that let you tune TTL and grace periods.
      --license.client.secret "00000000-0000-0000-0000-000000000000" \
      2> license_key.txt
    ```
+   {{< /tab >}}
+
+   {{< /tabs >}}
 
 ### Walkthrough: generate a key in a container
 
@@ -374,10 +457,40 @@ Copy the `id` value for the next step.
 
 #### 6. Generate the license key
 
-Call the Platform CLI tool with the deployment ID, the inventory file, and the
-license credentials you received from Arango (a client ID and a client
-secret). The command writes log output to standard output and writes the
-license key itself to standard error — redirect standard error to a file:
+Generate the license key using the deployment ID, the inventory file, and
+the license credentials you received from Arango (a client ID and a client
+secret). You can do this with the License Activation web UI (no extra tool
+needed) or with the Platform CLI tool inside the container. Both options
+produce an equivalent license key.
+
+{{< tabs "walkthrough-generate-license-key" >}}
+
+{{< tab "Web UI" >}}
+1. Open <https://activate.license.arango.ai/>.
+2. Enter your **License Client ID** and **License Client Secret**.
+3. Choose how to identify the deployment:
+   - **Inventory** (default): copy `inventory.json` out of the container so
+     you can upload it from your browser, then drop it into the upload area:
+
+     ```sh
+     docker cp arangodb:/inventory.json ./inventory.json
+     ```
+
+   - **Managed — Deployment ID only**: enter the deployment ID from the
+     previous step. No inventory file is needed.
+4. Optionally enable **Custom TTL** to override the default license duration.
+5. Click **Activate** and copy the generated license key into a local
+   `license_key.txt` file.
+
+The web UI is a convenient alternative for users who would otherwise run
+`arangodb_operator_platform license generate`.
+{{< /tab >}}
+
+{{< tab "Platform CLI" >}}
+Call the Platform CLI tool with the deployment ID, the inventory file, and
+the license credentials. The command writes log output to standard output
+and writes the license key itself to standard error — redirect standard
+error to a file:
 
 ```sh
 arangodb_operator_platform license generate \
@@ -396,6 +509,9 @@ out of the container before you stop it:
 ```sh
 docker cp arangodb:/license_key.txt ./license_key.txt
 ```
+{{< /tab >}}
+
+{{< /tabs >}}
 
 #### 7. Apply the license key to ArangoDB
 

--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -114,7 +114,7 @@ your contract enables it, with the License Activation portal in **Managed**
 or **Generic** mode. The Platform CLI tool is the recommended option for
 ongoing operation because it can re-activate the deployment automatically
 on a fixed interval. The activation portal is a quick, browser-based
-alternative for one-off activation. An activation is valid for ~2 weeks by
+alternative for one-off activation. An activation has a short validity by
 default; the portal's **Custom TTL** lets you override it within the limits
 permitted by your contract.
 
@@ -218,7 +218,7 @@ use the Platform CLI tool's `--license.interval` instead.
 2. Open <https://activate.license.arango.ai/>.
 3. Enter your **License Client ID** and **License Client Secret**.
 4. Select the activation mode:
-   - **Inventory** (default): drop the `inventory.json` file produced
+   - **Inventory** (default): upload the `inventory.json` file produced
      by `arangodb_operator_platform license inventory`. See
      [Generate a license key](#generate-a-license-key) for the
      end-to-end flow that uses this mode.
@@ -349,7 +349,7 @@ configuration options that let you tune TTL and grace periods.
    1. Open <https://activate.license.arango.ai/>.
    2. Enter your **License Client ID** and **License Client Secret**.
    3. Choose how to identify the deployment:
-      - **Inventory** (default): drop the `inventory.json` file into the upload
+      - **Inventory** (default): upload the `inventory.json` file into the upload
         area, or click to select it. Captures the full deployment shape and is
         recommended for offline / air-gapped environments.
       - **Managed — Deployment ID only**: enter the deployment ID directly.

--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -18,8 +18,8 @@ deployment has internet access:
 
 | Your deployment | How to license it | Run the Platform CLI tool? |
 |---|---|---|
-| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool (recommended for unattended renewal) or the [License Activation web UI](https://activate.license.arango.ai/) in **Managed** mode (one-off). | **Optional** — only if you use the Platform CLI tool |
-| **Standalone ArangoDB**, offline / air-gapped | [Generate a license key](#generate-a-license-key) on a separate internet-connected machine, then [apply it](#apply-a-license-key) via arangosh, the Web UI, or the HTTP API. | **Yes** — on the internet-connected machine only |
+| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool (recommended for unattended renewal) or, if **Managed** activation is enabled for your license, with the [License Activation portal](https://activate.license.arango.ai/) (one-off). | **Optional** — only if you use the Platform CLI tool |
+| **Standalone ArangoDB**, offline / air-gapped | [Generate a license key](#generate-a-license-key) on a separate internet-connected machine, then [apply it](#apply-a-license-key) via arangosh, the web interface, or the HTTP API. | **Yes** — on the internet-connected machine only |
 | **Kubernetes with internet access** (incl. Contextual Data Platform) | Create a Kubernetes secret with your client ID and client secret. The [ArangoDB Kubernetes Operator (kube-arangodb)](https://github.com/arangodb/kube-arangodb) activates the deployment and renews the license automatically. | **No** — the operator does everything |
 | **Air-gapped Kubernetes** (no internet access) | Generate a license key on a separate internet-connected machine, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes** — on the internet-connected machine only |
 
@@ -59,17 +59,26 @@ you use only for license generation.
 {{< /info >}}
 
 {{< tip >}}
-The [License Activation web UI](https://activate.license.arango.ai/) is a
-graphical alternative to the Platform CLI tool. It supports two modes:
+The [License Activation portal](https://activate.license.arango.ai/) is a
+browser-based alternative to the Platform CLI tool's `license activate` and
+`license generate` commands. It does not replace `license inventory` — the
+CLI is still required to produce an inventory file for the **Inventory**
+mode. The portal exposes two activation modes:
 
 - **Inventory** — upload an `inventory.json` file produced by
-  `arangodb_operator_platform license inventory`. Recommended for offline /
-  air-gapped flows.
-- **Managed** — provide just the deployment ID. Skips the inventory step;
-  suited to one-off activation of an online deployment.
+  `arangodb_operator_platform license inventory`. The standard mode and the
+  one to use for offline / air-gapped flows.
+- **Managed** — provide just the deployment ID. No inventory file is needed.
 
-See the **Web UI** entries in
-[Activate a deployment](#license-activation-web-ui-managed-mode),
+Which modes are available depends on the license configuration that Arango
+sets up for your account. **Managed** activation is not enabled for every
+customer. Check your contract or with your Arango contact for what was
+agreed. If you are unsure, you can try **Managed** first; if it is not
+enabled for your credentials, the portal rejects the request and you can
+fall back to **Inventory**.
+
+See the **Activation portal** entries in
+[Activate a deployment](#license-activation-portal-managed-mode),
 [Generate a license key](#generate-a-license-key), and the
 [container walkthrough](#walkthrough-generate-a-key-in-a-container).
 {{< /tip >}}
@@ -98,10 +107,12 @@ See the **Web UI** entries in
 
 ### Standalone deployment
 
-You can activate a standalone deployment with the Platform CLI tool or with
-the License Activation web UI. The CLI is the recommended option for ongoing
-operation because it can re-activate the deployment automatically on a fixed
-interval. The web UI is a quick, graphical alternative for one-off activation.
+You can activate a standalone deployment with the Platform CLI tool or, if
+**Managed** activation is enabled for your license, with the License
+Activation portal. The CLI is the recommended option for ongoing operation
+because it can re-activate the deployment automatically on a fixed interval.
+The activation portal is a quick, browser-based alternative for one-off
+activation.
 
 #### Platform CLI tool
 
@@ -165,9 +176,26 @@ interval. The web UI is a quick, graphical alternative for one-off activation.
    with a restart policy, or Kubernetes) so renewals resume automatically
    if the process exits unexpectedly.
 
-#### License Activation web UI (Managed mode)
+#### License Activation portal (Managed mode)
 
-The web UI generates a license key for a deployment without running the
+The portal supports two activation modes:
+
+- **Managed** identifies the deployment by its deployment ID alone. No
+  inventory file is needed. This is the mode used in this section, because
+  it applies to a running online standalone deployment.
+- **Inventory** identifies the deployment by an `inventory.json` file
+  produced by the Platform CLI tool. It is the mode used for offline /
+  air-gapped flows; see [Generate a license key](#generate-a-license-key)
+  below.
+
+{{< info >}}
+**Managed** activation is not enabled for every customer. Check your
+contract or with your Arango contact for what was agreed. If it is not
+enabled for your credentials, the portal rejects the request and you
+should use the [Platform CLI tool](#platform-cli-tool) instead.
+{{< /info >}}
+
+The portal generates a license key for a deployment without running the
 Platform CLI tool. It is suited to one-off activation; for unattended renewal,
 use the CLI's `--license.interval` instead.
 
@@ -188,7 +216,7 @@ use the CLI's `--license.interval` instead.
 6. Click **Activate** and copy the generated license key.
 7. Apply the license key to ArangoDB using one of the interfaces in
    [Apply a license key](#apply-a-license-key) — for example `arangosh` or
-   the Web interface.
+   the web interface.
 
 Repeat this procedure when the license is close to expiry. If you want
 unattended renewal, use the [Platform CLI tool](#platform-cli-tool) with
@@ -287,12 +315,12 @@ configuration options that let you tune TTL and grace periods.
    ```
 
 4. Generate the license key using the deployment ID, the inventory file, and
-   the license credentials. You can do this with the License Activation web UI
+   the license credentials. You can do this with the License Activation portal
    or with the Platform CLI tool — both produce an equivalent license key.
 
    {{< tabs "generate-license-key" >}}
 
-   {{< tab "Web UI" >}}
+   {{< tab "Activation portal" >}}
    1. Open <https://activate.license.arango.ai/>.
    2. Enter your **License Client ID** and **License Client Secret**.
    3. Choose how to identify the deployment:
@@ -300,14 +328,15 @@ configuration options that let you tune TTL and grace periods.
         area, or click to select it. Captures the full deployment shape and is
         recommended for offline / air-gapped environments.
       - **Managed — Deployment ID only**: enter the deployment ID directly.
-        The license server tracks the deployment state; no inventory file is
-        needed. Use this when you want a one-off key for a known online
-        deployment without running `license inventory`.
+        No inventory file is needed. Available only if **Managed** activation
+        is enabled for your license — check your contract or with your Arango
+        contact. If it is not enabled, the portal rejects the request and
+        you should use **Inventory** mode instead.
    4. Optionally enable **Custom TTL** to override the default license duration.
       Accepts values like `24h`, `168h`, `7d`, or `3600s`.
    5. Click **Activate** and copy the generated license key.
 
-   The web UI is a convenient alternative for users who would otherwise run
+   The activation portal is a convenient alternative for users who would otherwise run
    `arangodb_operator_platform license generate`. Inventory mode still requires
    the Platform CLI tool to produce the inventory file in the previous step;
    Managed mode skips that step entirely.
@@ -338,7 +367,7 @@ Use this walkthrough if you need to run
 `arangodb_operator_platform license generate` yourself — that is, you are:
 
 - Running **standalone ArangoDB** (no Kubernetes) and want a license key
-  file you can apply via arangosh or the Web UI, or
+  file you can apply via arangosh or the web interface, or
 - Preparing an **air-gapped Kubernetes** install and need to generate a key
   on an internet-connected machine to carry into the air-gapped cluster.
 
@@ -459,13 +488,13 @@ Copy the `id` value for the next step.
 
 Generate the license key using the deployment ID, the inventory file, and
 the license credentials you received from Arango (a client ID and a client
-secret). You can do this with the License Activation web UI (no extra tool
+secret). You can do this with the License Activation portal (no extra tool
 needed) or with the Platform CLI tool inside the container. Both options
 produce an equivalent license key.
 
 {{< tabs "walkthrough-generate-license-key" >}}
 
-{{< tab "Web UI" >}}
+{{< tab "Activation portal" >}}
 1. Open <https://activate.license.arango.ai/>.
 2. Enter your **License Client ID** and **License Client Secret**.
 3. Choose how to identify the deployment:
@@ -477,12 +506,14 @@ produce an equivalent license key.
      ```
 
    - **Managed — Deployment ID only**: enter the deployment ID from the
-     previous step. No inventory file is needed.
+     previous step. No inventory file is needed. Available only if
+     **Managed** activation is enabled for your license — check your
+     contract or with your Arango contact.
 4. Optionally enable **Custom TTL** to override the default license duration.
 5. Click **Activate** and copy the generated license key into a local
    `license_key.txt` file.
 
-The web UI is a convenient alternative for users who would otherwise run
+The activation portal is a convenient alternative for users who would otherwise run
 `arangodb_operator_platform license generate`.
 {{< /tab >}}
 

--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -26,8 +26,9 @@ deployment has internet access:
 {{< info >}}
 **Legacy deployments (pre-v3.12.6):** Arango issued a ready-made license
 key directly to customers — there were no client ID and client secret
-credentials, and no Platform CLI tool. If you are on v3.12.5 or earlier,
-skip the activation and generation steps and go directly to
+credentials, and no Platform CLI tool. If Arango issued you a ready-made
+license key rather than license credentials (a client ID and client
+secret), skip the activation and generation steps and go directly to
 [Apply a license key](#apply-a-license-key).
 {{< /info >}}
 
@@ -269,12 +270,24 @@ configuration options that let you tune TTL and grace periods.
    `arangodb_operator_platform` (with an `.exe` extension on Windows) and add it to
    the `PATH` environment variable to make it available as a command in the system.
 
-2. Create an inventory file using the Platform CLI tool. Point it to a running
-   ArangoDB deployment (running on `http://localhost:8529` in this example):
+2. Create an inventory file using the Platform CLI tool. Point it to the
+   running ArangoDB deployment that the license should apply to. Replace
+   `<arango-endpoint>` with the URL of that deployment — use
+   `http://localhost:8529` only if the Platform CLI tool runs on the same
+   host as the ArangoDB instance you want to license; otherwise use the
+   deployment's actual address (for example, `http://10.0.0.5:8529` or
+   `https://arangodb.example.com:8529`).
+
+   {{< warning >}}
+   The inventory file captures the deployment ID of whichever ArangoDB
+   instance you point the CLI at. The license key generated from it only
+   works for that instance. Make sure the endpoint is the deployment you
+   intend to license — not a local test or throwaway instance.
+   {{< /warning >}}
 
    ```sh
    arangodb_operator_platform license inventory \
-     --arango.endpoint="http://localhost:8529" \
+     --arango.endpoint="<arango-endpoint>" \
      inventory.json
    ```
 

--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -20,7 +20,7 @@ deployment has internet access:
 |---|---|---|
 | **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool (recommended for unattended renewal) or, if **Managed** activation is enabled for your license, with the [License Activation portal](https://activate.license.arango.ai/) (one-off). | **Optional** — only if you use the Platform CLI tool |
 | **Standalone ArangoDB**, offline / air-gapped | [Generate a license key](#generate-a-license-key) on a separate internet-connected machine, then [apply it](#apply-a-license-key) via arangosh, the web interface, or the HTTP API. | **Yes** — on the internet-connected machine only |
-| **Kubernetes with internet access** (incl. Contextual Data Platform) | Create a Kubernetes secret with your client ID and client secret. The [ArangoDB Kubernetes Operator (kube-arangodb)](https://github.com/arangodb/kube-arangodb) activates the deployment and renews the license automatically. | **No** — the operator does everything |
+| **Kubernetes with internet access** (incl. Contextual Data Platform) | Create a Kubernetes secret with your client ID and client secret. The [ArangoDB Kubernetes Operator (`kube-arangodb`)](https://github.com/arangodb/kube-arangodb) activates the deployment and renews the license automatically. | **No** — the operator does everything |
 | **Air-gapped Kubernetes** (no internet access) | Generate a license key on a separate internet-connected machine, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes** — on the internet-connected machine only |
 
 {{< info >}}

--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -67,17 +67,17 @@ Platform CLI tool is still required to produce an inventory file for the
 **Inventory** mode. The portal exposes three activation modes:
 
 - **Inventory** — license credentials plus an `inventory.json` file produced
-  by `arangodb_operator_platform license inventory`. The standard mode and
-  the right choice for most users; required for offline / air-gapped flows.
+  by `arangodb_operator_platform license inventory`. The default mode, and
+  the only option available for most customers.
 - **Managed** — license credentials plus the deployment ID only. No
   inventory file is needed.
 - **Generic** — license credentials only, with no deployment binding.
 
 The availability of **Managed** and **Generic** modes depends on the
-contractual agreement between Arango and the customer. **Inventory** is
-available to all customers and is the right choice for most users. If you
-try a mode that is not enabled for your credentials, the portal rejects
-the request — fall back to **Inventory**.
+contractual agreement between Arango and the customer. The **Inventory**
+mode is available to all customers and, for most, is the only option. If
+a mode is not enabled for your credentials, the portal rejects the
+request — fall back to **Inventory**.
 
 See the **Activation portal** entries in
 [Activate a deployment](#license-activation-portal),
@@ -114,7 +114,9 @@ your contract enables it, with the License Activation portal in **Managed**
 or **Generic** mode. The Platform CLI tool is the recommended option for
 ongoing operation because it can re-activate the deployment automatically
 on a fixed interval. The activation portal is a quick, browser-based
-alternative for one-off activation.
+alternative for one-off activation. An activation is valid for ~2 weeks by
+default; the portal's **Custom TTL** lets you override it within the limits
+permitted by your contract.
 
 #### Platform CLI tool
 
@@ -183,9 +185,8 @@ alternative for one-off activation.
 The portal supports three activation modes:
 
 - **Inventory** identifies the deployment by an `inventory.json` file
-  produced by the Platform CLI tool. The standard mode and the right
-  choice for most users; required for offline / air-gapped flows
-  (see [Generate a license key](#generate-a-license-key) below).
+  produced by the Platform CLI tool. The default mode, and the only
+  option available for most customers.
 - **Managed** identifies the deployment by its deployment ID alone. No
   inventory file is needed. The mode covered in the procedure below,
   because it applies to a running online standalone deployment.
@@ -194,10 +195,10 @@ The portal supports three activation modes:
 
 {{< info >}}
 The availability of **Managed** and **Generic** modes depends on the
-contractual agreement between Arango and the customer. **Inventory** is
-available to all customers. If a mode is not enabled for your credentials,
-the portal rejects the request and you should use **Inventory** or the
-[Platform CLI tool](#platform-cli-tool) instead.
+contractual agreement between Arango and the customer. The **Inventory**
+mode is available to all customers. If a mode is not enabled for your
+credentials, the portal rejects the request and you should use
+**Inventory** or the [Platform CLI tool](#platform-cli-tool) instead.
 {{< /info >}}
 
 The portal generates a license key for a deployment without running the
@@ -217,6 +218,10 @@ use the Platform CLI tool's `--license.interval` instead.
 2. Open <https://activate.license.arango.ai/>.
 3. Enter your **License Client ID** and **License Client Secret**.
 4. Select the activation mode:
+   - **Inventory** (default): drop the `inventory.json` file produced
+     by `arangodb_operator_platform license inventory`. See
+     [Generate a license key](#generate-a-license-key) for the
+     end-to-end flow that uses this mode.
    - **Managed — Deployment ID only**: paste the deployment ID from step 1.
    - **Generic** (if available): no further input is needed.
 5. Optionally enable **Custom TTL** to override the default license duration.

--- a/site/content/arangodb/3.12/operations/administration/license-management.md
+++ b/site/content/arangodb/3.12/operations/administration/license-management.md
@@ -63,23 +63,24 @@ you use only for license generation.
 The [License Activation portal](https://activate.license.arango.ai/) is a
 browser-based alternative to the Platform CLI tool's `license activate` and
 `license generate` commands. It does not replace `license inventory` — the
-CLI is still required to produce an inventory file for the **Inventory**
-mode. The portal exposes two activation modes:
+Platform CLI tool is still required to produce an inventory file for the
+**Inventory** mode. The portal exposes three activation modes:
 
-- **Inventory** — upload an `inventory.json` file produced by
-  `arangodb_operator_platform license inventory`. The standard mode and the
-  one to use for offline / air-gapped flows.
-- **Managed** — provide just the deployment ID. No inventory file is needed.
+- **Inventory** — license credentials plus an `inventory.json` file produced
+  by `arangodb_operator_platform license inventory`. The standard mode and
+  the right choice for most users; required for offline / air-gapped flows.
+- **Managed** — license credentials plus the deployment ID only. No
+  inventory file is needed.
+- **Generic** — license credentials only, with no deployment binding.
 
-Which modes are available depends on the license configuration that Arango
-sets up for your account. **Managed** activation is not enabled for every
-customer. Check your contract or with your Arango contact for what was
-agreed. If you are unsure, you can try **Managed** first; if it is not
-enabled for your credentials, the portal rejects the request and you can
-fall back to **Inventory**.
+The availability of **Managed** and **Generic** modes depends on the
+contractual agreement between Arango and the customer. **Inventory** is
+available to all customers and is the right choice for most users. If you
+try a mode that is not enabled for your credentials, the portal rejects
+the request — fall back to **Inventory**.
 
 See the **Activation portal** entries in
-[Activate a deployment](#license-activation-portal-managed-mode),
+[Activate a deployment](#license-activation-portal),
 [Generate a license key](#generate-a-license-key), and the
 [container walkthrough](#walkthrough-generate-a-key-in-a-container).
 {{< /tip >}}
@@ -109,11 +110,11 @@ See the **Activation portal** entries in
 ### Standalone deployment
 
 You can activate a standalone deployment with the Platform CLI tool or, if
-**Managed** activation is enabled for your license, with the License
-Activation portal. The CLI is the recommended option for ongoing operation
-because it can re-activate the deployment automatically on a fixed interval.
-The activation portal is a quick, browser-based alternative for one-off
-activation.
+your contract enables it, with the License Activation portal in **Managed**
+or **Generic** mode. The Platform CLI tool is the recommended option for
+ongoing operation because it can re-activate the deployment automatically
+on a fixed interval. The activation portal is a quick, browser-based
+alternative for one-off activation.
 
 #### Platform CLI tool
 
@@ -177,28 +178,31 @@ activation.
    with a restart policy, or Kubernetes) so renewals resume automatically
    if the process exits unexpectedly.
 
-#### License Activation portal (Managed mode)
+#### License Activation portal
 
-The portal supports two activation modes:
+The portal supports three activation modes:
 
-- **Managed** identifies the deployment by its deployment ID alone. No
-  inventory file is needed. This is the mode used in this section, because
-  it applies to a running online standalone deployment.
 - **Inventory** identifies the deployment by an `inventory.json` file
-  produced by the Platform CLI tool. It is the mode used for offline /
-  air-gapped flows; see [Generate a license key](#generate-a-license-key)
-  below.
+  produced by the Platform CLI tool. The standard mode and the right
+  choice for most users; required for offline / air-gapped flows
+  (see [Generate a license key](#generate-a-license-key) below).
+- **Managed** identifies the deployment by its deployment ID alone. No
+  inventory file is needed. The mode covered in the procedure below,
+  because it applies to a running online standalone deployment.
+- **Generic** uses the license credentials only, with no deployment
+  binding. The procedure below applies; just skip the deployment ID step.
 
 {{< info >}}
-**Managed** activation is not enabled for every customer. Check your
-contract or with your Arango contact for what was agreed. If it is not
-enabled for your credentials, the portal rejects the request and you
-should use the [Platform CLI tool](#platform-cli-tool) instead.
+The availability of **Managed** and **Generic** modes depends on the
+contractual agreement between Arango and the customer. **Inventory** is
+available to all customers. If a mode is not enabled for your credentials,
+the portal rejects the request and you should use **Inventory** or the
+[Platform CLI tool](#platform-cli-tool) instead.
 {{< /info >}}
 
 The portal generates a license key for a deployment without running the
 Platform CLI tool. It is suited to one-off activation; for unattended renewal,
-use the CLI's `--license.interval` instead.
+use the Platform CLI tool's `--license.interval` instead.
 
 1. Get the deployment ID from a running ArangoDB instance:
 
@@ -212,7 +216,9 @@ use the CLI's `--license.interval` instead.
 
 2. Open <https://activate.license.arango.ai/>.
 3. Enter your **License Client ID** and **License Client Secret**.
-4. Select **Managed — Deployment ID only** and paste the deployment ID.
+4. Select the activation mode:
+   - **Managed — Deployment ID only**: paste the deployment ID from step 1.
+   - **Generic** (if available): no further input is needed.
 5. Optionally enable **Custom TTL** to override the default license duration.
 6. Click **Activate** and copy the generated license key.
 7. Apply the license key to ArangoDB using one of the interfaces in
@@ -280,9 +286,10 @@ configuration options that let you tune TTL and grace periods.
 
    {{< warning >}}
    The inventory file captures the deployment ID of whichever ArangoDB
-   instance you point the CLI at. The license key generated from it only
-   works for that instance. Make sure the endpoint is the deployment you
-   intend to license — not a local test or throwaway instance.
+   instance you point the Platform CLI tool at. The license key generated
+   from it only works for that instance. Make sure the endpoint is the
+   deployment you intend to license — not a local test or throwaway
+   instance.
    {{< /warning >}}
 
    ```sh

--- a/site/content/arangodb/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -1020,14 +1020,14 @@ more data, less file descriptors are used.
 
 <small>Introduced in: v3.12.6</small>
 
-Enterprise Edition license keys are now longer issued directly. Customers receive
+Enterprise Edition license keys are no longer issued directly. Customers receive
 license credentials instead. You can use a command-line tool to either activate
 deployments or generate license keys using these credentials. An internet
 connection is required for both. A generated key can subsequently be applied to
 an air-gapped deployment without internet access.
 
 The activation and license keys are now typically short-lived and need to be
-renewed every two weeks. Old license keys remain valid until their regular
+renewed periodically. Old license keys remain valid until their regular
 expiration.
 
 See [Enterprise Edition License Management](../../operations/administration/license-management.md)

--- a/site/content/arangodb/4.0/operations/administration/license-management.md
+++ b/site/content/arangodb/4.0/operations/administration/license-management.md
@@ -28,8 +28,9 @@ deployment has internet access:
 {{< info >}}
 **Legacy deployments (pre-v3.12.6):** Arango issued a ready-made license
 key directly to customers — there were no client ID and client secret
-credentials, and no Platform CLI tool. If you are on v3.12.5 or earlier,
-skip the activation and generation steps and go directly to
+credentials, and no Platform CLI tool. If Arango issued you a ready-made
+license key rather than license credentials (a client ID and client
+secret), skip the activation and generation steps and go directly to
 [Apply a license key](#apply-a-license-key).
 {{< /info >}}
 
@@ -271,12 +272,24 @@ configuration options that let you tune TTL and grace periods.
    `arangodb_operator_platform` (with an `.exe` extension on Windows) and add it to
    the `PATH` environment variable to make it available as a command in the system.
 
-2. Create an inventory file using the Platform CLI tool. Point it to a running
-   ArangoDB deployment (running on `http://localhost:8529` in this example):
+2. Create an inventory file using the Platform CLI tool. Point it to the
+   running ArangoDB deployment that the license should apply to. Replace
+   `<arango-endpoint>` with the URL of that deployment — use
+   `http://localhost:8529` only if the Platform CLI tool runs on the same
+   host as the ArangoDB instance you want to license; otherwise use the
+   deployment's actual address (for example, `http://10.0.0.5:8529` or
+   `https://arangodb.example.com:8529`).
+
+   {{< warning >}}
+   The inventory file captures the deployment ID of whichever ArangoDB
+   instance you point the CLI at. The license key generated from it only
+   works for that instance. Make sure the endpoint is the deployment you
+   intend to license — not a local test or throwaway instance.
+   {{< /warning >}}
 
    ```sh
    arangodb_operator_platform license inventory \
-     --arango.endpoint="http://localhost:8529" \
+     --arango.endpoint="<arango-endpoint>" \
      inventory.json
    ```
 

--- a/site/content/arangodb/4.0/operations/administration/license-management.md
+++ b/site/content/arangodb/4.0/operations/administration/license-management.md
@@ -65,23 +65,24 @@ you use only for license generation.
 The [License Activation portal](https://activate.license.arango.ai/) is a
 browser-based alternative to the Platform CLI tool's `license activate` and
 `license generate` commands. It does not replace `license inventory` — the
-CLI is still required to produce an inventory file for the **Inventory**
-mode. The portal exposes two activation modes:
+Platform CLI tool is still required to produce an inventory file for the
+**Inventory** mode. The portal exposes three activation modes:
 
-- **Inventory** — upload an `inventory.json` file produced by
-  `arangodb_operator_platform license inventory`. The standard mode and the
-  one to use for offline / air-gapped flows.
-- **Managed** — provide just the deployment ID. No inventory file is needed.
+- **Inventory** — license credentials plus an `inventory.json` file produced
+  by `arangodb_operator_platform license inventory`. The default mode, and
+  the only option available for most customers.
+- **Managed** — license credentials plus the deployment ID only. No
+  inventory file is needed.
+- **Generic** — license credentials only, with no deployment binding.
 
-Which modes are available depends on the license configuration that Arango
-sets up for your account. **Managed** activation is not enabled for every
-customer. Check your contract or with your Arango contact for what was
-agreed. If you are unsure, you can try **Managed** first; if it is not
-enabled for your credentials, the portal rejects the request and you can
-fall back to **Inventory**.
+The availability of **Managed** and **Generic** modes depends on the
+contractual agreement between Arango and the customer. The **Inventory**
+mode is available to all customers and, for most, is the only option. If
+a mode is not enabled for your credentials, the portal rejects the
+request — fall back to **Inventory**.
 
 See the **Activation portal** entries in
-[Activate a deployment](#license-activation-portal-managed-mode),
+[Activate a deployment](#license-activation-portal),
 [Generate a license key](#generate-a-license-key), and the
 [container walkthrough](#walkthrough-generate-a-key-in-a-container).
 {{< /tip >}}
@@ -111,11 +112,13 @@ See the **Activation portal** entries in
 ### Standalone deployment
 
 You can activate a standalone deployment with the Platform CLI tool or, if
-**Managed** activation is enabled for your license, with the License
-Activation portal. The CLI is the recommended option for ongoing operation
-because it can re-activate the deployment automatically on a fixed interval.
-The activation portal is a quick, browser-based alternative for one-off
-activation.
+your contract enables it, with the License Activation portal in **Managed**
+or **Generic** mode. The Platform CLI tool is the recommended option for
+ongoing operation because it can re-activate the deployment automatically
+on a fixed interval. The activation portal is a quick, browser-based
+alternative for one-off activation. An activation has a short validity by
+default; the portal's **Custom TTL** lets you override it within the limits
+permitted by your contract.
 
 #### Platform CLI tool
 
@@ -179,28 +182,30 @@ activation.
    with a restart policy, or Kubernetes) so renewals resume automatically
    if the process exits unexpectedly.
 
-#### License Activation portal (Managed mode)
+#### License Activation portal
 
-The portal supports two activation modes:
+The portal supports three activation modes:
 
-- **Managed** identifies the deployment by its deployment ID alone. No
-  inventory file is needed. This is the mode used in this section, because
-  it applies to a running online standalone deployment.
 - **Inventory** identifies the deployment by an `inventory.json` file
-  produced by the Platform CLI tool. It is the mode used for offline /
-  air-gapped flows; see [Generate a license key](#generate-a-license-key)
-  below.
+  produced by the Platform CLI tool. The default mode, and the only
+  option available for most customers.
+- **Managed** identifies the deployment by its deployment ID alone. No
+  inventory file is needed. The mode covered in the procedure below,
+  because it applies to a running online standalone deployment.
+- **Generic** uses the license credentials only, with no deployment
+  binding. The procedure below applies; just skip the deployment ID step.
 
 {{< info >}}
-**Managed** activation is not enabled for every customer. Check your
-contract or with your Arango contact for what was agreed. If it is not
-enabled for your credentials, the portal rejects the request and you
-should use the [Platform CLI tool](#platform-cli-tool) instead.
+The availability of **Managed** and **Generic** modes depends on the
+contractual agreement between Arango and the customer. The **Inventory**
+mode is available to all customers. If a mode is not enabled for your
+credentials, the portal rejects the request and you should use
+**Inventory** or the [Platform CLI tool](#platform-cli-tool) instead.
 {{< /info >}}
 
 The portal generates a license key for a deployment without running the
 Platform CLI tool. It is suited to one-off activation; for unattended renewal,
-use the CLI's `--license.interval` instead.
+use the Platform CLI tool's `--license.interval` instead.
 
 1. Get the deployment ID from a running ArangoDB instance:
 
@@ -214,7 +219,13 @@ use the CLI's `--license.interval` instead.
 
 2. Open <https://activate.license.arango.ai/>.
 3. Enter your **License Client ID** and **License Client Secret**.
-4. Select **Managed — Deployment ID only** and paste the deployment ID.
+4. Select the activation mode:
+   - **Inventory** (default): upload the `inventory.json` file produced
+     by `arangodb_operator_platform license inventory`. See
+     [Generate a license key](#generate-a-license-key) for the
+     end-to-end flow that uses this mode.
+   - **Managed — Deployment ID only**: paste the deployment ID from step 1.
+   - **Generic** (if available): no further input is needed.
 5. Optionally enable **Custom TTL** to override the default license duration.
 6. Click **Activate** and copy the generated license key.
 7. Apply the license key to ArangoDB using one of the interfaces in
@@ -282,9 +293,10 @@ configuration options that let you tune TTL and grace periods.
 
    {{< warning >}}
    The inventory file captures the deployment ID of whichever ArangoDB
-   instance you point the CLI at. The license key generated from it only
-   works for that instance. Make sure the endpoint is the deployment you
-   intend to license — not a local test or throwaway instance.
+   instance you point the Platform CLI tool at. The license key generated
+   from it only works for that instance. Make sure the endpoint is the
+   deployment you intend to license — not a local test or throwaway
+   instance.
    {{< /warning >}}
 
    ```sh
@@ -339,7 +351,7 @@ configuration options that let you tune TTL and grace periods.
    1. Open <https://activate.license.arango.ai/>.
    2. Enter your **License Client ID** and **License Client Secret**.
    3. Choose how to identify the deployment:
-      - **Inventory** (default): drop the `inventory.json` file into the upload
+      - **Inventory** (default): upload the `inventory.json` file into the upload
         area, or click to select it. Captures the full deployment shape and is
         recommended for offline / air-gapped environments.
       - **Managed — Deployment ID only**: enter the deployment ID directly.

--- a/site/content/arangodb/4.0/operations/administration/license-management.md
+++ b/site/content/arangodb/4.0/operations/administration/license-management.md
@@ -20,7 +20,7 @@ deployment has internet access:
 
 | Your deployment | How to license it | Run the Platform CLI tool? |
 |---|---|---|
-| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool. | **Yes** — you run `arangodb_operator_platform` |
+| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool (recommended for unattended renewal) or the [License Activation web UI](https://activate.license.arango.ai/) in **Managed** mode (one-off). | **Optional** — only if you use the Platform CLI tool |
 | **Standalone ArangoDB**, offline / air-gapped | [Generate a license key](#generate-a-license-key) on a separate internet-connected machine, then [apply it](#apply-a-license-key) via arangosh or the HTTP API. | **Yes** — on the internet-connected machine only |
 | **Kubernetes with internet access** (incl. Contextual Data Platform) | Create a Kubernetes secret with your client ID and client secret. The [ArangoDB Kubernetes Operator (`kube-arangodb`)](https://github.com/arangodb/kube-arangodb) activates the deployment and renews the license automatically. | **No** — the operator does everything |
 | **Air-gapped Kubernetes** (no internet access) | Generate a license key on a separate internet-connected machine, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes** — on the internet-connected machine only |
@@ -60,6 +60,22 @@ ArangoDB endpoint over the network, including from inside a container
 you use only for license generation.
 {{< /info >}}
 
+{{< tip >}}
+The [License Activation web UI](https://activate.license.arango.ai/) is a
+graphical alternative to the Platform CLI tool. It supports two modes:
+
+- **Inventory** — upload an `inventory.json` file produced by
+  `arangodb_operator_platform license inventory`. Recommended for offline /
+  air-gapped flows.
+- **Managed** — provide just the deployment ID. Skips the inventory step;
+  suited to one-off activation of an online deployment.
+
+See the **Web UI** entries in
+[Activate a deployment](#license-activation-web-ui-managed-mode),
+[Generate a license key](#generate-a-license-key), and the
+[container walkthrough](#walkthrough-generate-a-key-in-a-container).
+{{< /tip >}}
+
 ## License methods summary
 
 - **Activate a deployment** (from v3.12.6 onward):\
@@ -82,7 +98,14 @@ you use only for license generation.
 
 ## Activate a deployment
 
-### Standalone deployment (Platform CLI)
+### Standalone deployment
+
+You can activate a standalone deployment with the Platform CLI tool or with
+the License Activation web UI. The CLI is the recommended option for ongoing
+operation because it can re-activate the deployment automatically on a fixed
+interval. The web UI is a quick, graphical alternative for one-off activation.
+
+#### Platform CLI tool
 
 1. Download the Platform CLI tool `arangodb_operator_platform` from
    <https://github.com/arangodb/kube-arangodb/releases>.
@@ -143,6 +166,35 @@ you use only for license generation.
    (for example a systemd unit with `Restart=always`, a container
    with a restart policy, or Kubernetes) so renewals resume automatically
    if the process exits unexpectedly.
+
+#### License Activation web UI (Managed mode)
+
+The web UI generates a license key for a deployment without running the
+Platform CLI tool. It is suited to one-off activation; for unattended renewal,
+use the CLI's `--license.interval` instead.
+
+1. Get the deployment ID from a running ArangoDB instance:
+
+   ```sh
+   # User credentials (-u username:password)
+   curl -u root: http://localhost:8529/_admin/deployment/id
+
+   # Example result:
+   # {"id":"6172616e-676f-4000-0000-05c958168340"}
+   ```
+
+2. Open <https://activate.license.arango.ai/>.
+3. Enter your **License Client ID** and **License Client Secret**.
+4. Select **Managed — Deployment ID only** and paste the deployment ID.
+5. Optionally enable **Custom TTL** to override the default license duration.
+6. Click **Activate** and copy the generated license key.
+7. Apply the license key to ArangoDB using one of the interfaces in
+   [Apply a license key](#apply-a-license-key) — for example `arangosh` or
+   the HTTP API.
+
+Repeat this procedure when the license is close to expiry. If you want
+unattended renewal, use the [Platform CLI tool](#platform-cli-tool) with
+`--license.interval` instead.
 
 ### Kubernetes-managed deployment
 
@@ -236,8 +288,36 @@ configuration options that let you tune TTL and grace periods.
    # {"id":"6172616e-676f-4000-0000-05c958168340"}
    ```
 
-4. Generate the license key using the deployment ID, the inventory file, and the
-   license credentials, and write it to a file:
+4. Generate the license key using the deployment ID, the inventory file, and
+   the license credentials. You can do this with the License Activation web UI
+   or with the Platform CLI tool — both produce an equivalent license key.
+
+   {{< tabs "generate-license-key" >}}
+
+   {{< tab "Web UI" >}}
+   1. Open <https://activate.license.arango.ai/>.
+   2. Enter your **License Client ID** and **License Client Secret**.
+   3. Choose how to identify the deployment:
+      - **Inventory** (default): drop the `inventory.json` file into the upload
+        area, or click to select it. Captures the full deployment shape and is
+        recommended for offline / air-gapped environments.
+      - **Managed — Deployment ID only**: enter the deployment ID directly.
+        The license server tracks the deployment state; no inventory file is
+        needed. Use this when you want a one-off key for a known online
+        deployment without running `license inventory`.
+   4. Optionally enable **Custom TTL** to override the default license duration.
+      Accepts values like `24h`, `168h`, `7d`, or `3600s`.
+   5. Click **Activate** and copy the generated license key.
+
+   The web UI is a convenient alternative for users who would otherwise run
+   `arangodb_operator_platform license generate`. Inventory mode still requires
+   the Platform CLI tool to produce the inventory file in the previous step;
+   Managed mode skips that step entirely.
+   {{< /tab >}}
+
+   {{< tab "Platform CLI" >}}
+   Run the Platform CLI tool with the deployment ID, the inventory file, and
+   the license credentials, and write the key to a file:
 
    ```sh
    arangodb_operator_platform license generate \
@@ -247,6 +327,9 @@ configuration options that let you tune TTL and grace periods.
      --license.client.secret "00000000-0000-0000-0000-000000000000" \
      2> license_key.txt
    ```
+   {{< /tab >}}
+
+   {{< /tabs >}}
 
 ### Walkthrough: generate a key in a container
 
@@ -376,10 +459,40 @@ Copy the `id` value for the next step.
 
 #### 6. Generate the license key
 
-Call the Platform CLI tool with the deployment ID, the inventory file, and the
-license credentials you received from Arango (a client ID and a client
-secret). The command writes log output to standard output and writes the
-license key itself to standard error — redirect standard error to a file:
+Generate the license key using the deployment ID, the inventory file, and
+the license credentials you received from Arango (a client ID and a client
+secret). You can do this with the License Activation web UI (no extra tool
+needed) or with the Platform CLI tool inside the container. Both options
+produce an equivalent license key.
+
+{{< tabs "walkthrough-generate-license-key" >}}
+
+{{< tab "Web UI" >}}
+1. Open <https://activate.license.arango.ai/>.
+2. Enter your **License Client ID** and **License Client Secret**.
+3. Choose how to identify the deployment:
+   - **Inventory** (default): copy `inventory.json` out of the container so
+     you can upload it from your browser, then drop it into the upload area:
+
+     ```sh
+     docker cp arangodb:/inventory.json ./inventory.json
+     ```
+
+   - **Managed — Deployment ID only**: enter the deployment ID from the
+     previous step. No inventory file is needed.
+4. Optionally enable **Custom TTL** to override the default license duration.
+5. Click **Activate** and copy the generated license key into a local
+   `license_key.txt` file.
+
+The web UI is a convenient alternative for users who would otherwise run
+`arangodb_operator_platform license generate`.
+{{< /tab >}}
+
+{{< tab "Platform CLI" >}}
+Call the Platform CLI tool with the deployment ID, the inventory file, and
+the license credentials. The command writes log output to standard output
+and writes the license key itself to standard error — redirect standard
+error to a file:
 
 ```sh
 arangodb_operator_platform license generate \
@@ -398,6 +511,9 @@ out of the container before you stop it:
 ```sh
 docker cp arangodb:/license_key.txt ./license_key.txt
 ```
+{{< /tab >}}
+
+{{< /tabs >}}
 
 #### 7. Apply the license key to ArangoDB
 

--- a/site/content/arangodb/4.0/operations/administration/license-management.md
+++ b/site/content/arangodb/4.0/operations/administration/license-management.md
@@ -20,7 +20,7 @@ deployment has internet access:
 
 | Your deployment | How to license it | Run the Platform CLI tool? |
 |---|---|---|
-| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool (recommended for unattended renewal) or the [License Activation web UI](https://activate.license.arango.ai/) in **Managed** mode (one-off). | **Optional** — only if you use the Platform CLI tool |
+| **Standalone ArangoDB** with internet access | [Activate the deployment](#activate-a-deployment) with the Platform CLI tool (recommended for unattended renewal) or, if **Managed** activation is enabled for your license, with the [License Activation portal](https://activate.license.arango.ai/) (one-off). | **Optional** — only if you use the Platform CLI tool |
 | **Standalone ArangoDB**, offline / air-gapped | [Generate a license key](#generate-a-license-key) on a separate internet-connected machine, then [apply it](#apply-a-license-key) via arangosh or the HTTP API. | **Yes** — on the internet-connected machine only |
 | **Kubernetes with internet access** (incl. Contextual Data Platform) | Create a Kubernetes secret with your client ID and client secret. The [ArangoDB Kubernetes Operator (`kube-arangodb`)](https://github.com/arangodb/kube-arangodb) activates the deployment and renews the license automatically. | **No** — the operator does everything |
 | **Air-gapped Kubernetes** (no internet access) | Generate a license key on a separate internet-connected machine, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes** — on the internet-connected machine only |
@@ -61,17 +61,26 @@ you use only for license generation.
 {{< /info >}}
 
 {{< tip >}}
-The [License Activation web UI](https://activate.license.arango.ai/) is a
-graphical alternative to the Platform CLI tool. It supports two modes:
+The [License Activation portal](https://activate.license.arango.ai/) is a
+browser-based alternative to the Platform CLI tool's `license activate` and
+`license generate` commands. It does not replace `license inventory` — the
+CLI is still required to produce an inventory file for the **Inventory**
+mode. The portal exposes two activation modes:
 
 - **Inventory** — upload an `inventory.json` file produced by
-  `arangodb_operator_platform license inventory`. Recommended for offline /
-  air-gapped flows.
-- **Managed** — provide just the deployment ID. Skips the inventory step;
-  suited to one-off activation of an online deployment.
+  `arangodb_operator_platform license inventory`. The standard mode and the
+  one to use for offline / air-gapped flows.
+- **Managed** — provide just the deployment ID. No inventory file is needed.
 
-See the **Web UI** entries in
-[Activate a deployment](#license-activation-web-ui-managed-mode),
+Which modes are available depends on the license configuration that Arango
+sets up for your account. **Managed** activation is not enabled for every
+customer. Check your contract or with your Arango contact for what was
+agreed. If you are unsure, you can try **Managed** first; if it is not
+enabled for your credentials, the portal rejects the request and you can
+fall back to **Inventory**.
+
+See the **Activation portal** entries in
+[Activate a deployment](#license-activation-portal-managed-mode),
 [Generate a license key](#generate-a-license-key), and the
 [container walkthrough](#walkthrough-generate-a-key-in-a-container).
 {{< /tip >}}
@@ -100,10 +109,12 @@ See the **Web UI** entries in
 
 ### Standalone deployment
 
-You can activate a standalone deployment with the Platform CLI tool or with
-the License Activation web UI. The CLI is the recommended option for ongoing
-operation because it can re-activate the deployment automatically on a fixed
-interval. The web UI is a quick, graphical alternative for one-off activation.
+You can activate a standalone deployment with the Platform CLI tool or, if
+**Managed** activation is enabled for your license, with the License
+Activation portal. The CLI is the recommended option for ongoing operation
+because it can re-activate the deployment automatically on a fixed interval.
+The activation portal is a quick, browser-based alternative for one-off
+activation.
 
 #### Platform CLI tool
 
@@ -167,9 +178,26 @@ interval. The web UI is a quick, graphical alternative for one-off activation.
    with a restart policy, or Kubernetes) so renewals resume automatically
    if the process exits unexpectedly.
 
-#### License Activation web UI (Managed mode)
+#### License Activation portal (Managed mode)
 
-The web UI generates a license key for a deployment without running the
+The portal supports two activation modes:
+
+- **Managed** identifies the deployment by its deployment ID alone. No
+  inventory file is needed. This is the mode used in this section, because
+  it applies to a running online standalone deployment.
+- **Inventory** identifies the deployment by an `inventory.json` file
+  produced by the Platform CLI tool. It is the mode used for offline /
+  air-gapped flows; see [Generate a license key](#generate-a-license-key)
+  below.
+
+{{< info >}}
+**Managed** activation is not enabled for every customer. Check your
+contract or with your Arango contact for what was agreed. If it is not
+enabled for your credentials, the portal rejects the request and you
+should use the [Platform CLI tool](#platform-cli-tool) instead.
+{{< /info >}}
+
+The portal generates a license key for a deployment without running the
 Platform CLI tool. It is suited to one-off activation; for unattended renewal,
 use the CLI's `--license.interval` instead.
 
@@ -289,12 +317,12 @@ configuration options that let you tune TTL and grace periods.
    ```
 
 4. Generate the license key using the deployment ID, the inventory file, and
-   the license credentials. You can do this with the License Activation web UI
+   the license credentials. You can do this with the License Activation portal
    or with the Platform CLI tool — both produce an equivalent license key.
 
    {{< tabs "generate-license-key" >}}
 
-   {{< tab "Web UI" >}}
+   {{< tab "Activation portal" >}}
    1. Open <https://activate.license.arango.ai/>.
    2. Enter your **License Client ID** and **License Client Secret**.
    3. Choose how to identify the deployment:
@@ -302,14 +330,15 @@ configuration options that let you tune TTL and grace periods.
         area, or click to select it. Captures the full deployment shape and is
         recommended for offline / air-gapped environments.
       - **Managed — Deployment ID only**: enter the deployment ID directly.
-        The license server tracks the deployment state; no inventory file is
-        needed. Use this when you want a one-off key for a known online
-        deployment without running `license inventory`.
+        No inventory file is needed. Available only if **Managed** activation
+        is enabled for your license — check your contract or with your Arango
+        contact. If it is not enabled, the portal rejects the request and
+        you should use **Inventory** mode instead.
    4. Optionally enable **Custom TTL** to override the default license duration.
       Accepts values like `24h`, `168h`, `7d`, or `3600s`.
    5. Click **Activate** and copy the generated license key.
 
-   The web UI is a convenient alternative for users who would otherwise run
+   The activation portal is a convenient alternative for users who would otherwise run
    `arangodb_operator_platform license generate`. Inventory mode still requires
    the Platform CLI tool to produce the inventory file in the previous step;
    Managed mode skips that step entirely.
@@ -461,13 +490,13 @@ Copy the `id` value for the next step.
 
 Generate the license key using the deployment ID, the inventory file, and
 the license credentials you received from Arango (a client ID and a client
-secret). You can do this with the License Activation web UI (no extra tool
+secret). You can do this with the License Activation portal (no extra tool
 needed) or with the Platform CLI tool inside the container. Both options
 produce an equivalent license key.
 
 {{< tabs "walkthrough-generate-license-key" >}}
 
-{{< tab "Web UI" >}}
+{{< tab "Activation portal" >}}
 1. Open <https://activate.license.arango.ai/>.
 2. Enter your **License Client ID** and **License Client Secret**.
 3. Choose how to identify the deployment:
@@ -479,12 +508,14 @@ produce an equivalent license key.
      ```
 
    - **Managed — Deployment ID only**: enter the deployment ID from the
-     previous step. No inventory file is needed.
+     previous step. No inventory file is needed. Available only if
+     **Managed** activation is enabled for your license — check your
+     contract or with your Arango contact.
 4. Optionally enable **Custom TTL** to override the default license duration.
 5. Click **Activate** and copy the generated license key into a local
    `license_key.txt` file.
 
-The web UI is a convenient alternative for users who would otherwise run
+The activation portal is a convenient alternative for users who would otherwise run
 `arangodb_operator_platform license generate`.
 {{< /tab >}}
 

--- a/site/content/arangodb/4.0/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -1020,14 +1020,14 @@ more data, less file descriptors are used.
 
 <small>Introduced in: v3.12.6</small>
 
-Enterprise Edition license keys are now longer issued directly. Customers receive
+Enterprise Edition license keys are no longer issued directly. Customers receive
 license credentials instead. You can use a command-line tool to either activate
 deployments or generate license keys using these credentials. An internet
 connection is required for both. A generated key can subsequently be applied to
 an air-gapped deployment without internet access.
 
 The activation and license keys are now typically short-lived and need to be
-renewed every two weeks. Old license keys remain valid until their regular
+renewed periodically. Old license keys remain valid until their regular
 expiration.
 
 See [Enterprise Edition License Management](../../operations/administration/license-management.md)

--- a/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
+++ b/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
@@ -451,13 +451,39 @@ The UUID wrapped in quote marks is the deployment ID.
 
 {{< tag "Internet-connected system" >}}
 
-Use your license credentials as well as the information from the previous step
-to create a license key.
+Use your license credentials together with the inventory file and deployment ID
+from the previous step to obtain a license key. You can do this with the
+License Activation web UI or with the Platform CLI tool — both produce an
+equivalent license key.
 
-Substitute `<license-client-id>` and `<license-client-secret>`
-with the actual license credentials. Specify the path to the inventory file
-`inventory.json` and replace `<deployment-id>` with the deployment ID from
-the previous step.
+{{< tabs "offline-generate-license-key" >}}
+
+{{< tab "Web UI" >}}
+1. Open <https://activate.license.arango.ai/> in a browser.
+2. Enter your **License Client ID** and **License Client Secret**.
+3. Choose how to identify the deployment:
+   - **Inventory** (default): drop the `inventory.json` file into the upload
+     area, or click to select it. Captures the full deployment shape and is
+     recommended for air-gapped deployments.
+   - **Managed — Deployment ID only**: enter the deployment ID from the
+     previous step. The license server tracks the deployment state; no
+     inventory file is needed.
+4. Optionally enable **Custom TTL** to override the default license duration.
+   Accepts values like `24h`, `168h`, `7d`, or `3600s`.
+5. Click **Activate** and copy the generated license key (e.g. into a local
+   `license.txt` file). You will use it in the next step to create the
+   Kubernetes secret on the air-gapped system.
+
+The web UI is a convenient alternative for users who would otherwise run
+`arangodb_operator_platform license generate`. Inventory mode still requires
+the Platform CLI tool to produce `inventory.json` in the previous step;
+Managed mode skips that step entirely.
+{{< /tab >}}
+
+{{< tab "Platform CLI" >}}
+Substitute `<license-client-id>` and `<license-client-secret>` with the actual
+license credentials. Specify the path to the inventory file `inventory.json`
+and replace `<deployment-id>` with the deployment ID from the previous step.
 
 ```sh
 arangodb_operator_platform license generate \
@@ -494,6 +520,9 @@ Expected output (_stdout_, `x` stands for varying letter or digit):
 2026-02-05T17:27:28+01:00 INF Generating License ClusterID=<deployment-id> Inventory=true
 2026-02-05T17:27:28+01:00 INF License Generated and printed to STDERR ClusterID=<deployment-id> Inventory=true LicenseID=xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
+{{< /tab >}}
+
+{{< /tabs >}}
 
 ## Step 8: Create a secret for the license
 

--- a/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
+++ b/site/content/contextual-data-platform/install-and-upgrade/offline-setup.md
@@ -453,12 +453,12 @@ The UUID wrapped in quote marks is the deployment ID.
 
 Use your license credentials together with the inventory file and deployment ID
 from the previous step to obtain a license key. You can do this with the
-License Activation web UI or with the Platform CLI tool — both produce an
+License Activation portal or with the Platform CLI tool — both produce an
 equivalent license key.
 
 {{< tabs "offline-generate-license-key" >}}
 
-{{< tab "Web UI" >}}
+{{< tab "Activation portal" >}}
 1. Open <https://activate.license.arango.ai/> in a browser.
 2. Enter your **License Client ID** and **License Client Secret**.
 3. Choose how to identify the deployment:
@@ -466,16 +466,18 @@ equivalent license key.
      area, or click to select it. Captures the full deployment shape and is
      recommended for air-gapped deployments.
    - **Managed — Deployment ID only**: enter the deployment ID from the
-     previous step. The license server tracks the deployment state; no
-     inventory file is needed.
+     previous step. No inventory file is needed. Available only if
+     **Managed** activation is enabled for your license — check your
+     contract or with your Arango contact. If it is not enabled, use
+     **Inventory** mode instead.
 4. Optionally enable **Custom TTL** to override the default license duration.
    Accepts values like `24h`, `168h`, `7d`, or `3600s`.
 5. Click **Activate** and copy the generated license key (e.g. into a local
    `license.txt` file). You will use it in the next step to create the
    Kubernetes secret on the air-gapped system.
 
-The web UI is a convenient alternative for users who would otherwise run
-`arangodb_operator_platform license generate`. Inventory mode still requires
+The activation portal is a convenient alternative for users who would otherwise
+run `arangodb_operator_platform license generate`. Inventory mode still requires
 the Platform CLI tool to produce `inventory.json` in the previous step;
 Managed mode skips that step entirely.
 {{< /tab >}}

--- a/site/content/contextual-data-platform/license-management.md
+++ b/site/content/contextual-data-platform/license-management.md
@@ -22,7 +22,7 @@ license service:
 | Your cluster | What you do | Platform CLI tool? |
 |---|---|---|
 | **Online** — can reach `*.license.arango.ai` | Create a Kubernetes secret with your **client ID** and **client secret**. The operator activates the deployment and renews the license automatically. | **No** |
-| **Air-gapped** — no internet access | Generate a **license key** on a separate internet-connected machine using the [License Activation web UI](https://activate.license.arango.ai/) or the Platform CLI tool, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes**, on the internet-connected machine only — the Platform CLI is required to produce the inventory file |
+| **Air-gapped** — no internet access | Generate a **license key** on a separate internet-connected machine using the [License Activation portal](https://activate.license.arango.ai/) or the Platform CLI tool, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes**, on the internet-connected machine only — the Platform CLI is required to produce the inventory file |
 
 The rest of this page describes how the operator manages the license and
 how to apply it for each flow.
@@ -44,7 +44,7 @@ the license.
 
 Air-gapped deployments do not need any outbound access from the Kubernetes cluster.
 License keys are generated on a separate internet-connected system using the
-[License Activation web UI](https://activate.license.arango.ai/) or the
+[License Activation portal](https://activate.license.arango.ai/) or the
 [Platform CLI tool](install-and-upgrade/offline-setup.md#step-7-generate-a-license-key)
 and then applied as a Kubernetes secret on the air-gapped cluster.
 
@@ -170,10 +170,12 @@ you generate a long-lived license key on an internet-connected system and
 apply it as a secret on the air-gapped cluster.
 
 1. On an internet-connected system, generate a license key for your deployment
-   using either the [License Activation web UI](https://activate.license.arango.ai/)
+   using either the [License Activation portal](https://activate.license.arango.ai/)
    or the Platform CLI tool. You need the deployment ID collected from the
-   air-gapped cluster, plus an inventory file (the web UI's **Managed** mode
-   accepts the deployment ID alone and skips the inventory file). See
+   air-gapped cluster, plus an inventory file. (If **Managed** activation is
+   enabled for your license, the portal accepts the deployment ID alone and
+   skips the inventory file — check your contract or with your Arango
+   contact.) See
    [Step 6: Collect information for the licensing](install-and-upgrade/offline-setup.md#step-6-collect-information-for-the-licensing)
    and [Step 7: Generate a license key](install-and-upgrade/offline-setup.md#step-7-generate-a-license-key)
    in the offline setup guide for the detailed procedure.

--- a/site/content/contextual-data-platform/license-management.md
+++ b/site/content/contextual-data-platform/license-management.md
@@ -22,7 +22,7 @@ license service:
 | Your cluster | What you do | Platform CLI tool? |
 |---|---|---|
 | **Online** — can reach `*.license.arango.ai` | Create a Kubernetes secret with your **client ID** and **client secret**. The operator activates the deployment and renews the license automatically. | **No** |
-| **Air-gapped** — no internet access | Generate a **license key** on a separate internet-connected machine using the Platform CLI tool, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes**, on the internet-connected machine only |
+| **Air-gapped** — no internet access | Generate a **license key** on a separate internet-connected machine using the [License Activation web UI](https://activate.license.arango.ai/) or the Platform CLI tool, then apply it as a Kubernetes secret on the air-gapped cluster. | **Yes**, on the internet-connected machine only — the Platform CLI is required to produce the inventory file |
 
 The rest of this page describes how the operator manages the license and
 how to apply it for each flow.
@@ -44,6 +44,7 @@ the license.
 
 Air-gapped deployments do not need any outbound access from the Kubernetes cluster.
 License keys are generated on a separate internet-connected system using the
+[License Activation web UI](https://activate.license.arango.ai/) or the
 [Platform CLI tool](install-and-upgrade/offline-setup.md#step-7-generate-a-license-key)
 and then applied as a Kubernetes secret on the air-gapped cluster.
 
@@ -168,9 +169,11 @@ In air-gapped environments, the Kubernetes cluster cannot reach the license serv
 you generate a long-lived license key on an internet-connected system and
 apply it as a secret on the air-gapped cluster.
 
-1. On an internet-connected system, use the Platform CLI tool to generate
-   a license key for your deployment. This requires an inventory file and
-   the deployment ID collected from the air-gapped cluster — see
+1. On an internet-connected system, generate a license key for your deployment
+   using either the [License Activation web UI](https://activate.license.arango.ai/)
+   or the Platform CLI tool. You need the deployment ID collected from the
+   air-gapped cluster, plus an inventory file (the web UI's **Managed** mode
+   accepts the deployment ID alone and skips the inventory file). See
    [Step 6: Collect information for the licensing](install-and-upgrade/offline-setup.md#step-6-collect-information-for-the-licensing)
    and [Step 7: Generate a license key](install-and-upgrade/offline-setup.md#step-7-generate-a-license-key)
    in the offline setup guide for the detailed procedure.


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * License Activation portal added as an alternative to the Platform CLI for internet-connected standalone deployments; CLI now optional for standalone+online when Managed is enabled
  * New portal modes: Managed (deployment ID only), Inventory (requires CLI-produced inventory.json), Generic (credentials-only); portal rejects unsupported modes
  * Added dedicated Managed activation flow, tabbed portal vs CLI license-generation steps, Custom TTL option, and updated container/offline walkthroughs
  * Clarified licensing wording: credentials-based issuance and renewal described as “renewed periodically” (older keys remain valid)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->