### PR TITLE
Correct and update the definition of RAG Strategizer

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -131,13 +131,14 @@ question, the large language model (LLM) is supplied with additional context
 from the knowledge graph, using lexical and semantic search. This enables
 accurate, context-aware intelligence grounded in enterprise data.
 
-### AutoGraph with AutoRAG
+### AutoGraph with the RAG Strategizer
 
-Arango [AutoGraph](agentic-ai-suite/autograph/_index.md) turbocharges GraphRAG
-with AutoRAG to automatically create a knowledge graph out of your organization's
-data with per-domain RAG partitions. Queries are intelligently routed, selecting
-the optimal domain-aware retrieval strategy.
+Arango [AutoGraph](agentic-ai-suite/autograph/_index.md) extends GraphRAG by
+automatically discovering knowledge domains in your organization's data and
+building a per-domain contextual knowledge graph. Its RAG Strategizer
+assigns each domain the right processing depth: full entity extraction for
+complex content, a lighter partition for simpler content.
 
-It creates knowledge shards for AI agents and co-pilot that let you improve
+It creates knowledge shards for AI agents and co-pilots that let you improve
 response accuracy, consistency, and explainability across enterprise
 AI applications.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -131,11 +131,11 @@ question, the large language model (LLM) is supplied with additional context
 from the knowledge graph, using lexical and semantic search. This enables
 accurate, context-aware intelligence grounded in enterprise data.
 
-### AutoGraph with the RAG Strategizer
+### AutoGraph with AutoRAG
 
 Arango [AutoGraph](agentic-ai-suite/autograph/_index.md) extends GraphRAG by
 automatically discovering knowledge domains in your organization's data and
-building a per-domain contextual knowledge graph. Its RAG Strategizer
+building a per-domain contextual knowledge graph. Its AutoRAG
 assigns each domain the right processing depth: full entity extraction for
 complex content, a lighter partition for simpler content.
 

--- a/site/content/agentic-ai-suite/_index.md
+++ b/site/content/agentic-ai-suite/_index.md
@@ -20,7 +20,7 @@ The Agentic AI Suite is composed of the following major components:
 
 - [**Ada**](ada.md): The AI digital assistant, for natural language interaction and development.
 - [**AutoGraph**](autograph/_index.md): Organize enterprise data into a
-  contextual knowledge graph, with the **RAG Strategizer** assigning each
+  contextual knowledge graph, with the **AutoRAG** assigning each
   domain the right processing depth.
 - [**Natural Language to AQL/AQLizer**](natural-language-to-aql/_index.md): Generate AQL
   queries from natural language to explore your data and gain insights without having

--- a/site/content/agentic-ai-suite/_index.md
+++ b/site/content/agentic-ai-suite/_index.md
@@ -19,9 +19,9 @@ aliases:
 The Agentic AI Suite is composed of the following major components:
 
 - [**Ada**](ada.md): The AI digital assistant, for natural language interaction and development.
-- [**AutoGraph**](autograph/_index.md): Organize enterprise data into contextual
-  knowledge graph, using **AutoRAG** to optimize retrieval across graph, vector,
-  and document data.
+- [**AutoGraph**](autograph/_index.md): Organize enterprise data into a
+  contextual knowledge graph, with the **RAG Strategizer** assigning each
+  domain the right processing depth.
 - [**Natural Language to AQL/AQLizer**](natural-language-to-aql/_index.md): Generate AQL
   queries from natural language to explore your data and gain insights without having
   to learn the query language first.

--- a/site/content/agentic-ai-suite/autograph/_index.md
+++ b/site/content/agentic-ai-suite/autograph/_index.md
@@ -48,12 +48,13 @@ By organizing enterprise data into contextual knowledge graphs, AutoGraph create
 - Operate within governance policies
 - Produce explainable outputs with traceable lineage
 
-## AutoRAG: Automated Retrieval Strategy Selection
+## RAG Strategizer
 
-AutoRAG automatically selects the optimal retrieval strategy by combining:
-- GraphRAG
-- Vector search
-- Hybrid retrieval
-- Contextual summarization
-
-The system dynamically selects the retrieval approach based on the query, enabling AI systems to reason across connected enterprise context.
+Not all content is equally complex. The RAG Strategizer examines the domain
+clusters in the Corpus Graph and assigns each one a processing strategy:
+complex domains get a full knowledge graph with extracted entities and
+relationships (FullGraphRAG); simpler domains get a lighter partition that
+skips entity extraction (VectorRAG). For FullGraphRAG domains, it also
+generates a domain-specific ontology (the entity types to extract), so the
+resulting knowledge graph reflects the concepts that actually matter in
+that content.

--- a/site/content/agentic-ai-suite/autograph/_index.md
+++ b/site/content/agentic-ai-suite/autograph/_index.md
@@ -10,10 +10,17 @@ aliases:
 
 ## What is AutoGraph?
 
-AutoGraph is an automation copilot that analyzes enterprise documents, discovers
-natural knowledge domains, and builds semantic infrastructure for intelligent
-retrieval at scale - importing documents, generating embeddings, building knowledge
-graphs, assigning RAG strategies per domain, and orchestrating downstream GraphRAG builds.
+AutoGraph is a large-scale RAG system that delivers strong accuracy at the
+quality-cost tradeoff you choose. It supports benchmarking, testset creation,
+automated ontologies, separation of concerns across tenants, and extensibility
+to new RAG methods - distilling lessons learned from running RAG at some of the
+world's largest enterprises.
+
+Under the hood, AutoGraph is an automation copilot that analyzes enterprise
+documents, discovers natural knowledge domains, and builds semantic infrastructure
+for intelligent retrieval at scale - importing documents, generating embeddings,
+building knowledge graphs, assigning RAG strategies per domain, and orchestrating
+downstream GraphRAG builds.
 
 Think of it as a **self-organizing knowledge system**. Instead of manually categorizing 
 documents or designing taxonomies, AutoGraph handles the following:

--- a/site/content/agentic-ai-suite/autograph/_index.md
+++ b/site/content/agentic-ai-suite/autograph/_index.md
@@ -12,9 +12,8 @@ aliases:
 
 AutoGraph is a large-scale RAG system that delivers strong accuracy at the
 quality-cost tradeoff you choose. It supports benchmarking, testset creation,
-automated ontologies, separation of concerns across tenants, and extensibility
-to new RAG methods - distilling lessons learned from running RAG at some of the
-world's largest enterprises.
+automated ontologies, and extensibility to new RAG methods - distilling lessons
+learned from running RAG at some of the world's largest enterprises.
 
 Under the hood, AutoGraph is an automation copilot that analyzes enterprise
 documents, discovers natural knowledge domains, and builds semantic infrastructure

--- a/site/content/contextual-data-platform/agentic-ai-suite.md
+++ b/site/content/contextual-data-platform/agentic-ai-suite.md
@@ -12,7 +12,7 @@ description: >-
   The AI digital assistant, for natural language interaction and development.
 - [**AutoGraph**](../agentic-ai-suite/autograph/_index.md):
   Organize enterprise data into a contextual knowledge graph, with the
-  **RAG Strategizer** assigning each domain the right processing depth
+  **AutoRAG** assigning each domain the right processing depth
 - [**AQLizer**](../agentic-ai-suite/natural-language-to-aql/_index.md):
   Generate AQL queries from natural language.
 - [**GraphRAG**](../agentic-ai-suite/graphrag/_index.md):

--- a/site/content/contextual-data-platform/agentic-ai-suite.md
+++ b/site/content/contextual-data-platform/agentic-ai-suite.md
@@ -11,8 +11,8 @@ description: >-
 - [**Ada**](../agentic-ai-suite/ada.md):
   The AI digital assistant, for natural language interaction and development.
 - [**AutoGraph**](../agentic-ai-suite/autograph/_index.md):
-  Organize enterprise data into contextual knowledge graph using
-  **AutoRAG** to optimize retrieval across graph, vector, and document data
+  Organize enterprise data into a contextual knowledge graph, with the
+  **RAG Strategizer** assigning each domain the right processing depth
 - [**AQLizer**](../agentic-ai-suite/natural-language-to-aql/_index.md):
   Generate AQL queries from natural language.
 - [**GraphRAG**](../agentic-ai-suite/graphrag/_index.md):


### PR DESCRIPTION
…y its incorrect definition

### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AutoGraph descriptions across docs to reference the "RAG Strategizer" for assigning per-domain processing depth.
  * Clarified domain-level RAG strategy: FullGraphRAG for complex domains and VectorRAG for simpler domains.
  * Reworded explanatory copy (including reference to "co-pilots") for clearer end-to-end automation and orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->