### PR TITLE
DOC-906 | Retriever: Update `use_cache` and `show_citations` support for different queries 

### DIFF
--- a/site/content/agentic-ai-suite/retriever/executing-queries.md
+++ b/site/content/agentic-ai-suite/retriever/executing-queries.md
@@ -161,6 +161,11 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
   }'
 ```
 
+{{< info >}}
+In Deep Search mode (`use_llm_planner=true`), citations are always disabled
+regardless of `show_citations`. The same applies to `GLOBAL` queries.
+{{< /info >}}
+
 **Global Search:**
 
 ```bash
@@ -172,6 +177,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
     "query_type": 1,
     "level": 1,
     "include_metadata": true,
+    "use_cache": true,
     "response_instructions": "Provide a high-level summary"
   }'
 ```

--- a/site/content/agentic-ai-suite/retriever/parameters.md
+++ b/site/content/agentic-ai-suite/retriever/parameters.md
@@ -131,11 +131,12 @@ Whether to show inline citations in the response.
   - When `true` (default): Citations appear inline as `[X]` in the response.
   - When `false`: All `[CITE:X]` patterns are stripped from the response.
   - This parameter controls displaying citations only. The actual citation URL metadata is set via [`citable_url`](../importer/parameters.md#file-source-parameters) at import time.
+- **Supported query types**: `LOCAL` (with `use_llm_planner=false`), `UNIFIED`, and `CUSTOM`.
+- **Not supported**: `GLOBAL` queries, and any query running in deep search mode (`use_llm_planner=true`); citations are always disabled in those cases regardless of this flag.
 
-{{< warning >}}
-For deep search queries (`use_llm_planner=true`), citations are always disabled
-regardless of this setting.
-{{< /warning >}}
+{{< info >}}
+For `CUSTOM` queries, a tool's own `show_citations: false` configuration can still suppress citations from that tool's results, even when the request-level flag is `true`.
+{{< /info >}}
 
 ### `response_instructions`
 
@@ -173,7 +174,8 @@ Whether to use caching for this query.
 - **Required**: No (defaults to `false` when unspecified).
 - **Description**:
   - When `true`: Checks cache for hits and saves responses to cache.
-  - When `false` (default): Skips cache entirely — no check, no write.
+  - When `false` (default): Skips cache entirely; no check, no write.
+- **Supported query types**: All query types (`GLOBAL`, `LOCAL`, `UNIFIED`, `CUSTOM`).
 
 **Example to enable caching:**
 


### PR DESCRIPTION
…ent queries

### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified citation behavior across search modes: citations are automatically disabled in Deep Search and Global Search modes, regardless of settings.
  * Confirmed caching support availability across all query types.
  * Added guidance for Custom queries enabling individual components to control citation display independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->