### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ redirect and `302` for a temporary one. Use `302` until the redirects have been
 tested, then change them to `301` - this avoids caching issues (browser, CDN)
 should it be necessary to fix some of the redirects.
 
-Netlify redirects are preferable SEO because search engines are more likely to
+Netlify redirects are preferable for SEO because search engines are more likely to
 update links in their indexes if they get a server-side `301 Permanent Redirect`
 HTTP status code, and it also works better when using e.g. cURL
 (`curl -L ...` to automatically follow redirects).

--- a/README.md
+++ b/README.md
@@ -867,18 +867,55 @@ weight: 42 # controls navigation position within the current section (low to hig
 
 Add the actual content formatted in Markdown syntax below the front matter.
 
-### Rename a page or section
+### Rename or move a page or section
+
+There are two options for setting up redirects when renaming or moving content:
+
+- **Netlify redirects**: Server-side, testable in Netlify deploy previews.
+  Use for unversioned content as well as when removing versioned content.
+- **Hugo aliases**: Client-side, can be tested locally. Use only when
+  renaming/moving versioned content to keep the version switcher working locally.
+
+Note that turning a page `topic.md` into a section `topic/_index.md` (in
+order to add child pages) does not affect the resulting URL (`/topic/`) and
+does therefore not require a redirect!
 
 Netlify supports server-side redirects configured with a text file
 ([documentation](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file)).
 This is helpful when renaming folders with many subfolders and files because
 there is support for splatting and placeholders (but not regular expressions). See
 [Redirect options](https://docs.netlify.com/routing/redirects/redirect-options/)
-for details. The configuration file is `site/static/_redirects`.
+for details.
 
-Otherwise, the following steps are necessary for moving content:
+The configuration file is [`site/static/_redirects`](site/static/_redirects).
+The general format is `/old/url/ /new/url/ 301`, where `301` is for a permanent
+redirect and `302` for a temporary one. Use `302` until the redirects have been
+tested, then change them to `301` - this avoids caching issues (browser, CDN)
+should it be necessary to fix some of the redirects.
+
+Netlify redirects are preferable SEO because search engines are more likely to
+update links in their indexes if they get a server-side `301 Permanent Redirect`
+HTTP status code, and it also works better when using e.g. cURL
+(`curl -L ...` to automatically follow redirects).
+
+Where Netlify redirects don't work is when you run the docs toolchain locally.
+This is generally not an issue because they can be tested using the automatic
+deploy previews, and you can only hit the redirects if you manually enter the
+old URLs. There is one exception, however: the **version selector**. If you
+switch between versions of a page, you can get a `404 Not Found` when running
+the docs toolchain locally, while in the Netlify deploy previews, you get
+redirected. This is because the version selector merely substitutes the version
+in the current URL and we hope that this page exists.
+
+To ensure a working version selector locally, which can be helpful when
+reviewing content, the rule is to use Hugo aliases instead of Netlify redirects
+when moving or renaming versioned pages (i.e. `/arangodb/<version>/...`).
+
+The following steps are necessary for moving/renaming versioned content:
 1. Rename file or folder
-2. Set up `aliases` via the front matter as needed
+2. Set up `aliases` via the front matter as needed - consider all version
+   switcher actions, like switching from an older version to any of the newer,
+   renamed/moved versions, and possibly vice versa!
 3. Adjust `weight` of pages in the front matter if necessary
 4. Update cross-references in all of the content to use the new file path
 
@@ -899,6 +936,16 @@ aliases:
 
 Don't forget to update any references to the old file in the content to the new
 path.
+
+Also don't forget to check whether an alias needs to be added for the opposite
+direction so that you can switch between old and new versions without getting
+a `404` error:
+
+| File                           | Alias      |
+|--------------------------------|------------|
+| `/arangodb/3.11/old-name.md`   | `new-name` |
+| `/arangodb/3.12/new-name.md`   | `old-name` |
+| `/arangodb/stable/new-name.md` | `old-name` |
 
 If you move a file from one folder to another, from `old/file.md` to `new/file.md`
 for instance, use a relative path as shown below:
@@ -1122,7 +1169,20 @@ It makes a warning show at the top of every page for that version.
 
    Add the new, untracked files to Git!
 
-8. In the `PULL_REQUEST_TEMPLATE.md` file, add a new line for the new version.
+8. Check whether you need to add additional `aliases` in the front matter of
+   pages. This is necessary keep the switching using the version selector
+   working, from renamed/moved pages in older versions to the corresponding
+   pages in the newer versions.
+
+   ```diff
+    aliases:
+      - ../arangodb/3.12/data-science/arangographml
+      - ../arangodb/stable/data-science/arangographml
+   +  - ../arangodb/4.0/data-science/arangographml
+   +  - ../arangodb/devel/data-science/arangographml
+   ```
+
+9. In the `PULL_REQUEST_TEMPLATE.md` file, add a new line for the new version.
    Example:
 
    ```diff
@@ -1138,33 +1198,33 @@ It makes a warning show at the top of every page for that version.
 
    Expect the plain build to fail for the time being because of missing data files.
 
-9. You can use CircleCI to initially generate the data files for the new version,
-   like the startup option dumps. You can also populate the example cache at the
-   same time.
+10. You can use CircleCI to initially generate the data files for the new version,
+    like the startup option dumps. You can also populate the example cache at the
+    same time.
 
-   Before you continue, make sure there are no conflicts in the PR with the
-   `main` branch. The CircleCI workflow will otherwise create a merge commit
-   favoring the `main` branch (in order to update the cache file but also
-   affecting other files), and this can cause e.g. the `versions.yaml` file to
-   get reverted in case of a conflict. The toolchain would then be unaware of
-   the newly added version.   
+    Before you continue, make sure there are no conflicts in the PR with the
+    `main` branch. The CircleCI workflow will otherwise create a merge commit
+    favoring the `main` branch (in order to update the cache file but also
+    affecting other files), and this can cause e.g. the `versions.yaml` file to
+    get reverted in case of a conflict. The toolchain would then be unaware of
+    the newly added version.   
    
-   In CircleCI at <https://app.circleci.com/pipelines/github/arangodb/docs-hugo>,
-   select the branch of your PR and click **Trigger Pipeline**.
-   Enter the parameters similar to this example:
+    In CircleCI at <https://app.circleci.com/pipelines/github/arangodb/docs-hugo>,
+    select the branch of your PR and click **Trigger Pipeline**.
+    Enter the parameters similar to this example:
 
-   | Type | Name | Value |
-   |:-----|:-----|:------|
-   | string | `workflow` | `generate` |
-   | string | `arangodb-4_0` | Docker Hub image (e.g. `arangodb/enterprise-preview:devel-nightly`) or GitHub main repo PR link (e.g. `https://github.com/arangodb/arangodb/pull/123456`) |
-   | string | `generators` | `examples metrics error-codes exit-codes optimizer options` |
-   | string | `deploy-url` | `deploy-preview-{PR-number}` with the number of the docs PR |
-   | boolean | `commit-generated` | `true` |
+    | Type | Name | Value |
+    |:-----|:-----|:------|
+    | string | `workflow` | `generate` |
+    | string | `arangodb-4_0` | Docker Hub image (e.g. `arangodb/enterprise-preview:devel-nightly`) or GitHub main repo PR link (e.g. `https://github.com/arangodb/arangodb/pull/123456`) |
+    | string | `generators` | `examples metrics error-codes exit-codes optimizer options` |
+    | string | `deploy-url` | `deploy-preview-{PR-number}` with the number of the docs PR |
+    | boolean | `commit-generated` | `true` |
 
-   Approve the workflow in CircleCI. After a successful run, you should see a
-   commit in the docs PR with the updated data files, as well as an updated
-   example cache file. The plain build should no longer fail and provide you
-   with a Netlify preview.
+    Approve the workflow in CircleCI. After a successful run, you should see a
+    commit in the docs PR with the updated data files, as well as an updated
+    example cache file. The plain build should no longer fail and provide you
+    with a Netlify preview.
 
 ### Remove a version
 

--- a/site/content/agentic-ai-suite/autograph/_index.md
+++ b/site/content/agentic-ai-suite/autograph/_index.md
@@ -4,8 +4,6 @@ menuTitle: AutoGraph
 weight: 4
 description: >-
   AutoGraph structures enterprise data into contextual knowledge shards with domain-aware retrieval strategies providing AI copilots and agents with production-grade context infrastructure
-aliases:
-  - ../reference/autograph/
 ---
 
 ## What is AutoGraph?

--- a/site/content/agentic-ai-suite/autograph/reference/_index.md
+++ b/site/content/agentic-ai-suite/autograph/reference/_index.md
@@ -4,8 +4,6 @@ menuTitle: Reference
 weight: 30
 description: >-
   AutoGraph HTTP REST API endpoints, authentication, call sequence, and workflow examples
-aliases:
-  - ../../reference/autograph/
 ---
 
 This section documents the AutoGraph HTTP REST API. All endpoints require

--- a/site/content/agentic-ai-suite/autograph/reference/corpus-build.md
+++ b/site/content/agentic-ai-suite/autograph/reference/corpus-build.md
@@ -4,8 +4,6 @@ menuTitle: Corpus Build
 description: >-
   Create and monitor corpus builds for document analysis and clustering
 weight: 40
-aliases:
-  - ../../../reference/autograph/corpus-build/
 ---
 
 ## Create Corpus Build

--- a/site/content/agentic-ai-suite/autograph/reference/embeddings.md
+++ b/site/content/agentic-ai-suite/autograph/reference/embeddings.md
@@ -4,8 +4,6 @@ menuTitle: Embeddings
 description: >-
   Add embeddings to documents in any ArangoDB collection
 weight: 55
-aliases:
-  - ../../../reference/autograph/embeddings/
 ---
 
 ## Embed field in collection

--- a/site/content/agentic-ai-suite/autograph/reference/importing-files.md
+++ b/site/content/agentic-ai-suite/autograph/reference/importing-files.md
@@ -4,8 +4,6 @@ menuTitle: Import Files
 description: >-
   Upload multiple files into the corpus graph with module organization
 weight: 35
-aliases:
-  - ../../../reference/autograph/importing-files/
 ---
 
 ## Import multiple files

--- a/site/content/agentic-ai-suite/autograph/reference/orchestration.md
+++ b/site/content/agentic-ai-suite/autograph/reference/orchestration.md
@@ -34,7 +34,7 @@ Spawn GraphRAG importer workers for all strategy profiles. Called after RAG stra
 |-----------|------|----------|-------------|-------------------|
 | `replicas` | integer | Yes | Number of Importer worker replicas (parallelism). Minimum: **1**. | **2–4** for typical jobs. Scale up only if you have many partitions and capacity. |
 | `max_retries` | integer | No | Retries per failed Importer job before giving up. | **3** (default) is appropriate for transient errors. |
-| `chat_api_keys` | string[] | No | Raw chat LLM API keys rotated across replicas. | Prefer **secret profiles** in production; use keys only when your deployment has no secret manager. |
+| `chat_api_keys` | string[] | No | Raw chat LLM API keys rotated across replicas. | Prefer **secret profiles** in production; use keys only when your deployment has no secrets manager. |
 | `chat_secret_profile_ids` | string[] | No | Platform secret profile ids for chat keys. Overrides `chat_api_keys` when both are provided. | Provide one or more secret profile IDs. Follow your operator's convention. |
 | `embedding_secret_profile_id` | string | No | Secret profile for embedding key on the Importer. | Set when embedding must come from vault, not env. |
 | `importer_env` | map | No | Extra environment variables for Importer pods (e.g. model names, timeouts). | Start **empty**; add only keys documented for your Importer version (often chunk or model overrides). |

--- a/site/content/agentic-ai-suite/autograph/reference/orchestration.md
+++ b/site/content/agentic-ai-suite/autograph/reference/orchestration.md
@@ -4,8 +4,6 @@ menuTitle: Orchestration
 description: >-
   Automatically spawn importer workers and execute RAG pipeline builds
 weight: 50
-aliases:
-  - ../../../reference/autograph/orchestration/
 ---
 
 ## Trigger Orchestration

--- a/site/content/agentic-ai-suite/autograph/reference/rag-strategizer.md
+++ b/site/content/agentic-ai-suite/autograph/reference/rag-strategizer.md
@@ -4,8 +4,6 @@ menuTitle: RAG Strategizer
 description: >-
   Analyze document clusters and assign optimal RAG strategies
 weight: 45
-aliases:
-  - ../../../reference/autograph/rag-strategizer/
 ---
 
 ## Trigger RAG Strategizer

--- a/site/content/agentic-ai-suite/graphrag/web-interface.md
+++ b/site/content/agentic-ai-suite/graphrag/web-interface.md
@@ -58,8 +58,9 @@ configure and start a new importer service job. Follow the steps below.
 1. Select **OpenAI** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
    the service is using **GPT-4o**.
-3. Enter your **OpenAI API Key**, or click the key icon to select a secret
-   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+3. Enter your **OpenAI API Key**, or click the key icon ({{< icon "key" >}})
+   to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Start importer service** button.
 {{< /tab >}}
 
@@ -67,10 +68,12 @@ configure and start a new importer service job. Follow the steps below.
 1. Select **OpenRouter** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
    the service uses **Mistral AI - Mistral Nemo**.
-3. Enter your **OpenAI API Key**, or click the key icon to select a secret
-   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
-4. Enter your **OpenRouter API Key**, or click the key icon to select a secret
-   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+3. Enter your **OpenAI API Key**, or click the key icon ({{< icon "key" >}})
+   to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
+4. Enter your **OpenRouter API Key**, or click the key icon ({{< icon "key" >}})
+   to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 5. Click the **Start importer service** button.
 
 {{< info >}}
@@ -109,8 +112,9 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Importer** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, or **OpenAI API Key** as needed.
-   For the API key, you can type a new value or click the key icon to select a
-   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+   For the API key, you can type a new value or click the key icon
+   ({{< icon "key" >}}) to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update importer service** button to apply the changes.
 {{< /tab >}}
 
@@ -118,8 +122,9 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Importer** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, **OpenAI API Key**, or **OpenRouter API Key** as needed.
-   For each API key, you can type a new value or click the key icon to select a
-   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+   For each API key, you can type a new value or click the key icon
+   ({{< icon "key" >}}) to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update importer service** button to apply the changes.
 {{< /tab >}}
 
@@ -217,8 +222,9 @@ the generated Knowledge Graph. To configure the retriever service, open the
 1. Select **OpenAI** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
    the service uses **GPT-4o**.
-3. Enter your **OpenAI API Key**, or click the key icon to select a secret
-   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+3. Enter your **OpenAI API Key**, or click the key icon ({{< icon "key" >}})
+   to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Start retriever service** button.
 {{< /tab >}}
 
@@ -226,8 +232,9 @@ the generated Knowledge Graph. To configure the retriever service, open the
 1. Select **OpenRouter** from the **LLM API Provider** dropdown menu.
 2. Select the model you want to use from the **Model** dropdown menu. By default,
    the service uses **Mistral AI - Mistral Nemo**.
-3. Enter your **OpenRouter API Key**, or click the key icon to select a secret
-   stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+3. Enter your **OpenRouter API Key**, or click the key icon ({{< icon "key" >}})
+   to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Start retriever service** button.
 
 {{< info >}}
@@ -266,8 +273,9 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Retriever** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, or **OpenAI API Key** as needed.
-   For the API key, you can type a new value or click the key icon to select a
-   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+   For the API key, you can type a new value or click the key icon
+   ({{< icon "key" >}}) to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update retriever service** button to apply the changes.
 {{< /tab >}}
 
@@ -275,8 +283,9 @@ provider combination, or if your API key has changed or expired.
 1. Open the **Project Settings** dialog.
 2. In the **Retriever** section, click **Edit service**.
 3. Update the **LLM API Provider**, **Model**, or **OpenRouter API Key** as needed.
-   For the API key, you can type a new value or click the key icon to select a
-   secret stored in the [Secrets Manager](../../platform-suite/secrets-manager.md).
+   For the API key, you can type a new value or click the key icon
+   ({{< icon "key" >}}) to select a secret stored in the
+   [Secrets Manager](../../platform-suite/secrets-manager.md).
 4. Click the **Update retriever service** button to apply the changes.
 {{< /tab >}}
 

--- a/site/content/agentic-ai-suite/natural-language-to-aql/_index.md
+++ b/site/content/agentic-ai-suite/natural-language-to-aql/_index.md
@@ -5,8 +5,6 @@ weight: 17
 description: >-
   Query your ArangoDB database using natural language with the AQLizer feature,
   which automatically translates plain language into AQL queries using generative AI
-aliases:
-  - /agentic-ai-suite/aqlizer
 ---
 
 ## Introduction

--- a/site/content/agentic-ai-suite/natural-language-to-aql/api-reference.md
+++ b/site/content/agentic-ai-suite/natural-language-to-aql/api-reference.md
@@ -5,8 +5,6 @@ weight: 20
 description: >-
   REST API reference for the Natural Language to AQL service, including
   endpoints for text processing, AQL generation, and query execution
-aliases:
-  - /agentic-ai-suite/reference/natural-language-to-aql
 ---
 
 This page documents the runtime REST endpoints of the Natural Language to AQL

--- a/site/content/arangodb/3.10/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.10/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -210,7 +210,7 @@ array values in the first level of each passed array.
 
 Now, there is no automatic flattening of arrays and arrays are cast using the
 new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
-members get concatenated - which seems the same as the previous flattening of
+members get concatenated - which is equivalent to the previous flattening of
 one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |

--- a/site/content/arangodb/3.10/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.10/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -180,35 +180,48 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 - arrays are now converted into their JSON-stringify equivalents, e.g.
 
-  - `[ ]` is now converted to `[]`
-  - `[ 1, 2, 3 ]` is now converted to `[1,2,3]`
-  - `[ "test", 1, 2 ] is now converted to `["test",1,2]`
+  - `[ ]` is now converted to `"[]"`
+  - `[ 1, 2, 3 ]` is now converted to `"[1,2,3]"`
+  - `[ "test", 1, 2 ]` is now converted to `"[\"test\",1,2]"`
    
   Previous versions of ArangoDB converted arrays with no members into the
   empty string, and non-empty arrays into a comma-separated list of member
-  values, without the surrounding angular brackets. Additionally, string
+  values, without the surrounding square brackets. Additionally, string
   array members were not enclosed in quotes in the result string:
 
-  - `[ ]` was converted to ``
-  - `[ 1, 2, 3 ]` was converted to `1,2,3`
-  - `[ "test", 1, 2 ] was converted to `test,1,2`
+  - `[ ]` was converted to `""`
+  - `[ 1, 2, 3 ]` was converted to `"1,2,3"`
+  - `[ "test", 1, 2 ]` was converted to `"test,1,2"`
   
 - objects are now converted to their JSON-stringify equivalents, e.g.
 
-  - `{ }` is converted to `{}`
-  - `{ a: 1, b: 2 }` is converted to `{"a":1,"b":2}`
-  - `{ "test" : "foobar" }` is converted to `{"test":"foobar"}`
+  - `{ }` is converted to `"{}"`
+  - `{ a: 1, b: 2 }` is converted to `"{\"a\":1,\"b\":2}"`
+  - `{ test: "foobar" }` is converted to `"{\"test\":\"foobar\"}"`
     
   Previous versions of ArangoDB always converted objects into the string
-  `[object Object]`  
+  `"[object Object]"`.
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
-of ArangoDB automatically flattened array values in the first level of the array, 
-e.g. `CONCAT([1, 2, 3, [ 4, 5, 6 ]])` produced `1,2,3,4,5,6`. Now this will produce
-`[1,2,3,[4,5,6]]`. To flatten array members on the top level, you can now use
-the more explicit `CONCAT(FLATTEN([1, 2, 3, [4, 5, 6]], 1))`.
+`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
+was used, and when you passed multiple parameters, previous versions of ArangoDB
+automatically flattened array values in the first level of each passed array.
+
+Now, if you pass multiple parameters, there is no automatic flattening of arrays
+and arrays are cast using the new `TO_STRING()` behavior.
+
+What is unchanged is that if you pass an array as the sole parameter, its
+members get concatenated.
+
+| Expression | Result before v3.0 | Result from v3.0 onward |
+|------------|--------------------|-------------------------|
+| `CONCAT([1, 2, 3, [4, 5, 6]])` | `"1234,5,6"` | `"123[4,5,6]"` |
+| `CONCAT([1, 2, 3, [4, 5, 6]], [7, 8])` | `"1234,5,678"` | `"[1,2,3,[4,5,6]][7,8]"` |
+
+You can use `FLATTEN()` if you want to manually flatten one or multiple levels
+of an array, like `CONCAT(FLATTEN([1, 2, [3, 4, [5, 6]]], 2))` to flatten the
+array to `[1, 2, 3, 4, 5, 6]` and then concatenating it to `"123456"`.
 
 ### Arithmetic operators
 
@@ -219,7 +232,7 @@ Some examples of the changed behavior:
 
 - `"foo" + 1` produces `1` now. In previous versions this produced `null`.
 - `[ 1, 2 ] + 1` produces `1`. In previous versions this produced `null`.
-- `1 + "foo" + 1´ produces `2` now. In previous version this produced `1`.
+- `1 + "foo" + 1` produces `2` now. In previous version this produced `1`.
 
 ### Attribute names and parameters
 

--- a/site/content/arangodb/3.10/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.10/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -204,15 +204,14 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
-was used, and when you passed multiple parameters, previous versions of ArangoDB
-automatically flattened array values in the first level of each passed array.
+`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
+of ArangoDB used the old `TO_STRING()` behavior and automatically flattened
+array values in the first level of each passed array.
 
-Now, if you pass multiple parameters, there is no automatic flattening of arrays
-and arrays are cast using the new `TO_STRING()` behavior.
-
-What is unchanged is that if you pass an array as the sole parameter, its
-members get concatenated.
+Now, there is no automatic flattening of arrays and arrays are cast using the
+new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
+members get concatenated - which seems the same as the previous flattening of
+one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |
 |------------|--------------------|-------------------------|

--- a/site/content/arangodb/3.11/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -210,7 +210,7 @@ array values in the first level of each passed array.
 
 Now, there is no automatic flattening of arrays and arrays are cast using the
 new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
-members get concatenated - which seems the same as the previous flattening of
+members get concatenated - which is equivalent to the previous flattening of
 one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |

--- a/site/content/arangodb/3.11/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -180,35 +180,48 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 - arrays are now converted into their JSON-stringify equivalents, e.g.
 
-  - `[ ]` is now converted to `[]`
-  - `[ 1, 2, 3 ]` is now converted to `[1,2,3]`
-  - `[ "test", 1, 2 ] is now converted to `["test",1,2]`
+  - `[ ]` is now converted to `"[]"`
+  - `[ 1, 2, 3 ]` is now converted to `"[1,2,3]"`
+  - `[ "test", 1, 2 ]` is now converted to `"[\"test\",1,2]"`
    
   Previous versions of ArangoDB converted arrays with no members into the
   empty string, and non-empty arrays into a comma-separated list of member
-  values, without the surrounding angular brackets. Additionally, string
+  values, without the surrounding square brackets. Additionally, string
   array members were not enclosed in quotes in the result string:
 
-  - `[ ]` was converted to ``
-  - `[ 1, 2, 3 ]` was converted to `1,2,3`
-  - `[ "test", 1, 2 ] was converted to `test,1,2`
+  - `[ ]` was converted to `""`
+  - `[ 1, 2, 3 ]` was converted to `"1,2,3"`
+  - `[ "test", 1, 2 ]` was converted to `"test,1,2"`
   
 - objects are now converted to their JSON-stringify equivalents, e.g.
 
-  - `{ }` is converted to `{}`
-  - `{ a: 1, b: 2 }` is converted to `{"a":1,"b":2}`
-  - `{ "test" : "foobar" }` is converted to `{"test":"foobar"}`
+  - `{ }` is converted to `"{}"`
+  - `{ a: 1, b: 2 }` is converted to `"{\"a\":1,\"b\":2}"`
+  - `{ test: "foobar" }` is converted to `"{\"test\":\"foobar\"}"`
     
   Previous versions of ArangoDB always converted objects into the string
-  `[object Object]`  
+  `"[object Object]"`.
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
-of ArangoDB automatically flattened array values in the first level of the array, 
-e.g. `CONCAT([1, 2, 3, [ 4, 5, 6 ]])` produced `1,2,3,4,5,6`. Now this will produce
-`[1,2,3,[4,5,6]]`. To flatten array members on the top level, you can now use
-the more explicit `CONCAT(FLATTEN([1, 2, 3, [4, 5, 6]], 1))`.
+`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
+was used, and when you passed multiple parameters, previous versions of ArangoDB
+automatically flattened array values in the first level of each passed array.
+
+Now, if you pass multiple parameters, there is no automatic flattening of arrays
+and arrays are cast using the new `TO_STRING()` behavior.
+
+What is unchanged is that if you pass an array as the sole parameter, its
+members get concatenated.
+
+| Expression | Result before v3.0 | Result from v3.0 onward |
+|------------|--------------------|-------------------------|
+| `CONCAT([1, 2, 3, [4, 5, 6]])` | `"1234,5,6"` | `"123[4,5,6]"` |
+| `CONCAT([1, 2, 3, [4, 5, 6]], [7, 8])` | `"1234,5,678"` | `"[1,2,3,[4,5,6]][7,8]"` |
+
+You can use `FLATTEN()` if you want to manually flatten one or multiple levels
+of an array, like `CONCAT(FLATTEN([1, 2, [3, 4, [5, 6]]], 2))` to flatten the
+array to `[1, 2, 3, 4, 5, 6]` and then concatenating it to `"123456"`.
 
 ### Arithmetic operators
 
@@ -219,7 +232,7 @@ Some examples of the changed behavior:
 
 - `"foo" + 1` produces `1` now. In previous versions this produced `null`.
 - `[ 1, 2 ] + 1` produces `1`. In previous versions this produced `null`.
-- `1 + "foo" + 1´ produces `2` now. In previous version this produced `1`.
+- `1 + "foo" + 1` produces `2` now. In previous version this produced `1`.
 
 ### Attribute names and parameters
 

--- a/site/content/arangodb/3.11/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -204,15 +204,14 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
-was used, and when you passed multiple parameters, previous versions of ArangoDB
-automatically flattened array values in the first level of each passed array.
+`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
+of ArangoDB used the old `TO_STRING()` behavior and automatically flattened
+array values in the first level of each passed array.
 
-Now, if you pass multiple parameters, there is no automatic flattening of arrays
-and arrays are cast using the new `TO_STRING()` behavior.
-
-What is unchanged is that if you pass an array as the sole parameter, its
-members get concatenated.
+Now, there is no automatic flattening of arrays and arrays are cast using the
+new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
+members get concatenated - which seems the same as the previous flattening of
+one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |
 |------------|--------------------|-------------------------|

--- a/site/content/arangodb/3.12/develop/http-api/authentication.md
+++ b/site/content/arangodb/3.12/develop/http-api/authentication.md
@@ -152,6 +152,7 @@ access token as the `password`. You can omit the `username`:
 {
   "password": "theAccessToken"
 }
+```
 
 If you specify the user name, it must match the name encoded in the token.
 

--- a/site/content/arangodb/3.12/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -210,7 +210,7 @@ array values in the first level of each passed array.
 
 Now, there is no automatic flattening of arrays and arrays are cast using the
 new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
-members get concatenated - which seems the same as the previous flattening of
+members get concatenated - which is equivalent to the previous flattening of
 one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |

--- a/site/content/arangodb/3.12/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -180,35 +180,48 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 - arrays are now converted into their JSON-stringify equivalents, e.g.
 
-  - `[ ]` is now converted to `[]`
-  - `[ 1, 2, 3 ]` is now converted to `[1,2,3]`
-  - `[ "test", 1, 2 ] is now converted to `["test",1,2]`
+  - `[ ]` is now converted to `"[]"`
+  - `[ 1, 2, 3 ]` is now converted to `"[1,2,3]"`
+  - `[ "test", 1, 2 ]` is now converted to `"[\"test\",1,2]"`
    
   Previous versions of ArangoDB converted arrays with no members into the
   empty string, and non-empty arrays into a comma-separated list of member
-  values, without the surrounding angular brackets. Additionally, string
+  values, without the surrounding square brackets. Additionally, string
   array members were not enclosed in quotes in the result string:
 
-  - `[ ]` was converted to ``
-  - `[ 1, 2, 3 ]` was converted to `1,2,3`
-  - `[ "test", 1, 2 ] was converted to `test,1,2`
+  - `[ ]` was converted to `""`
+  - `[ 1, 2, 3 ]` was converted to `"1,2,3"`
+  - `[ "test", 1, 2 ]` was converted to `"test,1,2"`
   
 - objects are now converted to their JSON-stringify equivalents, e.g.
 
-  - `{ }` is converted to `{}`
-  - `{ a: 1, b: 2 }` is converted to `{"a":1,"b":2}`
-  - `{ "test" : "foobar" }` is converted to `{"test":"foobar"}`
+  - `{ }` is converted to `"{}"`
+  - `{ a: 1, b: 2 }` is converted to `"{\"a\":1,\"b\":2}"`
+  - `{ test: "foobar" }` is converted to `"{\"test\":\"foobar\"}"`
     
   Previous versions of ArangoDB always converted objects into the string
-  `[object Object]`  
+  `"[object Object]"`.
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
-of ArangoDB automatically flattened array values in the first level of the array, 
-e.g. `CONCAT([1, 2, 3, [ 4, 5, 6 ]])` produced `1,2,3,4,5,6`. Now this will produce
-`[1,2,3,[4,5,6]]`. To flatten array members on the top level, you can now use
-the more explicit `CONCAT(FLATTEN([1, 2, 3, [4, 5, 6]], 1))`.
+`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
+was used, and when you passed multiple parameters, previous versions of ArangoDB
+automatically flattened array values in the first level of each passed array.
+
+Now, if you pass multiple parameters, there is no automatic flattening of arrays
+and arrays are cast using the new `TO_STRING()` behavior.
+
+What is unchanged is that if you pass an array as the sole parameter, its
+members get concatenated.
+
+| Expression | Result before v3.0 | Result from v3.0 onward |
+|------------|--------------------|-------------------------|
+| `CONCAT([1, 2, 3, [4, 5, 6]])` | `"1234,5,6"` | `"123[4,5,6]"` |
+| `CONCAT([1, 2, 3, [4, 5, 6]], [7, 8])` | `"1234,5,678"` | `"[1,2,3,[4,5,6]][7,8]"` |
+
+You can use `FLATTEN()` if you want to manually flatten one or multiple levels
+of an array, like `CONCAT(FLATTEN([1, 2, [3, 4, [5, 6]]], 2))` to flatten the
+array to `[1, 2, 3, 4, 5, 6]` and then concatenating it to `"123456"`.
 
 ### Arithmetic operators
 
@@ -219,7 +232,7 @@ Some examples of the changed behavior:
 
 - `"foo" + 1` produces `1` now. In previous versions this produced `null`.
 - `[ 1, 2 ] + 1` produces `1`. In previous versions this produced `null`.
-- `1 + "foo" + 1´ produces `2` now. In previous version this produced `1`.
+- `1 + "foo" + 1` produces `2` now. In previous version this produced `1`.
 
 ### Attribute names and parameters
 

--- a/site/content/arangodb/3.12/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -204,15 +204,14 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
-was used, and when you passed multiple parameters, previous versions of ArangoDB
-automatically flattened array values in the first level of each passed array.
+`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
+of ArangoDB used the old `TO_STRING()` behavior and automatically flattened
+array values in the first level of each passed array.
 
-Now, if you pass multiple parameters, there is no automatic flattening of arrays
-and arrays are cast using the new `TO_STRING()` behavior.
-
-What is unchanged is that if you pass an array as the sole parameter, its
-members get concatenated.
+Now, there is no automatic flattening of arrays and arrays are cast using the
+new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
+members get concatenated - which seems the same as the previous flattening of
+one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |
 |------------|--------------------|-------------------------|

--- a/site/content/arangodb/4.0/develop/http-api/authentication.md
+++ b/site/content/arangodb/4.0/develop/http-api/authentication.md
@@ -125,6 +125,7 @@ access token as the `password`. You can omit the `username`:
 {
   "password": "theAccessToken"
 }
+```
 
 If you specify the user name, it must match the name encoded in the token.
 

--- a/site/content/arangodb/4.0/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -210,7 +210,7 @@ array values in the first level of each passed array.
 
 Now, there is no automatic flattening of arrays and arrays are cast using the
 new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
-members get concatenated - which seems the same as the previous flattening of
+members get concatenated - which is equivalent to the previous flattening of
 one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |

--- a/site/content/arangodb/4.0/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -180,35 +180,48 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 - arrays are now converted into their JSON-stringify equivalents, e.g.
 
-  - `[ ]` is now converted to `[]`
-  - `[ 1, 2, 3 ]` is now converted to `[1,2,3]`
-  - `[ "test", 1, 2 ] is now converted to `["test",1,2]`
+  - `[ ]` is now converted to `"[]"`
+  - `[ 1, 2, 3 ]` is now converted to `"[1,2,3]"`
+  - `[ "test", 1, 2 ]` is now converted to `"[\"test\",1,2]"`
    
   Previous versions of ArangoDB converted arrays with no members into the
   empty string, and non-empty arrays into a comma-separated list of member
-  values, without the surrounding angular brackets. Additionally, string
+  values, without the surrounding square brackets. Additionally, string
   array members were not enclosed in quotes in the result string:
 
-  - `[ ]` was converted to ``
-  - `[ 1, 2, 3 ]` was converted to `1,2,3`
-  - `[ "test", 1, 2 ] was converted to `test,1,2`
+  - `[ ]` was converted to `""`
+  - `[ 1, 2, 3 ]` was converted to `"1,2,3"`
+  - `[ "test", 1, 2 ]` was converted to `"test,1,2"`
   
 - objects are now converted to their JSON-stringify equivalents, e.g.
 
-  - `{ }` is converted to `{}`
-  - `{ a: 1, b: 2 }` is converted to `{"a":1,"b":2}`
-  - `{ "test" : "foobar" }` is converted to `{"test":"foobar"}`
+  - `{ }` is converted to `"{}"`
+  - `{ a: 1, b: 2 }` is converted to `"{\"a\":1,\"b\":2}"`
+  - `{ test: "foobar" }` is converted to `"{\"test\":\"foobar\"}"`
     
   Previous versions of ArangoDB always converted objects into the string
-  `[object Object]`  
+  `"[object Object]"`.
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
-of ArangoDB automatically flattened array values in the first level of the array, 
-e.g. `CONCAT([1, 2, 3, [ 4, 5, 6 ]])` produced `1,2,3,4,5,6`. Now this will produce
-`[1,2,3,[4,5,6]]`. To flatten array members on the top level, you can now use
-the more explicit `CONCAT(FLATTEN([1, 2, 3, [4, 5, 6]], 1))`.
+`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
+was used, and when you passed multiple parameters, previous versions of ArangoDB
+automatically flattened array values in the first level of each passed array.
+
+Now, if you pass multiple parameters, there is no automatic flattening of arrays
+and arrays are cast using the new `TO_STRING()` behavior.
+
+What is unchanged is that if you pass an array as the sole parameter, its
+members get concatenated.
+
+| Expression | Result before v3.0 | Result from v3.0 onward |
+|------------|--------------------|-------------------------|
+| `CONCAT([1, 2, 3, [4, 5, 6]])` | `"1234,5,6"` | `"123[4,5,6]"` |
+| `CONCAT([1, 2, 3, [4, 5, 6]], [7, 8])` | `"1234,5,678"` | `"[1,2,3,[4,5,6]][7,8]"` |
+
+You can use `FLATTEN()` if you want to manually flatten one or multiple levels
+of an array, like `CONCAT(FLATTEN([1, 2, [3, 4, [5, 6]]], 2))` to flatten the
+array to `[1, 2, 3, 4, 5, 6]` and then concatenating it to `"123456"`.
 
 ### Arithmetic operators
 
@@ -219,7 +232,7 @@ Some examples of the changed behavior:
 
 - `"foo" + 1` produces `1` now. In previous versions this produced `null`.
 - `[ 1, 2 ] + 1` produces `1`. In previous versions this produced `null`.
-- `1 + "foo" + 1´ produces `2` now. In previous version this produced `1`.
+- `1 + "foo" + 1` produces `2` now. In previous version this produced `1`.
 
 ### Attribute names and parameters
 

--- a/site/content/arangodb/4.0/release-notes/version-3.0/incompatible-changes-in-3-0.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.0/incompatible-changes-in-3-0.md
@@ -204,15 +204,14 @@ The output of `TO_STRING()` has also changed for arrays and objects as follows:
 
 This change also affects other parts in AQL that used `TO_STRING()` to implicitly
 cast operands to strings. It also affects the AQL functions `CONCAT()` and 
-`CONCAT_SEPARATOR()` which treated array values differently. The old `TO_STRING()`
-was used, and when you passed multiple parameters, previous versions of ArangoDB
-automatically flattened array values in the first level of each passed array.
+`CONCAT_SEPARATOR()` which treated array values differently. Previous versions
+of ArangoDB used the old `TO_STRING()` behavior and automatically flattened
+array values in the first level of each passed array.
 
-Now, if you pass multiple parameters, there is no automatic flattening of arrays
-and arrays are cast using the new `TO_STRING()` behavior.
-
-What is unchanged is that if you pass an array as the sole parameter, its
-members get concatenated.
+Now, there is no automatic flattening of arrays and arrays are cast using the
+new `TO_STRING()` behavior. If you pass an array as the sole parameter, its
+members get concatenated - which seems the same as the previous flattening of
+one array level:
 
 | Expression | Result before v3.0 | Result from v3.0 onward |
 |------------|--------------------|-------------------------|

--- a/site/content/contextual-data-platform/platform-suite.md
+++ b/site/content/contextual-data-platform/platform-suite.md
@@ -92,9 +92,9 @@ The [File manager](../platform-suite/file-manager/_index.md) lets you view and m
 the data of services, such as your uploaded content for AutoGraph and GraphRAG,
 as well as the files used by service containers.
 
-### Secrets manager
+### Secrets Manager
 
-The [Secrets manager](../platform-suite/secrets-manager.md) stores secrets like
+The [Secrets Manager](../platform-suite/secrets-manager.md) stores secrets like
 API keys for easy use across the Contextual Data Platform.
 
 ## Additional services

--- a/site/content/contextual-data-platform/platform-suite.md
+++ b/site/content/contextual-data-platform/platform-suite.md
@@ -94,7 +94,7 @@ as well as the files used by service containers.
 
 ### Secrets manager
 
-The [Secrets manager](../platform-suite/secrets-manager.md) store secrets like
+The [Secrets manager](../platform-suite/secrets-manager.md) stores secrets like
 API keys for easy use across the Contextual Data Platform.
 
 ## Additional services

--- a/site/content/ecosystem/integrations/spring-boot-arangodb.md
+++ b/site/content/ecosystem/integrations/spring-boot-arangodb.md
@@ -522,7 +522,7 @@ Class<?>[]runner = new Class<?>[]{
 
 First, find Ned Stark again. But this time without knowing the id of the
 persisted entity. Start with creating a Character with the same property values
-as the searched one. Then create an `Example` instance of it with `Example.of(T)
+as the searched one. Then create an `Example` instance of it with `Example.of(T)`
 and search for it with `findOne(Example)` from your `CharacterRepository`:
 
 ```java

--- a/site/content/images/icons/key.svg
+++ b/site/content/images/icons/key.svg
@@ -1,0 +1,1 @@
+<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12.65 10A5.99 5.99 0 0 0 7 6c-3.31 0-6 2.69-6 6s2.69 6 6 6a5.99 5.99 0 0 0 5.65-4H17v4h4v-4h2v-4H12.65zM7 14c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"></path></svg>

--- a/site/content/platform-suite/_index.md
+++ b/site/content/platform-suite/_index.md
@@ -5,8 +5,6 @@ weight: 3
 description: >-
   The Platform Suite is a set of services and features for operating ArangoDB
   with Kubernetes and includes a Graph Visualizer and advanced Query Editor
-aliases:
-  - data-platform/get-started
 ---
 ## What Makes Up the Arango Platform Suite
 

--- a/site/content/platform-suite/cypher2aql.md
+++ b/site/content/platform-suite/cypher2aql.md
@@ -77,7 +77,7 @@ paths:
     post:
       operationId: createService
       description: |
-        Deploy an Cypher to AQL service with the Arango Control Plane (ACP).
+        Deploy a Cypher to AQL service with the Arango Control Plane (ACP).
       requestBody:
         content:
           application/json:

--- a/site/content/platform-suite/cypher2aql.md
+++ b/site/content/platform-suite/cypher2aql.md
@@ -77,7 +77,7 @@ paths:
     post:
       operationId: createService
       description: |
-        Deploy an `arango-cypher2aql` service with the Arango Control Plane (ACP)
+        Deploy an Cypher to AQL service with the Arango Control Plane (ACP).
       requestBody:
         content:
           application/json:
@@ -108,7 +108,8 @@ paths:
                     properties:
                       serviceId:
                         description: |
-                          The unique identifier assigned to the service.
+                          The service name followed by a hyphen and
+                          the unique identifier assigned to the service.
                         type: string
                         example: arango-cypher2aql-z8fue
                       description:
@@ -232,10 +233,11 @@ paths:
           in: path
           required: true
           description: |
-            The ID of the Cypher to AQL service that runs in the data platform.
+            The unique identifier of the Cypher to AQL service running in
+            the data platform.
           schema:
             type: string
-            example: arango-cypher2aql-z8fue
+            example: z8fue
       requestBody:
         content:
           application/json:
@@ -369,10 +371,11 @@ paths:
           in: path
           required: true
           description: |
-            The ID of the Cypher to AQL service that runs in the data platform.
+            The unique identifier of the Cypher to AQL service running in
+            the data platform.
           schema:
             type: string
-            example: arango-cypher2aql-z8fue
+            example: z8fue
       responses:
         '200':
           description: |
@@ -435,10 +438,11 @@ paths:
           in: path
           required: true
           description: |
-            The ID of the Cypher to AQL service that runs in the data platform.
+            The unique identifier of the Cypher to AQL service running in
+            the data platform.
           schema:
             type: string
-            example: arango-cypher2aql-z8fue
+            example: z8fue
       responses:
         '200':
           description: |
@@ -503,8 +507,9 @@ paths:
           in: path
           required: true
           description: |
-            The ID of the service to stop, here the ID of an
-            `arango-cypher2aql` service.
+            The identifier of the service to stop, here the name of the
+            Cypher to AQL service followed by a hyphen and the unique identifier
+            assigned to the service.
           schema:
             type: string
             example: arango-cypher2aql-z8fue

--- a/site/content/platform-suite/cypher2aql.md
+++ b/site/content/platform-suite/cypher2aql.md
@@ -529,7 +529,7 @@ paths:
                     properties:
                       serviceId:
                         description: |
-                          The unique identifier of the service.
+                          The service name followed by a hyphen and the unique identifier.
                         type: string
                         example: arango-cypher2aql-z8fue
                       description:

--- a/site/content/platform-suite/file-manager/_index.md
+++ b/site/content/platform-suite/file-manager/_index.md
@@ -2,8 +2,6 @@
 title: The File Manager of the Arango Contextual Data Platform
 menuTitle: File Manager
 weight: 25
-aliases:
-  - file-manager
 description: >-
   View and manage container service files and RAG input files stored by the
   Arango Contextual Data Platform

--- a/site/content/platform-suite/secrets-manager.md
+++ b/site/content/platform-suite/secrets-manager.md
@@ -18,7 +18,7 @@ deployment. If the value of a secret changes, you only need to update it in
 a single place.
 
 {{< tip >}}
-Services that utilize the secret manager are, for example, the GraphRAG importer
+Services that utilize the secrets manager are, for example, the GraphRAG importer
 and retriever services of the Agentic AI Suite. They require a Large Language Model
 (LLM) and need to store an API key for the LLM like OpenAI.
 {{< /tip >}}
@@ -89,8 +89,6 @@ See the reference for the full request and response schemas of the
 `/v1/secrets`, `/v1/secrets_batch`, and `/v1/secret_types` endpoints.
 
 ### How to use the secrets manager API
-
-<!-- TODO: /ai prefix to be replaced -->
 
 Before you create a secret, take a look at the available types you can specify:
 

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -170,11 +170,6 @@
 /data-platform/release-notes/                                                   /contextual-data-platform/release-notes/                        302
 /data-platform/*                                                                /platform-suite/:splat                                          302
 
-/data-platform/installation/                                                    /contextual-data-platform/install-and-upgrade/                  302
-/data-platform/features/                                                        /contextual-data-platform/                                      302
-/data-platform/release-notes/                                                   /contextual-data-platform/release-notes/                        302
-/data-platform/*                                                                /platform-suite/:splat                                          302
-
 /ai-suite/release-notes/                                                        /contextual-data-platform/release-notes/                        302
 /ai-suite/reference/ai-orchestrator/                                            /platform-suite/control-plane-acp/                              302
 /ai-suite/*                                                                     /agentic-ai-suite/:splat                                        302

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -161,7 +161,6 @@
 /agentic-ai-suite/reference/autograph/importing-files/                          /agentic-ai-suite/autograph/reference/importing-files/          302
 /agentic-ai-suite/reference/autograph/orchestration/                            /agentic-ai-suite/autograph/reference/orchestration/            302
 /agentic-ai-suite/reference/autograph/rag-strategizer/                          /agentic-ai-suite/autograph/reference/rag-strategizer/          302
-/agentic-ai-suite/reference/autograph/                                          /agentic-ai-suite/autograph/                                    302
 /agentic-ai-suite/aqlizer/                                                      /agentic-ai-suite/natural-language-to-aql/                      302
 /agentic-ai-suite/reference/natural-language-to-aql/                            /agentic-ai-suite/natural-language-to-aql/api-reference/        302
 

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -155,10 +155,21 @@
 /arangodb/3.11/develop/integrations/spring-data-arangodb/reference-version-4/repositories/queries/query-methods/    /ecosystem/integrations/spring-data-arangodb/repositories/queries/query-methods/    301
 /arangodb/3.11/develop/integrations/spring-data-arangodb/reference-version-4/template/                              /ecosystem/integrations/spring-data-arangodb/template/                              301
 
-/data-platform/installation/                       /contextual-data-platform/install-and-upgrade/     302
-/data-platform/features/                           /contextual-data-platform/                         302
-/data-platform/release-notes/                      /contextual-data-platform/release-notes/           302
-/data-platform/*                                   /platform-suite/:splat                             302
+/agentic-ai-suite/reference/autograph/                                          /agentic-ai-suite/autograph/reference/                          302
+/agentic-ai-suite/reference/autograph/corpus-build/                             /agentic-ai-suite/autograph/reference/corpus-build/             302
+/agentic-ai-suite/reference/autograph/embeddings/                               /agentic-ai-suite/autograph/reference/embeddings/               302
+/agentic-ai-suite/reference/autograph/importing-files/                          /agentic-ai-suite/autograph/reference/importing-files/          302
+/agentic-ai-suite/reference/autograph/orchestration/                            /agentic-ai-suite/autograph/reference/orchestration/            302
+/agentic-ai-suite/reference/autograph/rag-strategizer/                          /agentic-ai-suite/autograph/reference/rag-strategizer/          302
+/agentic-ai-suite/reference/autograph/                                          /agentic-ai-suite/autograph/                                    302
+/agentic-ai-suite/aqlizer/                                                      /agentic-ai-suite/natural-language-to-aql/                      302
+/agentic-ai-suite/reference/natural-language-to-aql/                            /agentic-ai-suite/natural-language-to-aql/api-reference/        302
+
+/data-platform/get-started/                                                     /platform-suite/                                                302
+/data-platform/installation/                                                    /contextual-data-platform/install-and-upgrade/                  302
+/data-platform/features/                                                        /contextual-data-platform/                                      302
+/data-platform/release-notes/                                                   /contextual-data-platform/release-notes/                        302
+/data-platform/*                                                                /platform-suite/:splat                                          302
 
 /data-platform/installation/                                                    /contextual-data-platform/install-and-upgrade/                  302
 /data-platform/features/                                                        /contextual-data-platform/                                      302

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -2222,3 +2222,8 @@ pre.mermaid > svg {
     height: 100%;
     max-width: none;
 }
+
+pre.mermaid > svg .nodeLabel {
+    word-break: normal;
+    overflow-wrap: break-word;
+}


### PR DESCRIPTION
### Description

- Fix some unclosed inline code and fenced code blocks
- Fix 3.0 release notes (TO_STRING, CONCAT functions)
- Better Mermaid label wrapping (I suppose there is a chance now that labels might get cut off if you're really unlucky but should generally be okay)
- Fix and replace aliases with redirects, update README
- Add a key icon (for accessing the secrets manager in the UI)

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README guidance for renaming/moving pages and version-switcher alias steps.
  * Removed legacy page aliases across multiple docs and clarified API parameter wording.
  * Added per-provider API key guidance and a new secrets-manager subsection; minor editorial tweaks.

* **Bug Fixes**
  * Fixed JSON/authentication examples, AQL examples, and corrected snippet rendering.

* **New Features**
  * Added numerous redirects for cross-site routing and improved Mermaid diagram label wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->