### PR TITLE
DOC-908 | Add `maxTransactionSize` to 3.11 HTTP API

### DIFF
--- a/site/content/arangodb/3.11/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.11/develop/http-api/transactions/stream-transactions.md
@@ -155,6 +155,12 @@ paths:
                     waiting for a lock.
                   type: integer
                   default: 900
+                maxTransactionSize:
+                  description: |
+                    Transaction size limit in bytes.
+
+                    Default: Controlled by the [`--transaction.streaming-max-transaction-size` startup option](../../../components/arangodb-server/options.md#--transactionstreaming-max-transaction-size).
+                  type: integer
       responses:
         '201':
           description: |

--- a/site/data/3.11/arangod.json
+++ b/site/data/3.11/arangod.json
@@ -14151,6 +14151,37 @@
     "section" : "transaction",
     "type" : "double"
   },
+  "transaction.streaming-max-transaction-size" : {
+    "base" : 1,
+    "category" : "option",
+    "component" : [
+      "dbserver",
+      "single"
+    ],
+    "default" : 134217728,
+    "deprecatedIn" : null,
+    "description" : "The maximum transaction size (in bytes) for Stream Transactions.",
+    "dynamic" : false,
+    "enterpriseOnly" : false,
+    "experimental" : false,
+    "hidden" : true,
+    "introducedIn" : [
+      "v3.11.14"
+    ],
+    "maxInclusive" : true,
+    "maxValue" : 18446744073709551615,
+    "minInclusive" : true,
+    "minValue" : 0,
+    "obsolete" : false,
+    "os" : [
+      "linux",
+      "macos",
+      "windows"
+    ],
+    "requiresValue" : true,
+    "section" : "transaction",
+    "type" : "uint64"
+  },
   "ttl.frequency" : {
     "base" : 1,
     "category" : "option",


### PR DESCRIPTION
### Description

Release notes etc. to be done later

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Stream Transaction HTTP API docs updated with a new maxTransactionSize request parameter, letting clients set per-request transaction size limits (bytes); server default applies when omitted.
* **Configuration**
  * Added a server configuration setting to control the default maximum size for streaming transactions, introduced in the 3.11.x line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->