### PR TITLE
DOC-908 | Release notes adjustable Stream Transaction size & OpenAPI cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ $Env:ENV='static'  # PowerShell
 
 The output files will be written to `site/public/`.
 
+You can additionally set the `HUGO_URL` environment variable to
+`https://docs.arango.ai/` to create a production-like build that
+includes Google Analytics etc.
+
 #### Scheduled and example generation build
 
 **Configuration**

--- a/site/content/arangodb/3.11/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.11/develop/http-api/transactions/stream-transactions.md
@@ -174,7 +174,7 @@ paths:
                           The status of the transaction. Always `running` for a
                           successfully started transaction.
                         type: string
-                        example: running
+                        const: running
         '400':
           description: |
             The transaction specification is either missing or malformed.
@@ -529,7 +529,7 @@ paths:
                           The status of the transaction. Always `committed` for a
                           successfully committed transaction.
                         type: string
-                        example: committed
+                        const: committed
         '400':
           description: |
             The transaction identifier is malformed, or the transaction is in
@@ -703,7 +703,7 @@ paths:
                           The status of the transaction. Always `aborted` for a
                           successfully aborted transaction.
                         type: string
-                        example: aborted
+                        const: aborted
         '400':
           description: |
             The transaction identifier is malformed, or the transaction is in
@@ -846,9 +846,10 @@ paths:
                           type: string
                         state:
                           description: |
-                            The status of the transaction.
+                            The status of the transaction. Always `running`
+                            if it's in the list of running transactions.
                           type: string
-                          enum: [running, committed, aborted]
+                          const: running
       tags:
         - Transactions
 ```

--- a/site/content/arangodb/3.11/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.11/develop/http-api/transactions/stream-transactions.md
@@ -51,33 +51,6 @@ paths:
         until the entire transaction times out.
 
         The transaction description must be passed in the body of the POST request.
-        If the transaction can be started on the server, *HTTP 201* is returned.
-
-        For successfully started transactions, the returned JSON object has the
-        following properties:
-
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'running'
-
-        If the transaction specification is either missing or malformed, the server
-        responds with *HTTP 400* or *HTTP 404*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
       parameters:
         - name: database-name
           in: path
@@ -164,16 +137,106 @@ paths:
       responses:
         '201':
           description: |
-            If the transaction is running on the server,
-            *HTTP 201* will be returned.
+            The transaction has been started on the server.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 201
+                  result:
+                    description: |
+                      An object describing the started transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `running` for a
+                          successfully started transaction.
+                        type: string
+                        example: running
         '400':
           description: |
-            If the transaction specification is either missing or malformed, the server
-            will respond with *HTTP 400*.
+            The transaction specification is either missing or malformed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction specification contains an unknown collection, the server
-            will respond with *HTTP 404*.
+            The transaction specification contains an unknown collection.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -234,12 +297,13 @@ paths:
     get:
       operationId: getStreamTransaction
       description: |
-        The result is an object describing the status of the transaction.
-        It has at least the following attributes:
+        Retrieve the status of a Stream Transaction by its identifier.
 
-        - `id`: the identifier of the transaction
-
-        - `status`: the status of the transaction. One of "running", "committed" or "aborted".
+        After a transaction is committed or aborted, the server remembers its
+        final state for a limited time. During this window, querying the
+        transaction returns its final status (`committed` or `aborted`). Once
+        the server garbage-collects this record, the same identifier becomes
+        unknown and the endpoint returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -259,16 +323,105 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction is fully executed and committed on the server,
-            *HTTP 200* will be returned.
+            The transaction is found and its status returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the status of the transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction.
+                        type: string
+                        enum: [running, committed, aborted]
         '400':
           description: |
-            If the transaction identifier specified is either missing or malformed, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is either missing or malformed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found with the specified identifier, the server
-            will respond with *HTTP 404*.
+            No transaction was found with the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -311,32 +464,15 @@ paths:
         Commit a running server-side transaction. Committing is an idempotent operation.
         It is not an error to commit a transaction more than once.
 
-        If the transaction can be committed, *HTTP 200* is returned.
-        The returned JSON object has the following properties:
+        The server remembers a transaction's final state for a limited time after
+        it ends. As a result, the response can vary depending on when you call
+        this endpoint:
 
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'committed'
-
-        If the transaction cannot be found, committing is not allowed or the
-        transaction was aborted, the server
-        responds with *HTTP 400*, *HTTP 404* or *HTTP 409*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
+        - While the transaction is still tracked: committing an already-committed
+          transaction returns `200` (idempotent), and committing an already-aborted
+          transaction returns `400`.
+        - Once the server has garbage-collected the transaction's record, the
+          identifier is no longer known and the endpoint returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -356,20 +492,108 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction was committed,
-            *HTTP 200* will be returned.
+            The transaction has been committed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the committed transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `committed` for a
+                          successfully committed transaction.
+                        type: string
+                        example: committed
         '400':
           description: |
-            If the transaction cannot be committed, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is malformed, or the transaction is in
+            a state that does not allow committing (for example, it was
+            already aborted).
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found, the server
-            will respond with *HTTP 404*.
-        '409':
-          description: |
-            If the transaction was already aborted, the server
-            will respond with *HTTP 409*.
+            No transaction is known under the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -412,32 +636,17 @@ paths:
         Abort a running server-side transaction. Aborting is an idempotent operation.
         It is not an error to abort a transaction more than once.
 
-        If the transaction can be aborted, *HTTP 200* is returned.
-        The returned JSON object has the following properties:
+        The server remembers a transaction's final state for a limited time after
+        it ends. As a result, the response can vary depending on when you call
+        this endpoint:
 
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'aborted'
-
-        If the transaction cannot be found, aborting is not allowed or the
-        transaction was already committed, the server
-        responds with *HTTP 400*, *HTTP 404* or *HTTP 409*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
+        - While the transaction is still tracked: aborting an already-aborted
+          transaction returns `200` (idempotent), and aborting an already-committed
+          transaction returns `400`.
+        - The first abort against an unknown identifier returns `404` and records
+          it as aborted. Subsequent aborts for the same identifier return `200`
+          until the record is garbage-collected, after which the identifier is
+          again unknown and the next abort once more returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -457,20 +666,108 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction was aborted,
-            *HTTP 200* will be returned.
+            The transaction has been aborted.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the aborted transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `aborted` for a
+                          successfully aborted transaction.
+                        type: string
+                        example: aborted
         '400':
           description: |
-            If the transaction cannot be aborted, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is malformed, or the transaction is in
+            a state that does not allow aborting (for example, it was
+            already committed).
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found, the server
-            will respond with *HTTP 404*.
-        '409':
-          description: |
-            If the transaction was already committed, the server
-            will respond with *HTTP 409*.
+            No transaction is known under the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -510,14 +807,8 @@ paths:
     get:
       operationId: listStreamTransactions
       description: |
-        The result is an object with the `transactions` attribute, which contains
-        an array of transactions.
-        In a cluster, the array contains the transactions from all Coordinators.
-
-        Each array entry contains an object with the following attributes:
-
-        - `id`: the transaction's id
-        - `state`: the transaction's status
+        List the currently running Stream Transactions.
+        In a cluster, the list contains the transactions from all Coordinators.
       parameters:
         - name: database-name
           in: path
@@ -530,7 +821,34 @@ paths:
       responses:
         '200':
           description: |
-            If the list of transactions can be retrieved successfully, *HTTP 200* will be returned.
+            The list of transactions can be retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - transactions
+                properties:
+                  transactions:
+                    description: |
+                      An array of currently running transactions. In a cluster, this
+                      contains the transactions from all Coordinators.
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - state
+                      properties:
+                        id:
+                          description: |
+                            The identifier of the transaction.
+                          type: string
+                        state:
+                          description: |
+                            The status of the transaction.
+                          type: string
+                          enum: [running, committed, aborted]
       tags:
         - Transactions
 ```

--- a/site/content/arangodb/3.11/develop/transactions/javascript-transactions.md
+++ b/site/content/arangodb/3.11/develop/transactions/javascript-transactions.md
@@ -302,7 +302,7 @@ For a complete list of possible ArangoDB errors, see
 ### Custom Exceptions
 
 You may want to define custom exceptions inside of a transaction. To have the
-exception propagate upwards properly, please throw an an instance of base
+exception propagate upwards properly, please throw an instance of the base
 JavaScript `Error` class or a derivative. To specify an error number, include it
 as the `errorNumber` field. As an example:
 

--- a/site/content/arangodb/3.11/develop/transactions/locking-and-isolation.md
+++ b/site/content/arangodb/3.11/develop/transactions/locking-and-isolation.md
@@ -48,7 +48,7 @@ be a write-write conflict, and one of the transactions will abort with error 120
 accept the failure.
 
 In order to guard long-running or complex transactions against concurrent operations
-on the same data, the RocksDB engine allows to access collections in exclusive mode.
+on the same data, the RocksDB engine allows you to access collections in exclusive mode.
 Exclusive accesses will internally acquire a write-lock on the collections, so they 
 are not executed in parallel with any other write operations. Read operations can still
 be carried out by other concurrent transactions.
@@ -208,7 +208,7 @@ db._executeTransaction({
 
 In the above example, a deadlock will occur if transaction T1 and T2 have both
 acquired their write locks (T1 for collection `c1` and T2 for collection `c2`) and
-are then trying to read from the other other (T1 will read from `c2`, T2 will read
+are then trying to read from the other (T1 will read from `c2`, T2 will read
 from `c1`). T1 will then try to acquire the read lock on collection `c2`, which
 is prevented by transaction T2. T2 however will wait for the read lock on 
 collection `c1`, which is prevented by transaction T1. 

--- a/site/content/arangodb/3.11/develop/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.11/develop/transactions/stream-transactions.md
@@ -44,9 +44,12 @@ on the Coordinator to ensure that abandoned transactions cannot block the
 cluster from operating properly:
 
 - Maximum idle timeout of up to **120 seconds** between operations.
-- Maximum transaction size of **128 MB** (per DB-Server in clusters).
+- Maximum transaction size with a default of **128 MiB** (per DB-Server in clusters).
 
 These limits are also enforced for Stream Transactions on single servers.
+
+The maximum size for a single Stream Transaction can be adjusted with the
+`--transaction.streaming-max-transaction-size` startup option.
 
 The default maximum idle timeout is **60 seconds** between operations in a
 single Stream Transaction. The maximum value can be bumped up to at most 120
@@ -102,6 +105,8 @@ Additionally, `options` can have the following optional attributes:
   waiting on collection locks. This option is only meaningful when using
   `exclusive` locks. If not specified, a default value is used. Setting
   `lockTimeout` to `0` makes ArangoDB not time out waiting for a lock.
+- `maxTransactionSize`: Transaction size limit in bytes. Can be at most the
+  value of the `--transaction.streaming-max-transaction-size` startup option.
 
 The method returns an object that lets you run supported operations as part of
 the transactions, get the status information, and commit or abort the transaction.

--- a/site/content/arangodb/3.11/develop/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.11/develop/transactions/stream-transactions.md
@@ -105,7 +105,7 @@ Additionally, `options` can have the following optional attributes:
   waiting on collection locks. This option is only meaningful when using
   `exclusive` locks. If not specified, a default value is used. Setting
   `lockTimeout` to `0` makes ArangoDB not time out waiting for a lock.
-- `maxTransactionSize`: Transaction size limit in bytes. Can be at most the
+- `maxTransactionSize`: Transaction size limit in bytes. It can be at most the
   value of the `--transaction.streaming-max-transaction-size` startup option.
 
 The method returns an object that lets you run supported operations as part of

--- a/site/content/arangodb/3.11/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.11/api-changes-in-3-11.md
@@ -792,6 +792,19 @@ following two new statistics in the `stats` attribute of the response now:
 The `GET /_api/query/rules` endpoint now includes a `description` attribute for
 every optimizer rule that briefly explains what it does.
 
+#### Adjustable Stream Transaction size
+
+<small>Introduced in: v3.11.14-4</small>
+
+The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
+can now be configured with the new `--transaction.streaming-max-transaction-size`
+startup option. The default value remains 128 MiB.
+
+When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
+for that particular transactions. The default value as well as the maximum value
+are defined by the `--transaction.streaming-max-transaction-size` startup option.
+See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
+
 ### Endpoints deprecated
 
 The `GET /_admin/database/target-version` endpoint is deprecated in favor of the

--- a/site/content/arangodb/3.11/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.11/api-changes-in-3-11.md
@@ -801,7 +801,7 @@ can now be configured with the new `--transaction.streaming-max-transaction-size
 startup option. The default value remains 128 MiB.
 
 When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
-for that particular transactions. The default value as well as the maximum value
+for that particular transaction. The default value as well as the maximum value
 are defined by the `--transaction.streaming-max-transaction-size` startup option.
 See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
 

--- a/site/content/arangodb/3.11/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1420,6 +1420,19 @@ means you may find more results than before.
 
 Also see [Geo-spatial functions in AQL](../../aql/functions/geo.md).
 
+### Adjustable Stream Transaction size
+
+<small>Introduced in: v3.11.14-4</small>
+
+The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
+can now be configured with the new `--transaction.streaming-max-transaction-size`
+startup option. The default value remains 128 MiB.
+
+When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
+for that particular transactions. The default value as well as the maximum value
+are defined by the `--transaction.streaming-max-transaction-size` startup option.
+See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
+
 ## Client tools
 
 ### arangodump

--- a/site/content/arangodb/3.11/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1429,7 +1429,7 @@ can now be configured with the new `--transaction.streaming-max-transaction-size
 startup option. The default value remains 128 MiB.
 
 When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
-for that particular transactions. The default value as well as the maximum value
+for that particular transaction. The default value as well as the maximum value
 are defined by the `--transaction.streaming-max-transaction-size` startup option.
 See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
 

--- a/site/content/arangodb/3.12/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.12/develop/http-api/transactions/stream-transactions.md
@@ -189,7 +189,7 @@ paths:
                           The status of the transaction. Always `running` for a
                           successfully started transaction.
                         type: string
-                        example: running
+                        const: running
         '400':
           description: |
             The transaction specification is either missing or malformed.
@@ -544,7 +544,7 @@ paths:
                           The status of the transaction. Always `committed` for a
                           successfully committed transaction.
                         type: string
-                        example: committed
+                        const: committed
         '400':
           description: |
             The transaction identifier is malformed, or the transaction is in
@@ -718,7 +718,7 @@ paths:
                           The status of the transaction. Always `aborted` for a
                           successfully aborted transaction.
                         type: string
-                        example: aborted
+                        const: aborted
         '400':
           description: |
             The transaction identifier is malformed, or the transaction is in
@@ -861,9 +861,10 @@ paths:
                           type: string
                         state:
                           description: |
-                            The status of the transaction.
+                            The status of the transaction. Always `running`
+                            if it's in the list of running transactions.
                           type: string
-                          enum: [running, committed, aborted]
+                          const: running
       tags:
         - Transactions
 ```

--- a/site/content/arangodb/3.12/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.12/develop/http-api/transactions/stream-transactions.md
@@ -51,33 +51,6 @@ paths:
         until the entire transaction times out.
 
         The transaction description must be passed in the body of the POST request.
-        If the transaction can be started on the server, *HTTP 201* is returned.
-
-        For successfully started transactions, the returned JSON object has the
-        following properties:
-
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'running'
-
-        If the transaction specification is either missing or malformed, the server
-        responds with *HTTP 400* or *HTTP 404*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
       parameters:
         - name: database-name
           in: path
@@ -179,16 +152,106 @@ paths:
       responses:
         '201':
           description: |
-            If the transaction is running on the server,
-            *HTTP 201* will be returned.
+            The transaction has been started on the server.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 201
+                  result:
+                    description: |
+                      An object describing the started transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `running` for a
+                          successfully started transaction.
+                        type: string
+                        example: running
         '400':
           description: |
-            If the transaction specification is either missing or malformed, the server
-            will respond with *HTTP 400*.
+            The transaction specification is either missing or malformed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction specification contains an unknown collection, the server
-            will respond with *HTTP 404*.
+            The transaction specification contains an unknown collection.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -249,12 +312,13 @@ paths:
     get:
       operationId: getStreamTransaction
       description: |
-        The result is an object describing the status of the transaction.
-        It has at least the following attributes:
+        Retrieve the status of a Stream Transaction by its identifier.
 
-        - `id`: the identifier of the transaction
-
-        - `status`: the status of the transaction. One of "running", "committed" or "aborted".
+        After a transaction is committed or aborted, the server remembers its
+        final state for a limited time. During this window, querying the
+        transaction returns its final status (`committed` or `aborted`). Once
+        the server garbage-collects this record, the same identifier becomes
+        unknown and the endpoint returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -274,16 +338,105 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction is fully executed and committed on the server,
-            *HTTP 200* will be returned.
+            The transaction is found and its status returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the status of the transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction.
+                        type: string
+                        enum: [running, committed, aborted]
         '400':
           description: |
-            If the transaction identifier specified is either missing or malformed, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is either missing or malformed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found with the specified identifier, the server
-            will respond with *HTTP 404*.
+            No transaction was found with the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -326,32 +479,15 @@ paths:
         Commit a running server-side transaction. Committing is an idempotent operation.
         It is not an error to commit a transaction more than once.
 
-        If the transaction can be committed, *HTTP 200* is returned.
-        The returned JSON object has the following properties:
+        The server remembers a transaction's final state for a limited time after
+        it ends. As a result, the response can vary depending on when you call
+        this endpoint:
 
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'committed'
-
-        If the transaction cannot be found, committing is not allowed or the
-        transaction was aborted, the server
-        responds with *HTTP 400*, *HTTP 404* or *HTTP 409*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
+        - While the transaction is still tracked: committing an already-committed
+          transaction returns `200` (idempotent), and committing an already-aborted
+          transaction returns `400`.
+        - Once the server has garbage-collected the transaction's record, the
+          identifier is no longer known and the endpoint returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -371,20 +507,108 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction was committed,
-            *HTTP 200* will be returned.
+            The transaction has been committed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the committed transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `committed` for a
+                          successfully committed transaction.
+                        type: string
+                        example: committed
         '400':
           description: |
-            If the transaction cannot be committed, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is malformed, or the transaction is in
+            a state that does not allow committing (for example, it was
+            already aborted).
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found, the server
-            will respond with *HTTP 404*.
-        '409':
-          description: |
-            If the transaction was already aborted, the server
-            will respond with *HTTP 409*.
+            No transaction is known under the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -427,32 +651,17 @@ paths:
         Abort a running server-side transaction. Aborting is an idempotent operation.
         It is not an error to abort a transaction more than once.
 
-        If the transaction can be aborted, *HTTP 200* is returned.
-        The returned JSON object has the following properties:
+        The server remembers a transaction's final state for a limited time after
+        it ends. As a result, the response can vary depending on when you call
+        this endpoint:
 
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'aborted'
-
-        If the transaction cannot be found, aborting is not allowed or the
-        transaction was already committed, the server
-        responds with *HTTP 400*, *HTTP 404* or *HTTP 409*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
+        - While the transaction is still tracked: aborting an already-aborted
+          transaction returns `200` (idempotent), and aborting an already-committed
+          transaction returns `400`.
+        - The first abort against an unknown identifier returns `404` and records
+          it as aborted. Subsequent aborts for the same identifier return `200`
+          until the record is garbage-collected, after which the identifier is
+          again unknown and the next abort once more returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -472,20 +681,108 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction was aborted,
-            *HTTP 200* will be returned.
+            The transaction has been aborted.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the aborted transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `aborted` for a
+                          successfully aborted transaction.
+                        type: string
+                        example: aborted
         '400':
           description: |
-            If the transaction cannot be aborted, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is malformed, or the transaction is in
+            a state that does not allow aborting (for example, it was
+            already committed).
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found, the server
-            will respond with *HTTP 404*.
-        '409':
-          description: |
-            If the transaction was already committed, the server
-            will respond with *HTTP 409*.
+            No transaction is known under the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -525,14 +822,8 @@ paths:
     get:
       operationId: listStreamTransactions
       description: |
-        The result is an object with the `transactions` attribute, which contains
-        an array of transactions.
-        In a cluster, the array contains the transactions from all Coordinators.
-
-        Each array entry contains an object with the following attributes:
-
-        - `id`: the transaction's id
-        - `state`: the transaction's status
+        List the currently running Stream Transactions.
+        In a cluster, the list contains the transactions from all Coordinators.
       parameters:
         - name: database-name
           in: path
@@ -545,7 +836,34 @@ paths:
       responses:
         '200':
           description: |
-            If the list of transactions can be retrieved successfully, *HTTP 200* will be returned.
+            The list of transactions can be retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - transactions
+                properties:
+                  transactions:
+                    description: |
+                      An array of currently running transactions. In a cluster, this
+                      contains the transactions from all Coordinators.
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - state
+                      properties:
+                        id:
+                          description: |
+                            The identifier of the transaction.
+                          type: string
+                        state:
+                          description: |
+                            The status of the transaction.
+                          type: string
+                          enum: [running, committed, aborted]
       tags:
         - Transactions
 ```

--- a/site/content/arangodb/3.12/develop/transactions/stream-transactions.md
+++ b/site/content/arangodb/3.12/develop/transactions/stream-transactions.md
@@ -105,7 +105,7 @@ Additionally, `options` can have the following optional attributes:
   waiting on collection locks. This option is only meaningful when using
   `exclusive` locks. If not specified, a default value is used. Setting
   `lockTimeout` to `0` makes ArangoDB not time out waiting for a lock.
-- `maxTransactionSize`: Transaction size limit in bytes. Can be at most the
+- `maxTransactionSize`: Transaction size limit in bytes. It can be at most the
   value of the `--transaction.streaming-max-transaction-size` startup option.
 - `skipFastLockRound`: Whether to disable fast locking for write operations
   (default: `false`).

--- a/site/content/arangodb/3.12/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.11/api-changes-in-3-11.md
@@ -790,6 +790,19 @@ following two new statistics in the `stats` attribute of the response now:
 The `GET /_api/query/rules` endpoint now includes a `description` attribute for
 every optimizer rule that briefly explains what it does.
 
+#### Adjustable Stream Transaction size
+
+<small>Introduced in: v3.11.14-4</small>
+
+The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
+can now be configured with the new `--transaction.streaming-max-transaction-size`
+startup option. The default value remains 128 MiB.
+
+When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
+for that particular transactions. The default value as well as the maximum value
+are defined by the `--transaction.streaming-max-transaction-size` startup option.
+See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
+
 ### Endpoints deprecated
 
 The `GET /_admin/database/target-version` endpoint is deprecated in favor of the

--- a/site/content/arangodb/3.12/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.11/api-changes-in-3-11.md
@@ -799,7 +799,7 @@ can now be configured with the new `--transaction.streaming-max-transaction-size
 startup option. The default value remains 128 MiB.
 
 When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
-for that particular transactions. The default value as well as the maximum value
+for that particular transaction. The default value as well as the maximum value
 are defined by the `--transaction.streaming-max-transaction-size` startup option.
 See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
 

--- a/site/content/arangodb/3.12/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1416,6 +1416,19 @@ means you may find more results than before.
 
 Also see [Geo-spatial functions in AQL](../../aql/functions/geo.md).
 
+### Adjustable Stream Transaction size
+
+<small>Introduced in: v3.11.14-4</small>
+
+The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
+can now be configured with the new `--transaction.streaming-max-transaction-size`
+startup option. The default value remains 128 MiB.
+
+When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
+for that particular transactions. The default value as well as the maximum value
+are defined by the `--transaction.streaming-max-transaction-size` startup option.
+See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
+
 ## Client tools
 
 ### arangodump

--- a/site/content/arangodb/3.12/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1425,7 +1425,7 @@ can now be configured with the new `--transaction.streaming-max-transaction-size
 startup option. The default value remains 128 MiB.
 
 When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
-for that particular transactions. The default value as well as the maximum value
+for that particular transaction. The default value as well as the maximum value
 are defined by the `--transaction.streaming-max-transaction-size` startup option.
 See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
 

--- a/site/content/arangodb/4.0/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/arangodb/4.0/develop/http-api/transactions/stream-transactions.md
@@ -189,7 +189,7 @@ paths:
                           The status of the transaction. Always `running` for a
                           successfully started transaction.
                         type: string
-                        example: running
+                        const: running
         '400':
           description: |
             The transaction specification is either missing or malformed.
@@ -544,7 +544,7 @@ paths:
                           The status of the transaction. Always `committed` for a
                           successfully committed transaction.
                         type: string
-                        example: committed
+                        const: committed
         '400':
           description: |
             The transaction identifier is malformed, or the transaction is in
@@ -718,7 +718,7 @@ paths:
                           The status of the transaction. Always `aborted` for a
                           successfully aborted transaction.
                         type: string
-                        example: aborted
+                        const: aborted
         '400':
           description: |
             The transaction identifier is malformed, or the transaction is in
@@ -861,9 +861,10 @@ paths:
                           type: string
                         state:
                           description: |
-                            The status of the transaction.
+                            The status of the transaction. Always `running`
+                            if it's in the list of running transactions.
                           type: string
-                          enum: [running, committed, aborted]
+                          const: running
       tags:
         - Transactions
 ```

--- a/site/content/arangodb/4.0/develop/http-api/transactions/stream-transactions.md
+++ b/site/content/arangodb/4.0/develop/http-api/transactions/stream-transactions.md
@@ -51,33 +51,6 @@ paths:
         until the entire transaction times out.
 
         The transaction description must be passed in the body of the POST request.
-        If the transaction can be started on the server, *HTTP 201* is returned.
-
-        For successfully started transactions, the returned JSON object has the
-        following properties:
-
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'running'
-
-        If the transaction specification is either missing or malformed, the server
-        responds with *HTTP 400* or *HTTP 404*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
       parameters:
         - name: database-name
           in: path
@@ -179,16 +152,106 @@ paths:
       responses:
         '201':
           description: |
-            If the transaction is running on the server,
-            *HTTP 201* will be returned.
+            The transaction has been started on the server.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 201
+                  result:
+                    description: |
+                      An object describing the started transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `running` for a
+                          successfully started transaction.
+                        type: string
+                        example: running
         '400':
           description: |
-            If the transaction specification is either missing or malformed, the server
-            will respond with *HTTP 400*.
+            The transaction specification is either missing or malformed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction specification contains an unknown collection, the server
-            will respond with *HTTP 404*.
+            The transaction specification contains an unknown collection.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -249,12 +312,13 @@ paths:
     get:
       operationId: getStreamTransaction
       description: |
-        The result is an object describing the status of the transaction.
-        It has at least the following attributes:
+        Retrieve the status of a Stream Transaction by its identifier.
 
-        - `id`: the identifier of the transaction
-
-        - `status`: the status of the transaction. One of "running", "committed" or "aborted".
+        After a transaction is committed or aborted, the server remembers its
+        final state for a limited time. During this window, querying the
+        transaction returns its final status (`committed` or `aborted`). Once
+        the server garbage-collects this record, the same identifier becomes
+        unknown and the endpoint returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -274,16 +338,105 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction is fully executed and committed on the server,
-            *HTTP 200* will be returned.
+            The transaction is found and its status returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the status of the transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction.
+                        type: string
+                        enum: [running, committed, aborted]
         '400':
           description: |
-            If the transaction identifier specified is either missing or malformed, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is either missing or malformed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found with the specified identifier, the server
-            will respond with *HTTP 404*.
+            No transaction was found with the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -326,32 +479,15 @@ paths:
         Commit a running server-side transaction. Committing is an idempotent operation.
         It is not an error to commit a transaction more than once.
 
-        If the transaction can be committed, *HTTP 200* is returned.
-        The returned JSON object has the following properties:
+        The server remembers a transaction's final state for a limited time after
+        it ends. As a result, the response can vary depending on when you call
+        this endpoint:
 
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'committed'
-
-        If the transaction cannot be found, committing is not allowed or the
-        transaction was aborted, the server
-        responds with *HTTP 400*, *HTTP 404* or *HTTP 409*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
+        - While the transaction is still tracked: committing an already-committed
+          transaction returns `200` (idempotent), and committing an already-aborted
+          transaction returns `400`.
+        - Once the server has garbage-collected the transaction's record, the
+          identifier is no longer known and the endpoint returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -371,20 +507,108 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction was committed,
-            *HTTP 200* will be returned.
+            The transaction has been committed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the committed transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `committed` for a
+                          successfully committed transaction.
+                        type: string
+                        example: committed
         '400':
           description: |
-            If the transaction cannot be committed, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is malformed, or the transaction is in
+            a state that does not allow committing (for example, it was
+            already aborted).
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found, the server
-            will respond with *HTTP 404*.
-        '409':
-          description: |
-            If the transaction was already aborted, the server
-            will respond with *HTTP 409*.
+            No transaction is known under the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -427,32 +651,17 @@ paths:
         Abort a running server-side transaction. Aborting is an idempotent operation.
         It is not an error to abort a transaction more than once.
 
-        If the transaction can be aborted, *HTTP 200* is returned.
-        The returned JSON object has the following properties:
+        The server remembers a transaction's final state for a limited time after
+        it ends. As a result, the response can vary depending on when you call
+        this endpoint:
 
-        - `error`: boolean flag to indicate if an error occurred (`false`
-          in this case)
-
-        - `code`: the HTTP status code
-
-        - `result`: result containing
-            - `id`: the identifier of the transaction
-            - `status`: containing the string 'aborted'
-
-        If the transaction cannot be found, aborting is not allowed or the
-        transaction was already committed, the server
-        responds with *HTTP 400*, *HTTP 404* or *HTTP 409*.
-
-        The body of the response then contains a JSON object with additional error
-        details. The object has the following attributes:
-
-        - `error`: boolean flag to indicate that an error occurred (`true` in this case)
-
-        - `code`: the HTTP status code
-
-        - `errorNum`: the server error number
-
-        - `errorMessage`: a descriptive error message
+        - While the transaction is still tracked: aborting an already-aborted
+          transaction returns `200` (idempotent), and aborting an already-committed
+          transaction returns `400`.
+        - The first abort against an unknown identifier returns `404` and records
+          it as aborted. Subsequent aborts for the same identifier return `200`
+          until the record is garbage-collected, after which the identifier is
+          again unknown and the next abort once more returns `404`.
       parameters:
         - name: database-name
           in: path
@@ -472,20 +681,108 @@ paths:
       responses:
         '200':
           description: |
-            If the transaction was aborted,
-            *HTTP 200* will be returned.
+            The transaction has been aborted.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - result
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that no error occurred.
+                    type: boolean
+                    example: false
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 200
+                  result:
+                    description: |
+                      An object describing the aborted transaction.
+                    type: object
+                    required:
+                      - id
+                      - status
+                    properties:
+                      id:
+                        description: |
+                          The identifier of the transaction.
+                        type: string
+                      status:
+                        description: |
+                          The status of the transaction. Always `aborted` for a
+                          successfully aborted transaction.
+                        type: string
+                        example: aborted
         '400':
           description: |
-            If the transaction cannot be aborted, the server
-            will respond with *HTTP 400*.
+            The transaction identifier is malformed, or the transaction is in
+            a state that does not allow aborting (for example, it was
+            already committed).
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 400
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
         '404':
           description: |
-            If the transaction was not found, the server
-            will respond with *HTTP 404*.
-        '409':
-          description: |
-            If the transaction was already committed, the server
-            will respond with *HTTP 409*.
+            No transaction is known under the specified identifier.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - code
+                  - errorNum
+                  - errorMessage
+                properties:
+                  error:
+                    description: |
+                      A flag indicating that an error occurred.
+                    type: boolean
+                    example: true
+                  code:
+                    description: |
+                      The HTTP response status code.
+                    type: integer
+                    example: 404
+                  errorNum:
+                    description: |
+                      The ArangoDB error number for the error that occurred.
+                    type: integer
+                  errorMessage:
+                    description: |
+                      A descriptive error message.
+                    type: string
       tags:
         - Transactions
 ```
@@ -525,14 +822,8 @@ paths:
     get:
       operationId: listStreamTransactions
       description: |
-        The result is an object with the `transactions` attribute, which contains
-        an array of transactions.
-        In a cluster, the array contains the transactions from all Coordinators.
-
-        Each array entry contains an object with the following attributes:
-
-        - `id`: the transaction's id
-        - `state`: the transaction's status
+        List the currently running Stream Transactions.
+        In a cluster, the list contains the transactions from all Coordinators.
       parameters:
         - name: database-name
           in: path
@@ -545,7 +836,34 @@ paths:
       responses:
         '200':
           description: |
-            If the list of transactions can be retrieved successfully, *HTTP 200* will be returned.
+            The list of transactions can be retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - transactions
+                properties:
+                  transactions:
+                    description: |
+                      An array of currently running transactions. In a cluster, this
+                      contains the transactions from all Coordinators.
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - state
+                      properties:
+                        id:
+                          description: |
+                            The identifier of the transaction.
+                          type: string
+                        state:
+                          description: |
+                            The status of the transaction.
+                          type: string
+                          enum: [running, committed, aborted]
       tags:
         - Transactions
 ```

--- a/site/content/arangodb/4.0/develop/transactions/stream-transactions.md
+++ b/site/content/arangodb/4.0/develop/transactions/stream-transactions.md
@@ -99,7 +99,7 @@ Additionally, `options` can have the following optional attributes:
   waiting on collection locks. This option is only meaningful when using
   `exclusive` locks. If not specified, a default value is used. Setting
   `lockTimeout` to `0` makes ArangoDB not time out waiting for a lock.
-- `maxTransactionSize`: Transaction size limit in bytes. Can be at most the
+- `maxTransactionSize`: Transaction size limit in bytes. It can be at most the
   value of the `--transaction.streaming-max-transaction-size` startup option.
 - `skipFastLockRound`: Whether to disable fast locking for write operations
   (default: `false`).

--- a/site/content/arangodb/4.0/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.11/api-changes-in-3-11.md
@@ -790,6 +790,19 @@ following two new statistics in the `stats` attribute of the response now:
 The `GET /_api/query/rules` endpoint now includes a `description` attribute for
 every optimizer rule that briefly explains what it does.
 
+#### Adjustable Stream Transaction size
+
+<small>Introduced in: v3.11.14-4</small>
+
+The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
+can now be configured with the new `--transaction.streaming-max-transaction-size`
+startup option. The default value remains 128 MiB.
+
+When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
+for that particular transactions. The default value as well as the maximum value
+are defined by the `--transaction.streaming-max-transaction-size` startup option.
+See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
+
 ### Endpoints deprecated
 
 The `GET /_admin/database/target-version` endpoint is deprecated in favor of the

--- a/site/content/arangodb/4.0/release-notes/version-3.11/api-changes-in-3-11.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.11/api-changes-in-3-11.md
@@ -799,7 +799,7 @@ can now be configured with the new `--transaction.streaming-max-transaction-size
 startup option. The default value remains 128 MiB.
 
 When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
-for that particular transactions. The default value as well as the maximum value
+for that particular transaction. The default value as well as the maximum value
 are defined by the `--transaction.streaming-max-transaction-size` startup option.
 See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
 

--- a/site/content/arangodb/4.0/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1416,6 +1416,19 @@ means you may find more results than before.
 
 Also see [Geo-spatial functions in AQL](../../aql/functions/geo.md).
 
+### Adjustable Stream Transaction size
+
+<small>Introduced in: v3.11.14-4</small>
+
+The previously fixed limit of 128 MiB for [Stream Transactions](../../develop/transactions/stream-transactions.md)
+can now be configured with the new `--transaction.streaming-max-transaction-size`
+startup option. The default value remains 128 MiB.
+
+When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
+for that particular transactions. The default value as well as the maximum value
+are defined by the `--transaction.streaming-max-transaction-size` startup option.
+See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
+
 ## Client tools
 
 ### arangodump

--- a/site/content/arangodb/4.0/release-notes/version-3.11/whats-new-in-3-11.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.11/whats-new-in-3-11.md
@@ -1425,7 +1425,7 @@ can now be configured with the new `--transaction.streaming-max-transaction-size
 startup option. The default value remains 128 MiB.
 
 When beginning a Stream Transaction, you can now specify a `maxTransactionSize`
-for that particular transactions. The default value as well as the maximum value
+for that particular transaction. The default value as well as the maximum value
 are defined by the `--transaction.streaming-max-transaction-size` startup option.
 See [HTTP interface for Stream Transactions](../../develop/http-api/transactions/stream-transactions.md#begin-a-stream-transaction).
 


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced Stream Transactions API documentation with explicit response schemas across all versions.
  * Stream Transaction maximum size is now configurable via startup option (128 MiB default).
  * New `maxTransactionSize` parameter available when creating Stream Transactions.
  * Updated build documentation to support optional production-like configuration settings.

* **Bug Fixes**
  * Corrected documentation typos and formatting inconsistencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arangodb/docs-hugo/pull/997)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->