### PR TITLE
Toolchain: Authenticated GitHub requests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
 
             pip install pyyaml requests
 
+            # The list of branches needs to be sorted by name (based on the `name` field in versions.yaml)!
             python3 generate_config.py \
               --workflow << pipeline.parameters.workflow >> \
               --arangodb-branches << pipeline.parameters.arangodb-3_10 >> << pipeline.parameters.arangodb-3_11 >> << pipeline.parameters.arangodb-3_12 >> << pipeline.parameters.arangodb-4_0 >> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,10 @@ jobs:
             fetched=false
             for i in $(seq 1 5); do
               echo ""
-              res=$(curl -fsS https://api.github.com/repos/arangodb/docs-hugo/contents/.circleci?ref=$CIRCLE_SHA1) || curlStatus=$?
+              headers=$(mktemp)
+              res=$(curl -sS -D "$headers" -H "Authorization: Bearer $CIRCLECI_GITHUB_READONLY" https://api.github.com/repos/arangodb/docs-hugo/contents/.circleci?ref=$CIRCLE_SHA1) || curlStatus=$?
+              headers_content=$(cat "$headers")
+              rm "$headers"
               if [[ -z "${curlStatus:-}" ]]; then
                 urls=$(echo "$res" | jq ".[].download_url") || jqStatus=$?
                 if [[ -z "${jqStatus:-}" ]]; then
@@ -99,7 +102,8 @@ jobs:
                 echo "jq failed with $jqStatus, input:"
                 echo "$res"
               else
-                echo "curl failed with $curlStatus"
+                echo "curl failed with $curlStatus, rate limit?"
+                echo "$headers_content" | grep -i "ratelimit\|retry-after"
               fi
               unset curlStatus
               unset jqStatus
@@ -109,8 +113,8 @@ jobs:
               echo "Failed to fetch download URLs"
               exit 1
             fi
-            echo "$urls" | xargs wget
-            wget https://raw.githubusercontent.com/arangodb/docs-hugo/$CIRCLE_SHA1/site/data/versions.yaml
+            echo "$urls" | xargs -n 1 curl -sS -O -H "Authorization: Bearer $CIRCLECI_GITHUB_READONLY"
+            curl -sS -O -H "Authorization: Bearer $CIRCLECI_GITHUB_READONLY" https://raw.githubusercontent.com/arangodb/docs-hugo/$CIRCLE_SHA1/site/data/versions.yaml
 
             pip install pyyaml requests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ parameters:
 jobs:
   generate-config:
     docker:
-      - image: cimg/python:3.11.1
+      - image: cimg/python:3.14.3
     executor: continuation/default
     steps:
       - run:

--- a/.circleci/generate_config.py
+++ b/.circleci/generate_config.py
@@ -33,7 +33,7 @@ parser.add_argument(
     "--workflow", help="The workflow to trigger", type=str
 )
 parser.add_argument(
-    "--arangodb-branches",  nargs='+', help="The arangodb/arangodb branches to be used for the generate workflow"
+    "--arangodb-branches",  nargs='+', help="The arangodb/arangodb branches to be used for the generate workflow (sorted by name)"
 )
 parser.add_argument(
     "--arangodb-branch", help="The arangodb/arangodb branch to be used for the release workflow", type=str

--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,25 @@ It makes a warning show at the top of every page for that version.
    +              --arangodb-branches << pipeline.parameters.arangodb-3_11 >> << pipeline.parameters.arangodb-3_12 >> << pipeline.parameters.arangodb-4_0 >> \
    ```
 
+   Note that the order of the branches is important because the version information
+   is looked up based on the index number. The branches need to be ordered according
+   to a sorted list of the `name` fields as defined in the `versions.yaml`.
+   
+   Code excerpt from `generate_config.py`:
+   
+   ```py
+   versions = yaml.safe_load(open("versions.yaml", "r"))
+   versions = sorted(versions["/arangodb/"], key=lambda d: d['name'])
+   
+   def workflow_generate(config):
+       # ...
+   
+       for i in range(len(versions)):
+           version = versions[i]["name"]
+           # ...
+           branch = args.arangodb_branches[i]
+   ```
+
 3. In the `toolchain/docker/amd64/docker-compose.yml` file, add an entry under
    `services.toolchain.volumes` for the new version. Simply increment the value
    after `:-/tmp/`. Example:


### PR DESCRIPTION
### Description

Cherry-picked from #845 to avoid errors in CI runs due to GitHub rate-limit  (authenticated users have a higher limit).

Also update CircleCI Python image to a supported version.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 
