### PR TITLE
DOC-922 | `serviceId` postfix clarification & use endpoint shortcode

### DIFF
--- a/site/content/agentic-ai-suite/autograph/quickstart.md
+++ b/site/content/agentic-ai-suite/autograph/quickstart.md
@@ -53,9 +53,8 @@ For detailed instructions on creating and managing projects, see the
 [Projects](../../platform-suite/control-plane-acp.md#projects) section in
 the Arango Control Plane (ACP) documentation.
 
-To install and start the AutoGraph service, use the AI service endpoint
-`/v1/AutoGraph` in the
-[Arango Control Plane (ACP)](../../platform-suite/control-plane-acp.md).
+To install and start the AutoGraph service, use the `/_platform/acp/v1/autograph`
+endpoint of the [Arango Control Plane (ACP)](../../platform-suite/control-plane-acp.md).
 
 ## Get started
 

--- a/site/content/agentic-ai-suite/autograph/quickstart.md
+++ b/site/content/agentic-ai-suite/autograph/quickstart.md
@@ -79,13 +79,13 @@ The AutoGraph service exposes HTTP REST endpoints (port `8080`)
 for programmatic access. The recommended call sequence is:
 
 1. **Import files**
-   {{< endpoint "POST" "/v1/import-multiple" >}}
+   {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/import-multiple" >}}
 2. **Build corpus**
-   {{< endpoint "POST" "/v1/corpus/builds" >}}
+   {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/corpus/builds" >}}
 3. **Generate strategies**
-   {{< endpoint "POST" "/v1/rag-strategizer/analyze" >}}
+   {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/rag-strategizer/analyze" >}}
 4. **Orchestrate import**
-   {{< endpoint "POST" "/v1/orchestrate" >}}
+   {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/orchestrate" >}}
 
 Authentication uses JWT Bearer tokens. For full endpoint documentation,
 see the [API Reference](reference/_index.md).

--- a/site/content/agentic-ai-suite/autograph/reference/corpus-build.md
+++ b/site/content/agentic-ai-suite/autograph/reference/corpus-build.md
@@ -85,7 +85,7 @@ curl -X POST \
     "file_ids": ["id1", "id2"],
     "strategy": { "top_k": 10, "cluster_threshold": 2 }
   }' \
-  http://localhost:8080/v1/corpus/builds
+  https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/corpus/builds
 ```
 
 ---
@@ -132,7 +132,7 @@ Check the progress of a corpus build.
 
 ```bash
 curl -H "Authorization: Bearer <token>" \
-  http://localhost:8080/v1/corpus/builds/cb_01ARZ3NDEKTSV4RRFFQ69G5FAV
+  https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/corpus/builds/cb_01ARZ3NDEKTSV4RRFFQ69G5FAV
 ```
 
 ---

--- a/site/content/agentic-ai-suite/autograph/reference/corpus-build.md
+++ b/site/content/agentic-ai-suite/autograph/reference/corpus-build.md
@@ -8,7 +8,7 @@ weight: 40
 
 ## Create Corpus Build
 
-{{< endpoint "POST" "/v1/corpus/builds" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/corpus/builds" >}}
 
 Trigger a corpus build from imported files or File Manager.
 
@@ -92,7 +92,7 @@ curl -X POST \
 
 ## Monitoring Build Status
 
-{{< endpoint "GET" "/v1/corpus/builds/{corpus_build_id}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/corpus/builds/{corpus_build_id}" >}}
 
 Check the progress of a corpus build.
 

--- a/site/content/agentic-ai-suite/autograph/reference/embeddings.md
+++ b/site/content/agentic-ai-suite/autograph/reference/embeddings.md
@@ -8,7 +8,7 @@ weight: 55
 
 ## Embed field in collection
 
-{{< endpoint "POST" "/v1/embed-field-in-collection" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/embed-field-in-collection" >}}
 
 Add embeddings to documents in **any** ArangoDB collection you already have. This path is **independent** of import, corpus build, clustering, and the `{project}_CorpusGraph` named graph.
 

--- a/site/content/agentic-ai-suite/autograph/reference/embeddings.md
+++ b/site/content/agentic-ai-suite/autograph/reference/embeddings.md
@@ -73,7 +73,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -d '{"collection": "products", "field": "description"}' \
-  http://localhost:8080/v1/embed-field-in-collection
+  https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/embed-field-in-collection
 ```
 
 ## Next Steps

--- a/site/content/agentic-ai-suite/autograph/reference/importing-files.md
+++ b/site/content/agentic-ai-suite/autograph/reference/importing-files.md
@@ -79,7 +79,7 @@ curl -X POST \
     ],
     "module": "default"
   }' \
-  http://localhost:8080/v1/import-multiple
+  https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/import-multiple
 ```
 
 ## Next Steps

--- a/site/content/agentic-ai-suite/autograph/reference/importing-files.md
+++ b/site/content/agentic-ai-suite/autograph/reference/importing-files.md
@@ -8,7 +8,7 @@ weight: 35
 
 ## Import multiple files
 
-{{< endpoint "POST" "/v1/import-multiple" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/import-multiple" >}}
 
 Import documents into the corpus for later processing.
 

--- a/site/content/agentic-ai-suite/autograph/reference/orchestration.md
+++ b/site/content/agentic-ai-suite/autograph/reference/orchestration.md
@@ -77,7 +77,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -d '{"replicas": 2, "max_retries": 3}' \
-  http://localhost:8080/v1/orchestrate
+  https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/orchestrate
 ```
 
 ## Next Steps

--- a/site/content/agentic-ai-suite/autograph/reference/orchestration.md
+++ b/site/content/agentic-ai-suite/autograph/reference/orchestration.md
@@ -8,7 +8,7 @@ weight: 50
 
 ## Trigger Orchestration
 
-{{< endpoint "POST" "/v1/orchestrate" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/orchestrate" >}}
 
 Spawn GraphRAG importer workers for all strategy profiles. Called after RAG strategizer is completed.
 

--- a/site/content/agentic-ai-suite/autograph/reference/rag-strategizer.md
+++ b/site/content/agentic-ai-suite/autograph/reference/rag-strategizer.md
@@ -8,7 +8,7 @@ weight: 45
 
 ## Trigger RAG Strategizer
 
-{{< endpoint "POST" "/v1/rag-strategizer/analyze" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/rag-strategizer/analyze" >}}
 
 Analyze existing clusters and assign optimal RAG strategies. Must be called **after** a corpus build is completed.
 
@@ -64,7 +64,7 @@ curl -X POST \
 
 ## Retrieve RAG Strategies
 
-{{< endpoint "GET" "/v1/rag-strategizer/strategy" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/rag-strategizer/strategy" >}}
 
 Retrieve all RAG strategies that have been created.
 

--- a/site/content/agentic-ai-suite/autograph/reference/rag-strategizer.md
+++ b/site/content/agentic-ai-suite/autograph/reference/rag-strategizer.md
@@ -57,7 +57,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -d '{"full_graph_rag_strategy": "high"}' \
-  http://localhost:8080/v1/rag-strategizer/analyze
+  https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/rag-strategizer/analyze
 ```
 
 ---
@@ -122,7 +122,7 @@ No body or query parameters.
 
 ```bash
 curl -H "Authorization: Bearer <token>" \
-  http://localhost:8080/v1/rag-strategizer/strategy
+  https://<EXTERNAL_ENDPOINT>:8529/autograph/v1/rag-strategizer/strategy
 ```
 
 ## Next Steps

--- a/site/content/agentic-ai-suite/graph-analytics/api.md
+++ b/site/content/agentic-ai-suite/graph-analytics/api.md
@@ -18,16 +18,16 @@ How to perform the steps is detailed in the subsequent sections.
 1. Determine the approximate size of the data that you will load into the GAE
    and ensure the machine to run the engine on has sufficient memory. The data as well as the
    temporarily needed space for computations and results needs to fit in memory.
-2. [Start a `graphanalytics` service](#start-a-graphanalytics-service) via the AI service
+2. [Start a `graphanalytics` service](#start-a-graphanalytics-service) via the ACP service
    that manages various Platform components for graph intelligence and machine learning.
    It only takes a few seconds until the engine service can be used. The engine
-   runs adjacent to the pods of the ArangoDB Core.
-3. [Load graph data](#load-data) from the ArangoDB Core into the engine. You can load
+   runs adjacent to the pods of the ArangoDB core.
+3. [Load graph data](#load-data) from the ArangoDB core into the engine. You can load
    named graphs or sets of node and edge collections. This loads the edge
    information and a configurable subset of the node attributes.
 4. [Run graph algorithms](#run-algorithms) on the data. You only need to load the data once per
    engine and can then run various algorithms with different settings.
-5. [Write the computation results back](#store-job-results) to the ArangoDB Core.
+5. [Write the computation results back](#store-job-results) to the ArangoDB core.
 6. [Stop the engine service](#stop-a-graphanalytics-service) once you are done.
 {{< /tab >}}
 
@@ -64,7 +64,7 @@ Single server deployments using ArangoDB version 3.11 are not supported.
 
 {{< tab "Contextual Data Platform" >}}
 You can use any of the available authentication methods the Contextual Data Platform
-supports to start and stop `graphanalytics` services via the AI service as
+supports to start and stop `graphanalytics` services via the ACP service as
 well as to authenticate requests to the [Engine API](#engine-api).
 
 - HTTP Basic Authentication
@@ -109,10 +109,10 @@ Note that all cURL examples use placeholder values that you should replace with 
 
 The interface for managing the engines depends on the environment you use:
 
-- **Contextual Data Platform**: [AI service](#ai-service)
+- **Contextual Data Platform**: [ACP service](#acp-service)
 - **Arango Managed Platform (AMP)**: [Management API](#management-api)
 
-### AI service
+### ACP service
 
 {{< tag "Contextual Data Platform" >}}
 
@@ -133,7 +133,8 @@ if the Platform deployment uses a self-signed certificate (default).
 
 {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/graphanalytics" >}}
 
-Start a GAE via the AI service with an empty request body. This returns a **SERVICE_ID** that you will need to construct the Engine API URL in the next section.
+Start a GAE via the ACP service with an empty request body. This returns a
+`serviceId` that you need to construct the Engine API URL in the next section.
 
 ```bash
 # Set your Contextual Data Platform endpoint
@@ -145,44 +146,47 @@ ADB_TOKEN=$(curl -sSk -X POST \
   "https://$EXTERNAL_ENDPOINT:8529/_open/auth" | jq -r .jwt)
 
 # Start the Graph Analytics service
-Service=$(curl -sSk -H "Authorization: bearer $ADB_TOKEN" \
+SERVICE=$(curl -sSk -H "Authorization: bearer $ADB_TOKEN" \
   -X POST "https://$EXTERNAL_ENDPOINT:8529/_platform/acp/v1/graphanalytics")
 
-# Extract the service ID (needed for Engine API URL construction)
-ServiceID=$(echo "$Service" | jq -r ".serviceInfo.serviceId")
+# Extract the trailing segment of the serviceId (needed for Engine API URL construction)
+SERVICE_ID=$(echo "$SERVICE" | jq ".serviceInfo.serviceId")
 
-if [[ "$ServiceID" == "null" ]]; then 
+if [[ "$SERVICE_ID" == "null" ]]; then 
   echo "Error starting Graph Analytics Engine"
 else
+  SERVICE_ID_POSTFIX=$(echo "$SERVICE_ID" | jq -r 'split("-") | last')
   echo "Graph Analytics service started successfully"
-  echo "Service ID: $ServiceID"
-  echo "Save this Service ID for constructing the Engine API URL"
+  echo "serviceIdPostfix: $SERVICE_ID_POSTFIX"
+  echo "Save the postfix for constructing the Engine API URL"
 fi
 
-echo "$Service" | jq
+echo "$SERVICE" | jq
 ```
 
 **Example response:**
 ```json
 {
   "serviceInfo": {
-    "serviceId": "tqcge",
+    "serviceId": "arangodb-gral-tqcge",
     "description": "Install complete",
     "status": "DEPLOYED",
-    "namespace": "arangodb"
+    "namespace": "arango",
+    "managingEntity": "ACP"
   }
 }
 ```
 
 {{< info >}}
-Save the `serviceId` from the response. You will use it to construct the Engine API URL for running graph analytics operations.
+Save the trailing segment of the `serviceId` from the response (here: `tqcge`).
+You need it to construct the Engine API URL for running graph analytics operations.
 {{< /info >}}
 
 #### List the services
 
 {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/list_services" >}}
 
-You can list all running services managed by the AI service, including the
+You can list all running services managed by the ACP service, including the
 `graphanalytics` services:
 
 ```bash
@@ -192,13 +196,13 @@ curl -sSk -H "Authorization: bearer <ADB_TOKEN>" \
 
 #### Stop a `graphanalytics` service
 
-{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/service/{SERVICE_ID}" >}}
+{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/service/{serviceId}" >}}
 
-Delete the desired engine via the AI service using the service ID:
+Delete the desired engine via the ACP service using the `serviceId`:
 
 ```bash
 curl -sSk -H "Authorization: bearer <ADB_TOKEN>" \
-  -X DELETE "https://data-platform.example.org:8529/_platform/acp/v1/service/tqcge" | jq
+  -X DELETE "https://data-platform.example.org:8529/_platform/acp/v1/service/arangodb-gral-tqcge" | jq
 ```
 
 ### Management API
@@ -208,7 +212,7 @@ curl -sSk -H "Authorization: bearer <ADB_TOKEN>" \
 {{< info >}}
 This section covers managing Graph Analytics Engines on the **Arango Managed Platform (AMP)**.
 
-If you are using the **Contextual Data Platform**, use the [AI service](#ai-service) instead.
+If you are using the **Contextual Data Platform**, use the [ACP service](#acp-service) instead.
 {{< /info >}}
 
 GAEs are deployed and deleted with the Management API for graph analytics on the
@@ -346,11 +350,12 @@ The Engine API URL is constructed from multiple parts depending on your platform
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/" >}}
+{{< endpoint "" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/" >}}
 
 Where:
 - `<EXTERNAL_ENDPOINT>`: Your Contextual Data Platform endpoint (e.g., `data-platform.example.org`)
-- `<SERVICE_ID>`: From the [AI service response](#start-a-graphanalytics-service) when you started the service
+- `:serviceIdPostfix`: From the [ACP service response](#start-a-graphanalytics-service)
+   when you started the service (the `serviceId` segment after the last hyphen)
 
 **Example:**
 
@@ -373,10 +378,10 @@ For convenience, you can store the Engine API base URL in a variable:
 EXTERNAL_ENDPOINT="data-platform.example.org"
 
 # Service ID from when you started the service
-SERVICE_ID="tqcge"
+SERVICE_ID_POSTFIX="tqcge"
 
 # Construct the Engine API base URL
-ENGINE_URL="https://$EXTERNAL_ENDPOINT:8529/gral/$SERVICE_ID"
+ENGINE_URL="https://$EXTERNAL_ENDPOINT:8529/gral/$SERVICE_ID_POSTFIX"
 ```
 
 This makes subsequent requests shorter and easier to manage. Alternatively, you can use the full URL directly in each request.
@@ -460,8 +465,8 @@ Bash as the shell and that the `curl` and `jq` commands are available.
 # Platform endpoint (from previous section)
 EXTERNAL_ENDPOINT="data-platform.example.org"
 
-# Service ID from when you started the service
-SERVICE_ID="tqcge"
+# Trailing segment of the serviceId from when you started the service (after last hyphen)
+SERVICE_ID_POSTFIX="tqcge"
 
 # Get authentication token
 ADB_TOKEN=$(curl -sSk -X POST \
@@ -469,7 +474,7 @@ ADB_TOKEN=$(curl -sSk -X POST \
   "https://$EXTERNAL_ENDPOINT:8529/_open/auth" | jq -r '.jwt')
 
 # Example: Use token to verify connection
-curl -sSk -H "Authorization: bearer $ADB_TOKEN" "https://$EXTERNAL_ENDPOINT:8529/gral/$SERVICE_ID/v1/jobs"
+curl -sSk -H "Authorization: bearer $ADB_TOKEN" "https://$EXTERNAL_ENDPOINT:8529/gral/$SERVICE_ID_POSTFIX/v1/jobs"
 ```
 
 {{< /tab >}}
@@ -524,7 +529,7 @@ named graphs as well as sets of node and edge collections (see
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/loaddata" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/loaddata" >}}
 
 **Example:**
 
@@ -635,7 +640,7 @@ for example, when using AQL traversals.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/loaddataaql" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/loaddataaql" >}}
 
 **Example:**
 
@@ -744,7 +749,7 @@ curl -H "Authorization: bearer $ADB_TOKEN" -XPOST \
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/pagerank" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/pagerank" >}}
 
 **Example:**
 
@@ -833,7 +838,7 @@ curl -H "Authorization: bearer $ADB_TOKEN" -XPOST -d "{\"graph_id\":$GRAPH_ID,\"
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/wcc" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/wcc" >}}
 
 **Example:**
 
@@ -880,7 +885,7 @@ obtain different IDs.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/scc" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/scc" >}}
 
 **Example:**
 
@@ -944,7 +949,7 @@ available, which should be equally usable for most use cases.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/betweennesscentrality" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/betweennesscentrality" >}}
 
 **Example:**
 
@@ -1027,7 +1032,7 @@ curl -H "Authorization: bearer $ADB_TOKEN" -XPOST -d "{\"graph_id\":$GRAPH_ID,\"
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/linerank" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/linerank" >}}
 
 **Example:**
 
@@ -1096,7 +1101,7 @@ based on common location, interests, occupation, etc.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/labelpropagation" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/labelpropagation" >}}
 
 **Example:**
 
@@ -1175,7 +1180,7 @@ The result is a community ID for each node.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/attributepropagation" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/attributepropagation" >}}
 
 **Example:**
 
@@ -1273,7 +1278,7 @@ curl -H "Authorization: bearer $ADB_TOKEN" -XPOST -d "{\"graph_id\":$GRAPH_ID,\"
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/storeresults" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/storeresults" >}}
 
 **Example:**
 
@@ -1326,7 +1331,7 @@ Parameters:
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/jobs" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/jobs" >}}
 
 **Example:**
 
@@ -1358,7 +1363,7 @@ List all active and finished jobs.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/jobs/{JOB_ID}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/jobs/{JOB_ID}" >}}
 
 **Example:**
 
@@ -1392,7 +1397,7 @@ Get detailed information about a specific job.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/jobs/{JOB_ID}" >}}
+{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/jobs/{JOB_ID}" >}}
 
 **Example:**
 
@@ -1426,7 +1431,7 @@ Delete a specific job.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/graphs" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/graphs" >}}
 
 **Example:**
 
@@ -1458,7 +1463,7 @@ List all loaded sets of graph data that reside in the memory of the engine node.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/graphs/{GRAPH_ID}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/graphs/{GRAPH_ID}" >}}
 
 **Example:**
 
@@ -1492,7 +1497,7 @@ Get detailed information about a specific set of graph data.
 
 {{< tab "Contextual Data Platform" >}}
 
-{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/gral/{SERVICE_ID}/v1/graphs/{GRAPH_ID}" >}}
+{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/gral/{serviceIdPostfix}/v1/graphs/{GRAPH_ID}" >}}
 
 **Example:**
 

--- a/site/content/agentic-ai-suite/graphrag/tutorial-notebook.md
+++ b/site/content/agentic-ai-suite/graphrag/tutorial-notebook.md
@@ -217,8 +217,8 @@ response = start_service("arangodb-graphrag-importer", importer_config)
 pprint(response)
 
 # Extract the service ID for future reference
-importer_service_id = response["serviceInfo"]["serviceId"].split("-")[-1]
-print(f"Importer Service ID: {importer_service_id}")
+importer_service_id_postfix = response["serviceInfo"]["serviceId"].split("-")[-1]
+print(f"Importer Service ID: {importer_service_id_postfix}")
 ```
 
 ### Submit your document
@@ -239,7 +239,7 @@ importer_payload = {
     "file_content": file_content,
 }
 
-importerResponse = send_request(f"/graphrag/importer/{importer_service_id}/v1/import", importer_payload, "POST")
+importerResponse = send_request(f"/graphrag/importer/{importer_service_id_postfix}/v1/import", importer_payload, "POST")
 pprint(importerResponse)
 ```
 
@@ -323,15 +323,14 @@ response = start_service("arangodb-graphrag-retriever", retriever_config)
 pprint(response)
 
 # Extract the service ID for future reference
-retriever_service_id = response["serviceInfo"]["serviceId"].split("-")[-1]
-print(f"Retriever Service ID: {retriever_service_id}")
+retriever_service_id_postfix = response["serviceInfo"]["serviceId"].split("-")[-1]
+print(f"Retriever Service ID: {retriever_service_id_postfix}")
 ```
 
 The Retriever service is available at the following endpoint, which allows you 
 to send queries to the Knowledge Graph:
-```
-/graphrag/retriever/{service_id}/v1/graphrag-query
-```
+
+{{< endpoint "" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{serviceIdPostfix}/v1/graphrag-query" >}}
 
 ### Query parameters
 
@@ -373,7 +372,7 @@ global_query_body = {
 
 print("Executing Global Query...")
 retrieverResponse = send_request(
-    f"/graphrag/retriever/{retriever_service_id}/v1/graphrag-query",
+    f"/graphrag/retriever/{retriever_service_id_postfix}/v1/graphrag-query",
     global_query_body,
     "POST"
 )
@@ -404,7 +403,7 @@ local_query_body = {
 
 print("Executing Local Query...")
 retrieverResponse = send_request(
-    f"/graphrag/retriever/{retriever_service_id}/v1/graphrag-query",
+    f"/graphrag/retriever/{retriever_service_id_postfix}/v1/graphrag-query",
     local_query_body,
     "POST"
 )
@@ -437,7 +436,7 @@ def query_graph(query, query_type):
         "provider": 0
     }
 
-    retrieverResponse = send_request(f"/graphrag/retriever/{retriever_service_id}/v1/graphrag-query", body, "POST")
+    retrieverResponse = send_request(f"/graphrag/retriever/{retriever_service_id_postfix}/v1/graphrag-query", body, "POST")
     result = retrieverResponse["result"]
 
     response = ""

--- a/site/content/agentic-ai-suite/importer/_index.md
+++ b/site/content/agentic-ai-suite/importer/_index.md
@@ -58,7 +58,7 @@ fail at runtime.
 
 ## Installation
 
-To install and start the Importer service, use the AI service endpoint:
+To install and start the Importer service, use the following endpoint:
 
 {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/graphragimporter" >}}
 

--- a/site/content/agentic-ai-suite/importer/importing-files.md
+++ b/site/content/agentic-ai-suite/importer/importing-files.md
@@ -51,7 +51,7 @@ Use single file import when you want to process one document at a time. This is
 ideal for testing, small documents, or when you need immediate feedback without 
 streaming progress updates.
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{serviceIdPostfix}/v1/import" >}}
 
 ### Basic example
 
@@ -60,7 +60,7 @@ streaming progress updates.
 base64_content=$(base64 -i your_document.txt)
 
 # Send to the Importer service
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/<SERVICE_ID_POSTFIX>/v1/import \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -72,7 +72,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/
 ### Example with common parameters
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/<SERVICE_ID_POSTFIX>/v1/import \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -103,12 +103,12 @@ Use multi-file import when you need to process multiple documents into a single
 Knowledge Graph. This API provides streaming progress updates, making it 
 ideal for batch processing and long-running imports where you need to track progress.
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{serviceIdPostfix}/v1/import-multiple" >}}
 
 ### Basic example
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/<SERVICE_ID_POSTFIX>/v1/import-multiple \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -141,7 +141,7 @@ For detailed information about all available parameters, see the [Import Paramet
 For faster processing when you only need semantic search over document chunks:
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/<SERVICE_ID_POSTFIX>/v1/import-multiple \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -292,7 +292,7 @@ data: {"type": "IMPORT_PROGRESS_TYPE_COMPLETED", "message": "Import completed su
 Use curl to view the raw SSE stream as it arrives:
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/<SERVICE_ID_POSTFIX>/v1/import-multiple \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   --no-buffer \
@@ -319,7 +319,7 @@ When using Python, you must parse the SSE format and strip the `data: ` prefix:
 import requests
 import json
 
-url = "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import-multiple"
+url = "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/<SERVICE_ID_POSTFIX>/v1/import-multiple"
 payload = {
     "files": [
         {
@@ -384,19 +384,19 @@ and checking service health.
 
 ### Check job status
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/jobs/{job_id}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{serviceIdPostfix}/v1/jobs/{job_id}" >}}
 
 Returns the current status of a specific import job.
 
 ### List all jobs
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/jobs" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{serviceIdPostfix}/v1/jobs" >}}
 
 Returns a list of all import jobs and their statuses.
 
 ### Health check
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/health" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{serviceIdPostfix}/v1/health" >}}
 
 Returns the health status of the Importer service.
 

--- a/site/content/agentic-ai-suite/importer/semantic-units.md
+++ b/site/content/agentic-ai-suite/importer/semantic-units.md
@@ -123,7 +123,7 @@ In this example, the Importer extracts all image references and stores complete 
 Here's a complete import request with semantic units enabled alongside other import parameters:
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/{SERVICE_ID}/v1/import \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/importer/<SERVICE_ID_POSTFIX>/v1/import \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{

--- a/site/content/agentic-ai-suite/natural-language-to-aql/api-reference.md
+++ b/site/content/agentic-ai-suite/natural-language-to-aql/api-reference.md
@@ -6,7 +6,6 @@ description: >-
   REST API reference for the Natural Language to AQL service, including
   endpoints for text processing, AQL generation, and query execution
 ---
-
 This page documents the runtime REST endpoints of the Natural Language to AQL
 service. For deployment and configuration, see [Setup](setup.md).
 
@@ -18,11 +17,12 @@ All endpoints require a valid platform-issued JWT sent as a Bearer token:
 Authorization: Bearer YOUR_ACCESS_TOKEN
 ```
 
-Use your platform external endpoint and service ID in all request URLs:
+Use your data platform's external endpoint and the trailing segment of the
+`serviceId` in all request URLs:
 
-```
-https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/<endpoint>
-```
+{{< endpoint "" "https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/..." >}}
+
+Example: `https://localhost:8529/graph-rag/xqfnq/v1/process_text_stream`
 
 ## Endpoints
 
@@ -31,9 +31,7 @@ https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/<endpoint>
 Ask general questions to the LLM and receive natural language responses.
 This endpoint does not query your database.
 
-```
-POST /v1/process_text
-```
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/process_text" >}}
 
 **Request body:**
 
@@ -45,7 +43,7 @@ POST /v1/process_text
 
 ```bash
 curl --request POST \
-  --url https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/process_text \
+  --url https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/process_text \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -66,9 +64,7 @@ curl --request POST \
 Stream responses in real-time as they are generated, rather than waiting for the
 complete response.
 
-```
-POST /v1/process_text_stream
-```
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/process_text_stream" >}}
 
 **Request body:**
 
@@ -88,7 +84,7 @@ querying your database.
 
 ```bash
 curl --request POST \
-  --url https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/process_text_stream \
+  --url https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/process_text_stream \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -97,6 +93,7 @@ curl --request POST \
 ```
 
 **Response:**
+
 ```
 Graph databases offer several key advantages: 1) Efficient relationship handling...
 ```
@@ -108,7 +105,7 @@ Use `response_instruction` to guide the output style.
 
 ```bash
 curl --request POST \
-  --url https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/process_text_stream \
+  --url https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/process_text_stream \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -119,6 +116,7 @@ curl --request POST \
 ```
 
 **Response:**
+
 ```aql
 FOR user IN users
   FILTER user.purchases[*].date ANY >= DATE_SUBTRACT(DATE_NOW(), 1, 'month')
@@ -129,6 +127,7 @@ The generated AQL is based on your actual database schema, making it immediately
 usable.
 
 **Example prompts:**
+
 - "List all distinct surnames in the database sorted in descending order"
 - "How many persons are there with the surname 'Stark'?"
 - "Find the parents of 'Arya Stark'"
@@ -138,9 +137,7 @@ usable.
 Convert a natural language question into an AQL query and execute it against your
 database. Returns results in one or more formats.
 
-```
-POST /v1/translate_query
-```
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/translate_query" >}}
 
 **Request body:**
 
@@ -154,7 +151,7 @@ POST /v1/translate_query
 
 ```bash
 curl --request POST \
-  --url https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/translate_query \
+  --url https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/translate_query \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -204,7 +201,7 @@ Set `request_timeout` (in seconds) in the `options` object.
 
 ```bash
 curl --request POST \
-  --url https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/translate_query \
+  --url https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/translate_query \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -220,15 +217,13 @@ curl --request POST \
 
 Check whether the service is running and healthy.
 
-```
-GET /v1/health
-```
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/health" >}}
 
 **Example:**
 
 ```bash
 curl --request GET \
-  --url https://<ExternalEndpoint>/graph-rag/<serviceID>/v1/health \
+  --url https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/health \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN'
 ```
 

--- a/site/content/agentic-ai-suite/natural-language-to-aql/api-reference.md
+++ b/site/content/agentic-ai-suite/natural-language-to-aql/api-reference.md
@@ -217,7 +217,7 @@ curl --request POST \
 
 Check whether the service is running and healthy.
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/health" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graph-rag/{serviceIdPostfix}/v1/health" >}}
 
 **Example:**
 

--- a/site/content/agentic-ai-suite/natural-language-to-aql/setup.md
+++ b/site/content/agentic-ai-suite/natural-language-to-aql/setup.md
@@ -13,7 +13,7 @@ You provide configuration parameters in the request body, and the platform
 automatically provisions the service with those settings.
 
 {{< info >}}
-Replace `<ExternalEndpoint>` in all examples below with your Arango Contextual
+Replace `<EXTERNAL_ENDPOINT>` in all examples below with your Arango Contextual
 Data Platform deployment URL.
 {{< /info >}}
 

--- a/site/content/agentic-ai-suite/natural-language-to-aql/setup.md
+++ b/site/content/agentic-ai-suite/natural-language-to-aql/setup.md
@@ -32,7 +32,7 @@ Before deploying, have ready:
 Generate a Bearer token using the ArangoDB authentication API:
 
 ```bash
-curl -X POST https://<ExternalEndpoint>:8529/_open/auth \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/_open/auth \
   -d '{"username": "your-username", "password": "your-password"}'
 ```
 
@@ -47,7 +47,7 @@ Create the service instance with your configuration:
 
 ```bash
 curl --request POST \
-  --url https://<ExternalEndpoint>:8529/_platform/acp/v1/graphrag \
+  --url https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/graphrag \
   --header 'Authorization: Bearer <your-bearer-token>' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -74,7 +74,8 @@ curl --request POST \
 ```
 
 {{< info >}}
-Save the `serviceId` from the response — you need it for all subsequent API calls.
+Save the trailing segment of the `serviceId` from the response (here: `xxxxx`).
+You need it to construct the endpoint URLs for all subsequent API calls.
 {{< /info >}}
 
 ## Configuration parameters
@@ -109,7 +110,7 @@ in the [Secrets Manager](../../platform-suite/secrets-manager.md):
 
 ```bash
 curl --request POST \
-  --url https://<ExternalEndpoint>:8529/_platform/acp/v1/graphrag \
+  --url https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/graphrag \
   --header 'Authorization: Bearer <your-bearer-token>' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -150,7 +151,7 @@ Check that the service is properly deployed:
 
 ```bash
 curl --request GET \
-  --url https://<ExternalEndpoint>:8529/_platform/acp/v1/service/arangodb-graph-rag-<serviceID> \
+  --url https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/service/<SERVICE_ID> \
   --header 'Authorization: Bearer <your-bearer-token>'
 ```
 
@@ -158,7 +159,7 @@ curl --request GET \
 ```json
 {
   "serviceInfo": {
-    "serviceId": "arangodb-graph-rag-<serviceID>",
+    "serviceId": "arangodb-graph-rag-xxxxx",
     "description": "Install complete",
     "status": "DEPLOYED",
     "namespace": "<arangodb>",
@@ -173,7 +174,7 @@ Verify that the service is running and healthy:
 
 ```bash
 curl --request GET \
-  --url https://<ExternalEndpoint>:8529/graph-rag/<serviceID>/v1/health \
+  --url https://<EXTERNAL_ENDPOINT>:8529/graph-rag/<SERVICE_ID_POSTFIX>/v1/health \
   --header 'Authorization: Bearer <your-bearer-token>'
 ```
 
@@ -185,8 +186,8 @@ curl --request GET \
 ```
 
 {{< info >}}
-The `serviceID` in the URL is typically the last part of the full service ID
-(for example, `xxxxx` from `arangodb-graph-rag-xxxxx`).
+The `serviceIdPostfix` in the URL is the trailing segment of the `serviceId`
+(after the last `-`), like `xxxxx` from `arangodb-graph-rag-xxxxx`.
 {{< /info >}}
 
 Once the service is running, see the [API Reference](api-reference.md) for endpoint

--- a/site/content/agentic-ai-suite/reference/mlflow.md
+++ b/site/content/agentic-ai-suite/reference/mlflow.md
@@ -58,9 +58,7 @@ The ArangoDB MLflow service is **started by default**.
 
 It is automatically spawned and available at the following URL:
 
-```
-https://<EXTERNAL_ENDPOINT>:8529/mlflow/
-```
+{{< endpoint "" "https://<EXTERNAL_ENDPOINT>:8529/mlflow/" >}}
 
 You can interact with the ArangoDB MLflow service in two ways:
 - **Programmatically**: Using the official MLflow client

--- a/site/content/agentic-ai-suite/reference/mlflow.md
+++ b/site/content/agentic-ai-suite/reference/mlflow.md
@@ -59,7 +59,7 @@ The ArangoDB MLflow service is **started by default**.
 It is automatically spawned and available at the following URL:
 
 ```
-https://<ExternalEndpoint>:8529/mlflow/
+https://<EXTERNAL_ENDPOINT>:8529/mlflow/
 ```
 
 You can interact with the ArangoDB MLflow service in two ways:
@@ -79,7 +79,7 @@ Before you can authenticate with the MLflow service, you need to obtain a
 Bearer token. You can generate this token using the ArangoDB authentication API:
 
 ```bash
-curl -X POST https://<ExternalEndpoint>:8529/_open/auth \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/_open/auth \
   -d '{"username": "your-username", "password": "your-password"}'
 ```
 
@@ -112,7 +112,7 @@ import os
 
 # Set authentication and tracking URI
 os.environ['MLFLOW_TRACKING_TOKEN'] = 'your-bearer-token-here'
-mlflow.set_tracking_uri("https://<ExternalEndpoint>:8529/mlflow/")
+mlflow.set_tracking_uri("https://<EXTERNAL_ENDPOINT>:8529/mlflow/")
 
 # Start logging your experiments
 with mlflow.start_run():
@@ -124,7 +124,7 @@ with mlflow.start_run():
 Set the environment variables in your shell:
 
 ```bash
-export MLFLOW_TRACKING_URI="https://<ExternalEndpoint>:8529/mlflow/"
+export MLFLOW_TRACKING_URI="https://<EXTERNAL_ENDPOINT>:8529/mlflow/"
 export MLFLOW_TRACKING_TOKEN="your-bearer-token-here"
 ```
 
@@ -143,7 +143,7 @@ with mlflow.start_run():
 To test whether the service is running, you can use the following snippet:
 
 ```bash
-curl -H "Authorization: Bearer your-bearer-token-here" https://<ExternalEndpoint>:8529/mlflow/health
+curl -H "Authorization: Bearer your-bearer-token-here" https://<EXTERNAL_ENDPOINT>:8529/mlflow/health
 ```
 
 Expected output on success: HTTP `200` status with response body `OK`.

--- a/site/content/agentic-ai-suite/reference/triton-inference-server.md
+++ b/site/content/agentic-ai-suite/reference/triton-inference-server.md
@@ -35,10 +35,10 @@ the Arango Contextual Data Platform ecosystem. It integrates with the:
 - MLFlow model registry for model management.
 - Storage sidecar for artifact storage.
 
-## Installation via AI Service API
+## Installation via ACP Service API
 
 To install the Triton LLM Host service, send an API request to the
-**AI service** using the following parameters:
+**ACP service** using the following parameters:
 
 ### Required parameters
 
@@ -162,7 +162,7 @@ Triton Inference Server for more details.
 - **Internal access (within Arango Contextual Data Platform)**:
   `https://{SERVICE_ID}.{KUBERNETES_NAMESPACE}.svc:8000`
   - `KUBERNETES_NAMESPACE` is available as an environment variable.
-  - `SERVICE_ID` is returned by the AI service API.
+  - `SERVICE_ID` is returned by the ACP service API.
 
   **Example**:
   To check server health:

--- a/site/content/agentic-ai-suite/retriever/_index.md
+++ b/site/content/agentic-ai-suite/retriever/_index.md
@@ -68,7 +68,7 @@ Before using the Retriever service, you need:
 
 ## Installation
 
-To install and start the Retriever service, use the AI service endpoint:
+To install and start the Retriever service, use the following endpoint:
 
 {{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/graphragretriever" >}}
 

--- a/site/content/agentic-ai-suite/retriever/executing-queries.md
+++ b/site/content/agentic-ai-suite/retriever/executing-queries.md
@@ -14,11 +14,11 @@ weight: 40
 
 The Retriever service provides two main query endpoints and a health endpoint:
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{serviceIdPostfix}/v1/graphrag-query" >}}
 
-{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query-stream" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{serviceIdPostfix}/v1/graphrag-query-stream" >}}
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/health" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{serviceIdPostfix}/v1/health" >}}
 
 {{< tip >}}
 The streaming endpoint (`/v1/graphrag-query-stream`) returns responses
@@ -47,7 +47,7 @@ it using the query endpoints.
 {{< tab "Global Search" >}}
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -63,7 +63,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
 {{< tab "Local Search" >}}
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -79,7 +79,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
 {{< tab "Deep Search" >}}
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -95,7 +95,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
 {{< tab "Instant Search" >}}
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query-stream \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query-stream \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -110,7 +110,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
 {{< tab "Custom Retriever" >}}
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -133,7 +133,7 @@ For detailed information about all available parameters, see the
 **Instant Search with response instructions:**
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query-stream \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query-stream \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -149,7 +149,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
 **Deep Search:**
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -169,7 +169,7 @@ regardless of `show_citations`. The same applies to `GLOBAL` queries.
 **Global Search:**
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{
@@ -185,7 +185,7 @@ curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1
 **Custom Retriever with partition filtering:**
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{

--- a/site/content/agentic-ai-suite/retriever/search-methods/custom-retriever.md
+++ b/site/content/agentic-ai-suite/retriever/search-methods/custom-retriever.md
@@ -123,7 +123,7 @@ Pass `"auto_create_indexes": true` in your request to create missing indexes
 automatically:
 
 ```bash
-curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/graphrag-query \
+curl -X POST https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/<SERVICE_ID_POSTFIX>/v1/graphrag-query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-jwt-token>" \
   -d '{

--- a/site/content/agentic-ai-suite/retriever/verify-and-monitor.md
+++ b/site/content/agentic-ai-suite/retriever/verify-and-monitor.md
@@ -14,7 +14,7 @@ weight: 50
 
 You can monitor the Retriever service health using the health endpoint:
 
-{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{SERVICE_ID}/v1/health" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/graphrag/retriever/{serviceIdPostfix}/v1/health" >}}
 
 ## Verify Service Status
 

--- a/site/content/platform-suite/cypher2aql.md
+++ b/site/content/platform-suite/cypher2aql.md
@@ -108,8 +108,7 @@ paths:
                     properties:
                       serviceId:
                         description: |
-                          The service name followed by a hyphen and
-                          the unique identifier assigned to the service.
+                          The unique identifier assigned to the service.
                         type: string
                         example: arango-cypher2aql-z8fue
                       description:
@@ -223,18 +222,18 @@ curl -s "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/service" \
 service: cypher2aql
 ---
 paths:
-  /cypher2aql/{serviceId}/v1/cypher2aql:
+  /cypher2aql/{serviceIdPostfix}/v1/cypher2aql:
     post:
       operationId: translateCypherToAql
       description: |
         Translates a query string from Cypher to AQL.
       parameters:
-        - name: serviceId
+        - name: serviceIdPostfix
           in: path
           required: true
           description: |
-            The unique identifier of the Cypher to AQL service running in
-            the data platform.
+            The trailing segment of the `arango-cypher2aql` service identifier
+            (after the last `-`).
           schema:
             type: string
             example: z8fue
@@ -361,18 +360,18 @@ curl -s -X POST "https://<EXTERNAL_ENDPOINT>:8529/cypher2aql/<SERVICE_ID>/v1/cyp
 service: cypher2aql
 ---
 paths:
-  /cypher2aql/{serviceId}/v1/version:
+  /cypher2aql/{serviceIdPostfix}/v1/version:
     get:
       operationId: getVersion
       description: |
         Returns the service version.
       parameters:
-        - name: serviceId
+        - name: serviceIdPostfix
           in: path
           required: true
           description: |
-            The unique identifier of the Cypher to AQL service running in
-            the data platform.
+            The trailing segment of the `arango-cypher2aql` service identifier
+            (after the last `-`).
           schema:
             type: string
             example: z8fue
@@ -428,18 +427,18 @@ curl -s "https://<EXTERNAL_ENDPOINT>:8529/cypher2aql/<SERVICE_ID>/v1/version" \
 service: cypher2aql
 ---
 paths:
-  /cypher2aql/{serviceId}/v1/health:
+  /cypher2aql/{serviceIdPostfix}/v1/health:
     get:
       operationId: getHealth
       description: |
         Returns a simple health status.
       parameters:
-        - name: serviceId
+        - name: serviceIdPostfix
           in: path
           required: true
           description: |
-            The unique identifier of the Cypher to AQL service running in
-            the data platform.
+            The trailing segment of the `arango-cypher2aql` service identifier
+            (after the last `-`).
           schema:
             type: string
             example: z8fue
@@ -507,8 +506,8 @@ paths:
           in: path
           required: true
           description: |
-            The identifier of the service to stop, here the name of the
-            Cypher to AQL service followed by a hyphen and the unique identifier
+            The identifier of the service to stop, here the ID of the
+            `arango-cypher2aql` service.
             assigned to the service.
           schema:
             type: string
@@ -529,7 +528,7 @@ paths:
                     properties:
                       serviceId:
                         description: |
-                          The service name followed by a hyphen and the unique identifier.
+                          The unique identifier assigned to the service.
                         type: string
                         example: arango-cypher2aql-z8fue
                       description:

--- a/site/content/platform-suite/cypher2aql.md
+++ b/site/content/platform-suite/cypher2aql.md
@@ -508,7 +508,6 @@ paths:
           description: |
             The identifier of the service to stop, here the ID of the
             `arango-cypher2aql` service.
-            assigned to the service.
           schema:
             type: string
             example: arango-cypher2aql-z8fue

--- a/site/content/platform-suite/file-manager/api.md
+++ b/site/content/platform-suite/file-manager/api.md
@@ -17,7 +17,7 @@ Authentication uses a Bearer token in the `Authorization` header.
 
 ## Health Check
 
-{{< endpoint "GET" "/_platform/filemanager/health" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/health" >}}
 
 Returns the current health status of the service.
 
@@ -42,7 +42,7 @@ file. The original filename is preserved in the `file_name` metadata field.
 
 ### Upload a BYOC File
 
-{{< endpoint "POST" "/_platform/filemanager/global/byoc/" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc/" >}}
 
 Uploads a code package for a BYOC container service deployment.
 
@@ -87,7 +87,7 @@ curl -X POST "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc
 
 ### List BYOC Services
 
-{{< endpoint "GET" "/_platform/filemanager/global/byoc/" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc/" >}}
 
 Lists all uploaded BYOC services with optional filtering and pagination.
 
@@ -127,7 +127,7 @@ Lists all uploaded BYOC services with optional filtering and pagination.
 
 ### List Versions of a BYOC Service
 
-{{< endpoint "GET" "/_platform/filemanager/global/byoc/{name}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc/{name}" >}}
 
 Lists all available versions of a specific BYOC service.
 
@@ -170,7 +170,7 @@ Lists all available versions of a specific BYOC service.
 
 ### Get BYOC File Info
 
-{{< endpoint "GET" "/_platform/filemanager/global/byoc/{name}/{version}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc/{name}/{version}" >}}
 
 Retrieves metadata for a specific version of a BYOC service.
 
@@ -203,7 +203,7 @@ Retrieves metadata for a specific version of a BYOC service.
 
 ### Download a BYOC File
 
-{{< endpoint "GET" "/_platform/filemanager/global/byoc/{name}/{version}/download" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc/{name}/{version}/download" >}}
 
 Downloads the file content as a binary stream.
 
@@ -231,7 +231,7 @@ curl -X GET \
 
 ### Delete a BYOC File
 
-{{< endpoint "DELETE" "/_platform/filemanager/global/byoc/{name}/{version}" >}}
+{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc/{name}/{version}" >}}
 
 Deletes a specific version of a BYOC service file and its metadata.
 Deletion is only permitted when `safe_to_delete` is `true` in the file metadata,
@@ -267,7 +267,7 @@ include images, videos, audio, PDFs, and other binary media.
 
 ### Upload a RAG Input File
 
-{{< endpoint "POST" "/_platform/filemanager/_db/{database}/rag-input" >}}
+{{< endpoint "POST" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/_db/{database}/rag-input" >}}
 
 Uploads a file for RAG processing. Re-uploading a file with the same name
 within the same database automatically creates a new version.
@@ -308,7 +308,7 @@ within the same database automatically creates a new version.
 
 ### List RAG Input Files
 
-{{< endpoint "GET" "/_platform/filemanager/_db/{database}/rag-input" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/_db/{database}/rag-input" >}}
 
 Lists RAG input files for a specific database.
 
@@ -353,7 +353,7 @@ Lists RAG input files for a specific database.
 
 ### Get Version History
 
-{{< endpoint "GET" "/_platform/filemanager/_db/{database}/rag-input/versions" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/_db/{database}/rag-input/versions" >}}
 
 Returns the full version history for a file, looked up by name within the
 specified database.
@@ -396,7 +396,7 @@ specified database.
 
 ### Get RAG Input File Info
 
-{{< endpoint "GET" "/_platform/filemanager/_db/{database}/rag-input/{id}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/_db/{database}/rag-input/{id}" >}}
 
 Retrieves metadata for a stored RAG input file. Returns the latest version
 unless a specific version is requested.
@@ -436,7 +436,7 @@ unless a specific version is requested.
 
 ### Download a RAG Input File
 
-{{< endpoint "GET" "/_platform/filemanager/_db/{database}/rag-input/{id}/download" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/_db/{database}/rag-input/{id}/download" >}}
 
 Downloads the file content as a binary stream. Returns the latest version
 unless a specific version is requested.
@@ -462,7 +462,7 @@ unless a specific version is requested.
 
 ### Delete a RAG Input File
 
-{{< endpoint "DELETE" "/_platform/filemanager/_db/{database}/rag-input/{id}" >}}
+{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/_db/{database}/rag-input/{id}" >}}
 
 Deletes a RAG input file and its metadata. Defaults to the latest version
 unless a specific version is specified. Deletion is only permitted when the
@@ -503,7 +503,7 @@ with no path prefix.
 
 ### Upload an Artifact
 
-{{< endpoint "PUT" "/_platform/filemanager/{file_path}" >}}
+{{< endpoint "PUT" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/{file_path}" >}}
 
 Uploads a file to the specified path in artifact storage.
 
@@ -529,7 +529,7 @@ Uploads a file to the specified path in artifact storage.
 
 ### List Artifacts
 
-{{< endpoint "GET" "/_platform/filemanager/mlflow-artifacts/artifacts" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/mlflow-artifacts/artifacts" >}}
 
 Lists MLflow artifacts at the specified directory path.
 
@@ -564,7 +564,7 @@ Lists MLflow artifacts at the specified directory path.
 
 ### Download an Artifact
 
-{{< endpoint "GET" "/_platform/filemanager/{file_path}" >}}
+{{< endpoint "GET" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/{file_path}" >}}
 
 Downloads the content of the specified artifact file.
 
@@ -582,7 +582,7 @@ Downloads the content of the specified artifact file.
 
 ### Delete an Artifact
 
-{{< endpoint "DELETE" "/_platform/filemanager/{file_path}" >}}
+{{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/{file_path}" >}}
 
 Removes the specified file or directory and all its contents from artifact storage.
 


### PR DESCRIPTION
### Description

Moreover, refer to ACP service rather than AI service (except about the deletion of project metadata, unclear what it means in the context)

Code examples use `<PLACEHOLDERS>` rather `{PLACEHOLDERS}` but endpoint short uses `{placeHolders}` - in this case `SERVICE_ID` in curl commands and `serviceId` for endpoint descriptions (because the latter aligns well with the ACP response which calls it `serviceId`)

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated endpoints and examples to use ACP-based service endpoints and fully qualified external URLs where applicable (e.g., AutoGraph, File Manager, Triton, MLflow).
  * Standardized and renamed service identifier placeholders to use a serviceIdPostfix/postfix-style placeholder across API examples, quickstarts, and tutorials for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arangodb/docs-hugo/pull/1004)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->