### PR TITLE
Adjust mention of RocksDB total WAL size default value

### DIFF
--- a/site/content/arangodb/3.12/operations/administration/reduce-memory-footprint.md
+++ b/site/content/arangodb/3.12/operations/administration/reduce-memory-footprint.md
@@ -177,7 +177,7 @@ option
 --rocksdb.max-total-wal-size
 ```
 
-to some value smaller than its default of 80MB can potentially help
+to some value smaller than its default of 256MB can potentially help
 to reduce RAM usage. However, the effect is rather indirect.
 
 ## Write Buffers

--- a/site/content/arangodb/4.0/operations/administration/reduce-memory-footprint.md
+++ b/site/content/arangodb/4.0/operations/administration/reduce-memory-footprint.md
@@ -172,7 +172,7 @@ option
 --rocksdb.max-total-wal-size
 ```
 
-to some value smaller than its default of 80MB can potentially help
+to some value smaller than its default of 256MB can potentially help
 to reduce RAM usage. However, the effect is rather indirect.
 
 ## Write Buffers


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the documented default value for the rocksdb.max-total-wal-size configuration setting from 80MB to 256MB in ArangoDB documentation for versions 3.12 and 4.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arangodb/docs-hugo/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->