### PR TITLE
Clarify ACP delete project endpoint

### DIFF
--- a/site/content/platform-suite/control-plane-acp.md
+++ b/site/content/platform-suite/control-plane-acp.md
@@ -406,7 +406,8 @@ The response includes:
 
 ### Deleting a project
 
-Remove a project's metadata from the AI service:
+Delete a project. The project record is removed entirely; only the external
+resources it referenced (services, collections, graphs) remain.
 
 {{< endpoint "DELETE" "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/project/{project_db_name}/{project_name}" >}}
 
@@ -416,13 +417,14 @@ curl -X DELETE https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/project/<projec
 ```
 
 {{< warning >}}
-Deleting a project only removes the project metadata from the AI service.
-It does **not** delete:
-- Services associated with the project (must be deleted separately)
-- ArangoDB collections and data
-- Knowledge graphs
+Deleting a project removes the project record itself, but it does **not**
+delete the resources the project referenced:
+- Importer, Retriever, and AutoGraph services
+- ArangoDB collections created with the project name as prefix
+  (for example, `docs_Documents`, `docs_Chunks`)
+- Knowledge graphs stored in ArangoDB
 
-You must manually delete services and collections if needed.
+Delete those separately if you no longer need them.
 {{< /warning >}}
 
 ## Secrets


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project deletion documentation to clarify that external resources (services, ArangoDB collections, and knowledge graphs) are not automatically deleted with the project record. Added warning instructing users to manually delete these resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arangodb/docs-hugo/pull/1009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->