### PR TITLE
DOC-924 | Update base images in Container Manager

### DIFF
--- a/site/content/contextual-data-platform/release-notes.md
+++ b/site/content/contextual-data-platform/release-notes.md
@@ -105,11 +105,10 @@ deploy and manage custom services directly within the Arango Contextual Data Pla
 running your own applications alongside platform services.
 
 Deploy services by uploading source code packages (`.tar.gz`) or providing Docker
-image URLs, with support for Python 3.12 (including PyTorch and cuGraph variants)
-and Node.js 22 runtimes. Services can be scoped globally or per-database, with
-version management and deployment via
-[web interface](../platform-suite/container-manager/web-interface.md) or
-[API](../platform-suite/container-manager/deploy-api/).
+image URLs, with support for Python 3.12 runtimes (including PyTorch and cuGraph
+variants). Services can be scoped globally or per-database, with version management
+and deployment via [web interface](../platform-suite/container-manager/web-interface.md)
+or [API](../platform-suite/container-manager/deploy-api/).
 
 ### File Manager
 

--- a/site/content/contextual-data-platform/release-notes.md
+++ b/site/content/contextual-data-platform/release-notes.md
@@ -105,10 +105,11 @@ deploy and manage custom services directly within the Arango Contextual Data Pla
 running your own applications alongside platform services.
 
 Deploy services by uploading source code packages (`.tar.gz`) or providing Docker
-image URLs, with support for Python 3.13 runtimes (including PyTorch and cuGraph
-variants). Services can be scoped globally or per-database, with version management
-and deployment via [web interface](../platform-suite/container-manager/web-interface.md)
-or [API](../platform-suite/container-manager/deploy-api/).
+image URLs, with support for Python 3.12 (including PyTorch and cuGraph variants)
+and Node.js 22 runtimes. Services can be scoped globally or per-database, with
+version management and deployment via
+[web interface](../platform-suite/container-manager/web-interface.md) or
+[API](../platform-suite/container-manager/deploy-api/).
 
 ### File Manager
 

--- a/site/content/platform-suite/container-manager/_index.md
+++ b/site/content/platform-suite/container-manager/_index.md
@@ -68,8 +68,9 @@ You may consider using AI tools for this.
   provide Docker image URLs to deploy running services.
 
 - **Multiple Runtimes**: For code-based deployments, supported runtime
-  environments include Python with optional CUDA/GPU support. For image-based
-  deployments, you can use any runtime packaged in your Docker image.
+  environments include Python (with optional CUDA/GPU support) and Node.js.
+  For image-based deployments, you can use any runtime packaged in your
+  Docker image.
 
 - **Version Management**: Maintain and deploy multiple versions of the same
   service with easy updates.
@@ -95,7 +96,8 @@ Control where your services are accessible and how they integrate with your data
 Deploy services using runtime environments and resources tailored to your needs.
 
 **Code-based deployments (Bring Your Own Code):**
-- **Python 3.13** (base, PyTorch, and cuGraph variants available)
+- **Python 3.12** (base, PyTorch, and cuGraph variants available)
+- **Node.js 22** (base runtime)
 
 **Container-based deployments (Bring Your Own Container):**
 - Any runtime or language packaged in your container image

--- a/site/content/platform-suite/container-manager/_index.md
+++ b/site/content/platform-suite/container-manager/_index.md
@@ -68,9 +68,8 @@ You may consider using AI tools for this.
   provide Docker image URLs to deploy running services.
 
 - **Multiple Runtimes**: For code-based deployments, supported runtime
-  environments include Python (with optional CUDA/GPU support) and Node.js.
-  For image-based deployments, you can use any runtime packaged in your
-  Docker image.
+  environments include Python with optional CUDA/GPU support. For image-based
+  deployments, you can use any runtime packaged in your Docker image.
 
 - **Version Management**: Maintain and deploy multiple versions of the same
   service with easy updates.
@@ -97,7 +96,6 @@ Deploy services using runtime environments and resources tailored to your needs.
 
 **Code-based deployments (Bring Your Own Code):**
 - **Python 3.12** (base, PyTorch, and cuGraph variants available)
-- **Node.js 22** (base runtime)
 
 **Container-based deployments (Bring Your Own Container):**
 - Any runtime or language packaged in your container image

--- a/site/content/platform-suite/container-manager/deploy-api.md
+++ b/site/content/platform-suite/container-manager/deploy-api.md
@@ -41,7 +41,7 @@ curl -X POST "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc
 |-------|-------------|----------|
 | `name` | Application name identifier (alphanumeric, hyphens, underscores) | Yes |
 | `version` | Application version (e.g., `1.0.0`) | Yes |
-| `language` | Programming language: `python` or `javascript` | Yes |
+| `language` | Programming language: `python` | Yes |
 | `type` | Deployment type: `Service` | Yes |
 | `file` | The `.tar.gz` archive file | Yes |
 
@@ -98,7 +98,6 @@ curl -X POST "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/uds" \
 | `py12base` | Python 3.12 base runtime |
 | `py12torch` | Python 3.12 with PyTorch |
 | `py12cugraph` | Python 3.12 with cuGraph |
-| `node22base` | Node.js 22 base runtime |
 
 ## Deploy an Image-Based Service
 
@@ -203,7 +202,7 @@ Get a list of all uploaded services:
 | Parameter | Description | Required |
 |-----------|-------------|----------|
 | `name` | Filter by service name | No |
-| `language` | Filter by language (`python` or `javascript`) | No |
+| `language` | Filter by language (`python`) | No |
 | `type` | Filter by type (`Service` or `Job`) | No |
 | `limit` | Maximum results to return (default: 100) | No |
 | `offset` | Pagination offset (default: 0) | No |

--- a/site/content/platform-suite/container-manager/deploy-api.md
+++ b/site/content/platform-suite/container-manager/deploy-api.md
@@ -41,7 +41,7 @@ curl -X POST "https://<EXTERNAL_ENDPOINT>:8529/_platform/filemanager/global/byoc
 |-------|-------------|----------|
 | `name` | Application name identifier (alphanumeric, hyphens, underscores) | Yes |
 | `version` | Application version (e.g., `1.0.0`) | Yes |
-| `language` | Programming language: `python` | Yes |
+| `language` | Programming language: `python` or `javascript` | Yes |
 | `type` | Deployment type: `Service` | Yes |
 | `file` | The `.tar.gz` archive file | Yes |
 
@@ -73,7 +73,7 @@ curl -X POST "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/uds" \
     "app_version": "<APP_VERSION>",
     "env": {
       "service_type": "base_type",
-      "base_image": "py13base",
+      "base_image": "py12base",
       "app_instance_name": "<APP_INSTANCE_NAME>",
       "db_name": "<DATABASE_NAME>"
     }
@@ -95,9 +95,10 @@ curl -X POST "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/uds" \
 
 | Image Name | Description |
 |------------|-------------|
-| `py13base` | Python 3.13 base runtime |
-| `py13torch` | Python 3.13 with PyTorch |
-| `py13cugraph` | Python 3.13 with cuGraph |
+| `py12base` | Python 3.12 base runtime |
+| `py12torch` | Python 3.12 with PyTorch |
+| `py12cugraph` | Python 3.12 with cuGraph |
+| `node22base` | Node.js 22 base runtime |
 
 ## Deploy an Image-Based Service
 
@@ -202,7 +203,7 @@ Get a list of all uploaded services:
 | Parameter | Description | Required |
 |-----------|-------------|----------|
 | `name` | Filter by service name | No |
-| `language` | Filter by language (`python`) | No |
+| `language` | Filter by language (`python` or `javascript`) | No |
 | `type` | Filter by type (`Service` or `Job`) | No |
 | `limit` | Maximum results to return (default: 100) | No |
 | `offset` | Pagination offset (default: 0) | No |
@@ -341,7 +342,7 @@ curl -X POST "$ENDPOINT/_platform/acp/v1/uds" \
     \"app_version\": \"$SERVICE_VERSION\",
     \"env\": {
       \"service_type\": \"base_type\",
-      \"base_image\": \"py13base\",
+      \"base_image\": \"py12base\",
       \"app_instance_name\": \"$INSTANCE_NAME\",
       \"db_name\": \"$DATABASE\"
     }

--- a/site/content/platform-suite/container-manager/package-code.md
+++ b/site/content/platform-suite/container-manager/package-code.md
@@ -48,17 +48,25 @@ follow the steps below.
 1. Create a project structure with your application code and entry point script.
 2. Add a dependency configuration file:
    - For Python: Create a `pyproject.toml` with your dependencies and Python version requirement.
-3. Use `uv` for Python projects (recommended):
+   - For Node.js: Create a `package.json` with your dependencies and the
+     `engines.node` field set to your target runtime.
+3. For Python projects, use `uv` (recommended):
    - Ensure your `pyproject.toml` specifies `requires-python` matching your target runtime
-     (e.g., `">=3.11"` for Python 3.11 and newer runtimes).
+     (e.g., `">=3.12"` for the `py12*` base images).
    - List all dependencies in the `dependencies` array.
    - The platform uses `uv` to install dependencies during containerization.
-4. Create the archive:
+4. For Node.js projects:
+   - Set `"engines": { "node": ">=22" }` in `package.json` to match the
+     `node22base` runtime.
+   - List all dependencies under `dependencies` (and `devDependencies` as needed).
+   - The platform uses `npm` to install dependencies during containerization.
+5. Create the archive:
    ```bash
    tar -czf myservice.tar.gz myproject/
    ```
-5. Test locally (optional but recommended):
-   - Install dependencies using `uv sync`.
+6. Test locally (optional but recommended):
+   - For Python, install dependencies using `uv sync`.
+   - For Node.js, install dependencies using `npm install`.
    - Run your entry point script to verify it works before uploading.
 
 ## Example: Python Project
@@ -76,11 +84,41 @@ myproject/
 [project]
 name = "my-service"
 version = "1.0.0"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
 ]
+```
+
+**Create the archive:**
+```bash
+tar -czf myservice.tar.gz myproject/
+```
+
+## Example: Node.js Project
+
+**Project structure:**
+```
+myproject/
+├── package.json
+├── index.js
+└── config.json
+```
+
+**Example `package.json`:**
+```json
+{
+  "name": "my-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "express": "^4.19.0"
+  }
+}
 ```
 
 **Create the archive:**

--- a/site/content/platform-suite/container-manager/package-code.md
+++ b/site/content/platform-suite/container-manager/package-code.md
@@ -48,25 +48,17 @@ follow the steps below.
 1. Create a project structure with your application code and entry point script.
 2. Add a dependency configuration file:
    - For Python: Create a `pyproject.toml` with your dependencies and Python version requirement.
-   - For Node.js: Create a `package.json` with your dependencies and the
-     `engines.node` field set to your target runtime.
-3. For Python projects, use `uv` (recommended):
+3. Use `uv` for Python projects (recommended):
    - Ensure your `pyproject.toml` specifies `requires-python` matching your target runtime
      (e.g., `">=3.12"` for the `py12*` base images).
    - List all dependencies in the `dependencies` array.
    - The platform uses `uv` to install dependencies during containerization.
-4. For Node.js projects:
-   - Set `"engines": { "node": ">=22" }` in `package.json` to match the
-     `node22base` runtime.
-   - List all dependencies under `dependencies` (and `devDependencies` as needed).
-   - The platform uses `npm` to install dependencies during containerization.
-5. Create the archive:
+4. Create the archive:
    ```bash
    tar -czf myservice.tar.gz myproject/
    ```
-6. Test locally (optional but recommended):
-   - For Python, install dependencies using `uv sync`.
-   - For Node.js, install dependencies using `npm install`.
+5. Test locally (optional but recommended):
+   - Install dependencies using `uv sync`.
    - Run your entry point script to verify it works before uploading.
 
 ## Example: Python Project
@@ -89,36 +81,6 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
 ]
-```
-
-**Create the archive:**
-```bash
-tar -czf myservice.tar.gz myproject/
-```
-
-## Example: Node.js Project
-
-**Project structure:**
-```
-myproject/
-├── package.json
-├── index.js
-└── config.json
-```
-
-**Example `package.json`:**
-```json
-{
-  "name": "my-service",
-  "version": "1.0.0",
-  "main": "index.js",
-  "engines": {
-    "node": ">=22"
-  },
-  "dependencies": {
-    "express": "^4.19.0"
-  }
-}
 ```
 
 **Create the archive:**

--- a/site/content/platform-suite/container-manager/web-interface.md
+++ b/site/content/platform-suite/container-manager/web-interface.md
@@ -39,9 +39,10 @@ See [Package Your Code](package-code/) for instructions.
 4. Specify a **Version** using semantic versioning (e.g., `1.0.0`, `2.1.3`).
    This allows you to maintain multiple versions of the same service.
 5. Choose the **Base Image** from the dropdown:
-   - `py13base`: Python 3.13 base runtime
-   - `py13torch`: Python 3.13 with PyTorch
-   - `py13cugraph`: Python 3.13 with cuGraph
+   - `py12base`: Python 3.12 base runtime
+   - `py12torch`: Python 3.12 with PyTorch
+   - `py12cugraph`: Python 3.12 with cuGraph
+   - `node22base`: Node.js 22 base runtime
 6. Define the **Service URL Path** where your service will be accessible
    (e.g., `my-service`).
 7. Check **Make this a global URL service** to make the service accessible

--- a/site/content/platform-suite/container-manager/web-interface.md
+++ b/site/content/platform-suite/container-manager/web-interface.md
@@ -42,7 +42,6 @@ See [Package Your Code](package-code/) for instructions.
    - `py12base`: Python 3.12 base runtime
    - `py12torch`: Python 3.12 with PyTorch
    - `py12cugraph`: Python 3.12 with cuGraph
-   - `node22base`: Node.js 22 base runtime
 6. Define the **Service URL Path** where your service will be accessible
    (e.g., `my-service`).
 7. Check **Make this a global URL service** to make the service accessible


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Container Manager now documents Python 3.12 as the supported runtime (base, PyTorch, and cuGraph variants).
  * Packaging guidance updated to require Python >=3.12.
  * Deployment examples, API docs, and the web UI base‑image dropdown updated to reference the Python 3.12 images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arangodb/docs-hugo/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->