### PR TITLE
DOC-916 | Enable git info in hugo config

### DIFF
--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -3,6 +3,7 @@ languageCode: "en-us"
 title: "Arango Documentation"
 theme: "arangodb-docs-theme"
 timeout: "200000000"
+enableGitInfo: true
 
 disableKinds: # Switch off tags and categories
   - taxonomy

--- a/site/themes/arangodb-docs-theme/layouts/partials/meta.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/meta.html
@@ -10,6 +10,9 @@
 <meta property="og:title" content="{{ .Title | default .Site.Title | markdownify | plainify }}">
 <meta property="og:type" content="website">
 <meta property="og:description" content="{{ $pageDescription }}">
+{{- if not .Lastmod.IsZero }}
+<meta property="article:modified_time" content="{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}">
+{{ end }}
 {{- with .Site.Params.author }}
 <meta name="author" content="{{ . }}">
 {{- end }}

--- a/toolchain/scripts/start_hugo.sh
+++ b/toolchain/scripts/start_hugo.sh
@@ -23,6 +23,10 @@ checkIPIsReachable "$arangoproxyUrl/health"
 
 cd /home/site
 
+# Hugo's enableGitInfo runs `git log` per file; mark the bind-mounted
+# repo as safe so Git doesn't refuse on uid mismatch between host and container.
+git config --global --add safe.directory /home
+
 hugoOptions=""
 if [ "$ENV" = "local" ]; then
     # Without --buildDrafts (rarely used) to match CI builds


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Git metadata integration for the site build so commit-based info is available during site generation.
  * Adjusted startup behavior to avoid Git-related build failures in container environments.

* **New Features**
  * Emit an article:modified_time meta tag when a page has a valid last-modified timestamp, improving page metadata visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->