### PR TITLE
Exclude noindex pages from sitemap

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/_default/sitemap.xml
+++ b/site/themes/arangodb-docs-theme/layouts/_default/sitemap.xml
@@ -1,7 +1,8 @@
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 {{- range .Data.Pages }}
-{{- if .Title }}
+{{- $noindex := (partialCached "version-noindex.html" .RelPermalink .RelPermalink) }}
+{{- if and .Title (not $noindex) }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/version-noindex-map.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/version-noindex-map.html
@@ -1,0 +1,16 @@
+{{- $versionNameOrAlias := . }}
+{{- $noindexMap := dict }}
+{{- $versions := index site.Data.versions "/arangodb/" }}
+{{- range $i, $version := $versions }}
+  {{- $noindex := or $version.deprecated $version.inDevelopment }}
+  {{- $noindexMap = merge $noindexMap (dict
+    $version.name $noindex
+    $version.alias $noindex
+  ) }}
+{{- end }}
+{{- if not (isset $noindexMap $versionNameOrAlias) }}
+  {{- errorf "Failed to look up noindex status from version name or alias '%v'" $versionNameOrAlias }}
+{{- end }}
+{{- $noindex := index $noindexMap $versionNameOrAlias }}
+{{- /* warnf "Looked up noindex status '%v' from version name or alias '%v', %v" $noindex $versionNameOrAlias $noindexMap */}}
+{{- return $noindex -}}

--- a/site/themes/arangodb-docs-theme/layouts/partials/version-noindex.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/version-noindex.html
@@ -1,0 +1,10 @@
+{{- $path := . }}
+{{- $splitPath := split $path "/" }}
+{{- $noindex := false }}
+{{- if and (ge ($splitPath | len) 3) (eq (index $splitPath 1) "arangodb") }}
+  {{- $coreVersion := index $splitPath 2 }}
+  {{- if ne $coreVersion "" }}
+    {{- $noindex = partialCached "version-noindex-map.html" $coreVersion $coreVersion }}
+  {{- end }}
+{{- end }}
+{{- return $noindex -}}


### PR DESCRIPTION
### Description

Deprecated an in-development ArangoDB versions are flagged as noindex

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sitemap generation to correctly exclude pages marked as noindex, ensuring search engines identify which documentation should be indexed across all versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->