### PR TITLE
Experimental anchor shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,10 @@ The following shortcodes also exist but are rarely used:
   {{< /details >}}
   ```
 
+- `{{< anchor "Former headline" >}}` adds an invisible anchor to the content,
+  turning the specified string into a fragment identifier. Useful to keep
+  anchor links working when changing headlines.
+
 - `{{< youtube id="dQw4w9WgXcQ" >}}` can be used to embed a single YouTube video,
   and `{{< youtube-playlist id="PL0tn-TSss6NV45d1HnLA57VJFH6h1SeH7" >}}`
   for a YouTube playlist.

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/anchor.html
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/anchor.html
@@ -1,0 +1,11 @@
+{{ $headline := .Get 0 -}}
+{{ if not $headline -}}
+  {{ errorf "Old headline: Missing required parameter in '%v'" .Page.File.Path -}}
+{{ else -}}
+  {{ $fragment := $headline | urlize -}}
+  {{ if (.Page.Fragments.Identifiers.Contains $fragment) -}}
+    {{ errorf "Old headline: Fragment identifier '%v' already used in '%v'" $fragment .Page.File.Path -}}
+  {{ else -}}
+    <a name="{{ $fragment }}" id="{{ $fragment }}" class="anchor" area-hidden="true"></a>
+  {{ end -}}
+{{ end -}}

--- a/site/themes/arangodb-docs-theme/static/css/theme.css
+++ b/site/themes/arangodb-docs-theme/static/css/theme.css
@@ -252,6 +252,13 @@ ul ul, ul ol, ol ul, ol ol {
     margin-bottom: .5rem;
 }
 
+.anchor {
+    display: block;
+    height: 0;
+    position: relative;
+    top: -4rem;
+}
+
 .link,
 .link:visited {
     text-decoration: none;


### PR DESCRIPTION
### Description

Adds an `<a>` element with a fragment identifier

The position is hardcoded to roughly align with a headline if the shortcode is placed beneath it, but it's not a great solution.

The bigger question is whether this is actually useful - it only works if headlines are changed within a page but not if the content is moved to another page, and it can be a lot of extra work to maintain.

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 
