### PR TITLE
Add link to source file under diagrams

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/embed-svg.html
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/embed-svg.html
@@ -18,11 +18,11 @@
         {{- $svg.Content | safeHTML -}}
         <figcaption style="font-size: 0.9em; color: #666; margin-top: 0.5rem;">
         {{- with $caption }}<em>{{ . | markdownify }}</em>{{ end -}}
-        &nbsp;<a href="{{ $svg.Permalink }}" target="_blank" class="link"><em>View file</em></a>{{/* Whitespace control */ -}}
+        &nbsp;<a href="{{ $svg.Permalink }}" target="_blank" rel="noopener" class="link"><em>View file</em></a>{{/* Whitespace control */ -}}
         </figcaption>
       </figure>
+    {{- else -}}
+      {{ errorf "File '%v' not found for '%v'" $svgPath .Page.File.Path -}}
     {{- end }}
-  {{- else -}}
-    {{ errorf "File '%v' not found for '%v'" $svgPath .Page.File.Path -}}
   {{ end -}}
 {{ end -}}

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/embed-svg.html
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/embed-svg.html
@@ -11,17 +11,18 @@
     {{ end -}}
   {{ end -}}
   {{ if $ok -}}
-    {{ $svgPath := printf "content/images/%s.svg" $svgName -}}
-    {{ $svgContent := readFile $svgPath -}}
-    {{ if $svgContent -}}
-    <figure style="margin: 2rem 0; text-align: center;">
-    {{ $svgContent | safeHTML }}
-    {{ with $caption -}}
-    <figcaption style="font-size: 0.9em; color: #666; margin-top: 0.5rem;"><em>{{ . | markdownify }}</em></figcaption>
-    {{ end -}}
-    </figure>
-    {{ else -}}
-      {{ errorf "File '%v' not found for '%v'" $svgPath .Page.File.Path -}}
-    {{ end -}}
+    {{ $svgPath := printf "images/%s.svg" $svgName -}}
+    {{ $svg := resources.Get $svgPath -}}
+    {{ if $svg -}}
+      <figure style="margin: 2rem 0; text-align: center;">
+        {{- $svg.Content | safeHTML -}}
+        <figcaption style="font-size: 0.9em; color: #666; margin-top: 0.5rem;">
+        {{- with $caption }}<em>{{ . | markdownify }}</em>{{ end -}}
+        &nbsp;<a href="{{ $svg.Permalink }}" target="_blank" class="link"><em>View file</em></a>{{/* Whitespace control */ -}}
+        </figcaption>
+      </figure>
+    {{- end }}
+  {{- else -}}
+    {{ errorf "File '%v' not found for '%v'" $svgPath .Page.File.Path -}}
   {{ end -}}
 {{ end -}}


### PR DESCRIPTION
### Description

Modify the embed-svg shortcode to add the link to the caption, so users can open diagrams in a new tab and zoom them with the browser, e.g. https://deploy-preview-1031--docs-hugo.netlify.app/agentic-ai-suite/

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * SVG embeds now include "View file" links integrated directly into figure captions, enabling faster access to original SVG files.
  * SVG asset loading mechanism updated to use Hugo's standard asset pipeline, improving reliability and consistency with documentation build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->