### PR TITLE
AutoGraph Data Model Docs

### DIFF
--- a/site/content/agentic-ai-suite/autograph/architecture.md
+++ b/site/content/agentic-ai-suite/autograph/architecture.md
@@ -14,6 +14,13 @@ owner, a set of collections, and a specific purpose.
 All collection names are prefixed with your project name. For example, if the
 project is `myapp`, collections will be `myapp_sources`, `myapp_domains`, and so on.
 
+An AutoGraph project is made of two graphs that work as a pipeline: the **corpus
+graph** (`{project}_CorpusGraph`) organizes the documents you feed in, and the
+**knowledge graph** (`{project}_kg`) is the GraphRAG graph built inside each
+partition. They meet only at the `partition_id` link.
+
+{{< embed-svg "AutoGraph-Data-Model-Overview" "The AutoGraph data model. Left: the corpus graph. Right: the knowledge graph. Solid arrows are stored edges; the dashed link is a shared-property reference, not an edge." >}}
+
 ## Collections per layer
 
 ```mermaid
@@ -52,6 +59,8 @@ graph TD
 
 AutoGraph builds the corpus by creating collections in Layers 1 and 2. These
 collections are organized into a named graph called `{project}_CorpusGraph`.
+
+{{< embed-svg "AutoGraph-Corpus-Graph" "The corpus graph groups ingested sources into topic domains; each domain becomes a retrievable RAG partition." >}}
 
 | Collection | Type | Built by |
 |------------|------|----------|
@@ -93,6 +102,8 @@ graph stored in the named graph `{project}_kg`. This layer contains the actual d
 content, text chunks, and optionally extracted entities and communities, depending on
 your chosen RAG strategy.
 
+{{< embed-svg "AutoGraph-Knowledge-Graph" "Inside a partition, documents become chunks, entities are extracted from chunks, and entities are grouped into communities." >}}
+
 | Collection | Type | `full_graphrag` | `vector_rag` |
 |------------|------|:-:|:-:|
 | `Documents` | vertex (original documents) | yes | yes |
@@ -114,10 +125,154 @@ custom post-processing. See [Known Limitations](reference/error-handling.md#cita
 Layer 3 collections share the same `{project}_` prefix. Each document in Layer 3
 carries a `partition_id` field so data from different partitions coexists in the same collections.
 
+{{< info >}}
+**Where the relationship type is stored differs between the two graphs.** In the
+corpus graph, `corpus_relations` and `similarities` store the relationship name in
+a **`label`** field. In the knowledge graph, `{project}_Relations` stores it in a
+**`type`** field instead (`PART_OF`, `MENTIONED_IN`, `RELATED_TO`, `IN_COMMUNITY`,
+`SUB_COMMUNITY_OF`). In both cases the value also lines up one-to-one with the
+`_from`/`_to` collection pair, so you can filter either way. See
+[Edge fields](#edge-fields) for the full per-edge field list.
+{{< /info >}}
+
 The named graph `{project}_CorpusGraph` ties Layers 1 and 2 together.
 It contains two edge definitions:
 - `similarities` (connecting sources to sources),
 - `corpus_relations` (connecting sources, domains, modules, and rags).
+
+## Node fields
+
+When you open a node in the ArangoDB graph viewer (right-click a node and choose
+**View node**), a Properties panel lists that node's fields. The tables below show
+the fields you can expect on one node of each type, with example values. The system
+fields `_id`, `_key`, and `_rev` exist on every node and are omitted. Collection
+names use the `{project}_` prefix (the examples below come from a project whose
+prefix is `SG_`).
+
+### Corpus-graph nodes
+
+**`sources`** — one ingested source document
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `filename` | `about-us.md` | Original file name. |
+| `content` | `"--- source: https://… Building the world's leading AI data…"` | The raw source text. |
+| `module` | `default` | Which module / corpus it belongs to. |
+| `partition_id` | (empty until assigned) | Filled once its domain becomes a partition. |
+| `embedding` | `[vector]` | Corpus-level vector used to cluster sources into domains. |
+
+**`domains`** — a topic cluster of similar sources
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `size` | `100` | Number of sources in the cluster. |
+| `members` | `[source ids]` | The sources grouped into this domain. |
+| `module` | `default` | Owning module. |
+
+**`rags`** — the RAG-partition configuration (written by the RAG Strategizer)
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `rag_mode` / `strategy_type` | `FullGraphRAG` | Which RAG strategy the partition uses. |
+| `rag_partition_id` | `default_0_a` | Links the partition to its knowledge-graph rows. |
+| `chunk_token_size` | `1200` | Target chunk size when splitting documents. |
+| `chunk_overlap_token_size` | `100` | Token overlap between consecutive chunks. |
+| `enable_chunk_embeddings` | `true` | Whether chunks get their own embeddings. |
+| `entity_types` | `[configured types]` | Entity types the extractor may produce (the per-cluster ontology; typically 8–12 types). |
+| `smart_graph_attribute` | `partition_id` | The SmartGraph sharding key. |
+
+**`modules`** — the top-level corpus container
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `name` | `default` | Module name. |
+| `clusters` | `[domains/cluster_default_0]` | The domains grouped under this module. |
+
+### Knowledge-graph nodes
+
+**`Documents`** — a full document inside a partition (provenance)
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `file_name` | `enterprise-context-management.md` | Source file (provenance). |
+| `content` | `"--- source: https://…"` | Full document text. |
+| `partition_id` | `default_0_a` | Which RAG partition it belongs to. |
+| `import_number` | `1` | Which import / build produced it. |
+
+**`Chunks`** — a token-sized passage, the retrieval unit
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `tokens` | `740` | Length of the chunk in tokens. |
+| `chunk_order_index` | `0` | Position of the chunk within its document. |
+| `content` | `"--- source: …"` | The passage text. |
+| `partition_id` | `default_0_a` | Owning partition. |
+| `embedding` | `[vector, when enabled]` | Per-chunk vector for search. |
+
+**`Entities`** — an extracted entity, a node in the graph
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `entity_name` | `CUSTOMER 360 CO-PILOTS` | The entity's name. |
+| `entity_type` | `use_case` | One of the partition's configured ontology types. |
+| `description` | `"A use case of the Arango AI Data Platform that unifies profiles…"` | LLM-written description. |
+| `partition_id` | `default_0_a` | Owning partition. |
+| `embedding` | `[vector]` | Entity embedding for similarity. |
+
+The set of `entity_type` values you see across a corpus is the union of every
+partition's ontology, so a multi-cluster corpus shows more distinct types than any
+single partition's 8–12.
+
+**`Communities`** — a cluster of related entities
+
+| Field | Example value | What it is |
+|-------|---------------|------------|
+| `title` | `Cluster 32` | Community title. |
+| `level` | `1` | Level in the community hierarchy. |
+| `report_string` | `"# GraphRAG and ArangoDB… Community…"` | LLM-written summary report (Markdown). |
+| `report_json` | `{ title, summary, rating, rating_explanation, findings }` | Structured version of the report. |
+| `occurrence` | `0.37` | How prominent the community is. |
+| `sub_communities` | `[ids, if any]` | Child communities (hierarchy). |
+
+## Edge fields
+
+Each edge collection records its relationship name in a different field, plus a few
+extras. This is the distinction that is easiest to misread, so it is worth checking
+the field name before writing AQL filters.
+
+| Edge collection | Relationship-type field | Other fields |
+|-----------------|-------------------------|--------------|
+| `corpus_relations` | `label` = `HAS_CLUSTER` / `IN_DOMAIN` / `INGESTED_AS` | `module`, `cluster_id`, `_from`, `_to` |
+| `Relations` | `type` = `PART_OF` / `MENTIONED_IN` / `RELATED_TO` / `IN_COMMUNITY` / `SUB_COMMUNITY_OF` | `partition_id`, `import_number`, `type`, `_from`, `_to` |
+| `similarities` | `label` = `SIMILAR_TO` | `similarity_score`, `module`, `_from`, `_to` |
+
+Knowledge-graph relationships in `Relations` also line up one-to-one with the
+collections each edge connects:
+
+| `_from` | `type` | `_to` |
+|---------|--------|-------|
+| `Entities` | `MENTIONED_IN` | `Chunks` |
+| `Entities` | `IN_COMMUNITY` | `Communities` |
+| `Entities` | `RELATED_TO` | `Entities` |
+| `Chunks` | `PART_OF` | `Documents` |
+| `Communities` | `SUB_COMMUNITY_OF` | `Communities` |
+
+## Things people misread
+
+- **Two graphs, not one.** The corpus graph and the knowledge graph are separate;
+  they meet only at the partition.
+- **The relationship type lives in different fields.** `corpus_relations` and
+  `similarities` use a `label` field; `Relations` uses a `type` field. Both also
+  match the `_from`/`_to` collections.
+- **Arrow direction is not build order.** Arrows show ownership/provenance, not the
+  sequence in which the pipeline created the nodes.
+- **`rags` → `Documents` is a property link, not a stored edge.** They are joined by
+  `partition_id`, not by an edge in any collection.
+- **`module` is both a vertex and a property.** It is a node in the `modules`
+  collection and also a field stored on `sources`, `domains`, and `rags`.
+- **The corpus embedding is not the retrieval index.** The `sources` embedding is a
+  single-vector clustering signature (from the first chunk); the full text is
+  chunked and indexed separately in the knowledge graph.
 
 ## Complete Pipeline
 

--- a/site/content/agentic-ai-suite/autograph/architecture.md
+++ b/site/content/agentic-ai-suite/autograph/architecture.md
@@ -142,8 +142,9 @@ It contains two edge definitions:
 
 ## Node fields
 
-When you open a node in the ArangoDB graph viewer (right-click a node and choose
-**View node**), a Properties panel lists that node's fields. The tables below show
+When you open a node in the
+[Graph Visualizer](../../platform-suite/graph-visualizer.md#view-node-and-edge-properties)
+(right-click a node and choose **View node**), a Properties panel lists that node's fields. The tables below show
 the fields you can expect on one node of each type, with example values. The system
 fields `_id`, `_key`, and `_rev` exist on every node and are omitted. Collection
 names use the `{project}_` prefix (the examples below come from a project whose
@@ -159,7 +160,7 @@ prefix is `SG_`).
 | `content` | `"--- source: https://… Building the world's leading AI data…"` | The raw source text. |
 | `module` | `default` | Which module / corpus it belongs to. |
 | `partition_id` | (empty until assigned) | Filled once its domain becomes a partition. |
-| `embedding` | `[vector]` | Corpus-level vector used to cluster sources into domains. |
+| `embeddings` | `[vector]` | Corpus-level vector used to cluster sources into domains. |
 
 **`domains`** — a topic cluster of similar sources
 
@@ -242,7 +243,7 @@ the field name before writing AQL filters.
 
 | Edge collection | Relationship-type field | Other fields |
 |-----------------|-------------------------|--------------|
-| `corpus_relations` | `label` = `HAS_CLUSTER` / `IN_DOMAIN` / `INGESTED_AS` | `module`, `cluster_id`, `_from`, `_to` |
+| `corpus_relations` | `label` = `HAS_CLUSTER` / `IN_DOMAIN` / `INGESTED_AS` | `module`, `cluster_id` (IN_DOMAIN only), `_from`, `_to` |
 | `Relations` | `type` = `PART_OF` / `MENTIONED_IN` / `RELATED_TO` / `IN_COMMUNITY` / `SUB_COMMUNITY_OF` | `partition_id`, `import_number`, `type`, `_from`, `_to` |
 | `similarities` | `label` = `SIMILAR_TO` | `similarity_score`, `module`, `_from`, `_to` |
 
@@ -267,7 +268,8 @@ collections each edge connects:
 - **Arrow direction is not build order.** Arrows show ownership/provenance, not the
   sequence in which the pipeline created the nodes.
 - **`rags` → `Documents` is a property link, not a stored edge.** They are joined by
-  `partition_id`, not by an edge in any collection.
+  the `rags` side's `rag_partition_id` matching `Documents.partition_id`, not by an
+  edge in any collection.
 - **`module` is both a vertex and a property.** It is a node in the `modules`
   collection and also a field stored on `sources`, `domains`, and `rags`.
 - **The corpus embedding is not the retrieval index.** The `sources` embedding is a

--- a/site/content/images/AutoGraph-Corpus-Graph.svg
+++ b/site/content/images/AutoGraph-Corpus-Graph.svg
@@ -1,0 +1,67 @@
+<svg viewBox="0 0 820 460"
+     xmlns="http://www.w3.org/2000/svg"
+     style="display:block;width:100%;max-width:820px;margin:0 auto">
+  <style>
+    .agcorp text { font-family: sans-serif; }
+    .agcorp .vtx { fill: #b9f5a0; stroke: #4ade80; stroke-width: 1.5; }
+    .agcorp .card:hover .vtx { fill: #ffffff; stroke: #22c55e; }
+    .agcorp .vtitle { font-size: 16px; font-weight: bold; fill: #0b2e1e; }
+    .agcorp .vsub { font-size: 11px; font-style: italic; fill: #14532d; }
+    .agcorp .elabel { font-size: 11px; font-weight: bold; fill: #0b2e1e; }
+    .agcorp .ebadge { fill: #ecfccb; stroke: #4ade80; stroke-width: 1; }
+    .agcorp .note { font-size: 11px; fill: #666; }
+  </style>
+  <defs>
+    <marker id="agc-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0,10 4,0 8" fill="#4ade80"/>
+    </marker>
+  </defs>
+  <g class="agcorp">
+    <rect width="820" height="460" fill="#f3f4f6" rx="6"/>
+    <text x="410" y="30" text-anchor="middle" font-size="17" font-weight="bold" fill="#0b2e1e">Corpus graph — {project}_CorpusGraph</text>
+
+    <g class="card">
+      <rect class="vtx" x="325" y="55" width="170" height="58" rx="14"/>
+      <text class="vtitle" x="410" y="80" text-anchor="middle">modules</text>
+      <text class="vsub" x="410" y="98" text-anchor="middle">name, clusters</text>
+    </g>
+
+    <g class="card">
+      <rect class="vtx" x="55" y="270" width="195" height="72" rx="14"/>
+      <text class="vtitle" x="152" y="300" text-anchor="middle">sources</text>
+      <text class="vsub" x="152" y="320" text-anchor="middle">text + embedding</text>
+    </g>
+
+    <g class="card">
+      <rect class="vtx" x="312" y="270" width="195" height="72" rx="14"/>
+      <text class="vtitle" x="409" y="300" text-anchor="middle">domains</text>
+      <text class="vsub" x="409" y="320" text-anchor="middle">members, size</text>
+    </g>
+
+    <g class="card">
+      <rect class="vtx" x="570" y="270" width="195" height="72" rx="14"/>
+      <text class="vtitle" x="667" y="300" text-anchor="middle">rags</text>
+      <text class="vsub" x="667" y="320" text-anchor="middle">RAG config</text>
+    </g>
+
+    <path d="M 410 113 L 409 270" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agc-arrow)"/>
+    <rect class="ebadge" x="358" y="178" width="104" height="22" rx="11"/>
+    <text class="elabel" x="410" y="193" text-anchor="middle">HAS_CLUSTER</text>
+
+    <path d="M 250 306 L 312 306" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agc-arrow)"/>
+    <rect class="ebadge" x="237" y="246" width="88" height="22" rx="11"/>
+    <text class="elabel" x="281" y="261" text-anchor="middle">IN_DOMAIN</text>
+
+    <path d="M 507 306 L 570 306" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agc-arrow)"/>
+    <rect class="ebadge" x="491" y="246" width="96" height="22" rx="11"/>
+    <text class="elabel" x="539" y="261" text-anchor="middle">INGESTED_AS</text>
+
+    <path d="M 110 270 C 100 218, 204 218, 196 268" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agc-arrow)"/>
+    <rect class="ebadge" x="107" y="210" width="92" height="22" rx="11"/>
+    <text class="elabel" x="153" y="225" text-anchor="middle">SIMILAR_TO</text>
+
+    <text class="note" x="410" y="392" text-anchor="middle">Stored in edge collection corpus_relations (HAS_CLUSTER / IN_DOMAIN / INGESTED_AS), with the type in a label field.</text>
+    <text class="note" x="410" y="410" text-anchor="middle">SIMILAR_TO is a source-to-source self relationship in the separate similarities collection (carries similarity_score).</text>
+    <text class="note" x="410" y="428" text-anchor="middle">module is also stored as a property on sources, domains, and rags.</text>
+  </g>
+</svg>

--- a/site/content/images/AutoGraph-Corpus-Graph.svg
+++ b/site/content/images/AutoGraph-Corpus-Graph.svg
@@ -29,7 +29,7 @@
     <g class="card">
       <rect class="vtx" x="55" y="270" width="195" height="72" rx="14"/>
       <text class="vtitle" x="152" y="300" text-anchor="middle">sources</text>
-      <text class="vsub" x="152" y="320" text-anchor="middle">text + embedding</text>
+      <text class="vsub" x="152" y="320" text-anchor="middle">text + embeddings</text>
     </g>
 
     <g class="card">

--- a/site/content/images/AutoGraph-Data-Model-Overview.svg
+++ b/site/content/images/AutoGraph-Data-Model-Overview.svg
@@ -1,0 +1,109 @@
+<svg viewBox="0 0 920 540"
+     xmlns="http://www.w3.org/2000/svg"
+     style="display:block;width:100%;max-width:920px;margin:0 auto">
+  <style>
+    .agov text { font-family: sans-serif; }
+    .agov .vtx { fill: #b9f5a0; stroke: #4ade80; stroke-width: 1.5; }
+    .agov .card:hover .vtx { fill: #ffffff; stroke: #22c55e; }
+    .agov .vtitle { font-size: 14px; font-weight: bold; fill: #0b2e1e; }
+    .agov .panel { fill: #ffffff; stroke: #22c55e; stroke-width: 1.5; }
+    .agov .phead { font-size: 13px; font-weight: bold; fill: #14532d; }
+    .agov .elabel { font-size: 10px; font-weight: bold; fill: #0b2e1e; }
+    .agov .ebadge { fill: #ecfccb; stroke: #4ade80; stroke-width: 1; }
+    .agov .note { font-size: 11px; fill: #666; }
+  </style>
+  <defs>
+    <marker id="agov-arrow" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0,9 3.5,0 7" fill="#4ade80"/>
+    </marker>
+  </defs>
+  <g class="agov">
+    <rect width="920" height="540" fill="#f3f4f6" rx="6"/>
+    <text x="460" y="30" text-anchor="middle" font-size="17" font-weight="bold" fill="#0b2e1e">AutoGraph data model — two graphs, one pipeline</text>
+
+    <rect class="panel" x="20" y="55" width="410" height="400" rx="12"/>
+    <text class="phead" x="225" y="78" text-anchor="middle">Corpus graph — {project}_CorpusGraph</text>
+
+    <g class="card">
+      <rect class="vtx" x="170" y="95" width="130" height="44" rx="12"/>
+      <text class="vtitle" x="235" y="122" text-anchor="middle">modules</text>
+    </g>
+    <g class="card">
+      <rect class="vtx" x="40" y="205" width="110" height="46" rx="12"/>
+      <text class="vtitle" x="95" y="233" text-anchor="middle">sources</text>
+    </g>
+    <g class="card">
+      <rect class="vtx" x="180" y="205" width="110" height="46" rx="12"/>
+      <text class="vtitle" x="235" y="233" text-anchor="middle">domains</text>
+    </g>
+    <g class="card">
+      <rect class="vtx" x="265" y="330" width="110" height="46" rx="12"/>
+      <text class="vtitle" x="320" y="358" text-anchor="middle">rags</text>
+    </g>
+
+    <path d="M 235 139 L 235 205" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="237" y="161" width="92" height="20" rx="10"/>
+    <text class="elabel" x="283" y="175" text-anchor="middle">HAS_CLUSTER</text>
+
+    <path d="M 150 228 L 180 228" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="120" y="258" width="80" height="20" rx="10"/>
+    <text class="elabel" x="160" y="272" text-anchor="middle">IN_DOMAIN</text>
+
+    <path d="M 248 251 L 305 330" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="300" y="280" width="92" height="20" rx="10"/>
+    <text class="elabel" x="346" y="294" text-anchor="middle">INGESTED_AS</text>
+
+    <path d="M 60 205 C 50 160, 140 160, 130 203" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="48" y="155" width="86" height="20" rx="10"/>
+    <text class="elabel" x="91" y="169" text-anchor="middle">SIMILAR_TO</text>
+
+    <rect class="panel" x="490" y="55" width="410" height="400" rx="12"/>
+    <text class="phead" x="695" y="78" text-anchor="middle">Knowledge graph — {project}_kg</text>
+
+    <g class="card">
+      <rect class="vtx" x="510" y="95" width="120" height="46" rx="12"/>
+      <text class="vtitle" x="570" y="123" text-anchor="middle">Documents</text>
+    </g>
+    <g class="card">
+      <rect class="vtx" x="665" y="95" width="120" height="46" rx="12"/>
+      <text class="vtitle" x="725" y="123" text-anchor="middle">Chunks</text>
+    </g>
+    <g class="card">
+      <rect class="vtx" x="755" y="215" width="120" height="46" rx="12"/>
+      <text class="vtitle" x="815" y="243" text-anchor="middle">Entities</text>
+    </g>
+    <g class="card">
+      <rect class="vtx" x="615" y="335" width="150" height="46" rx="12"/>
+      <text class="vtitle" x="690" y="363" text-anchor="middle">Communities</text>
+    </g>
+
+    <path d="M 665 118 L 630 118" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="595" y="148" width="74" height="20" rx="10"/>
+    <text class="elabel" x="632" y="162" text-anchor="middle">PART_OF</text>
+
+    <path d="M 800 215 L 740 141" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="700" y="168" width="100" height="20" rx="10"/>
+    <text class="elabel" x="750" y="182" text-anchor="middle">MENTIONED_IN</text>
+
+    <path d="M 845 215 C 885 175, 905 250, 870 258" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="818" y="186" width="86" height="20" rx="10"/>
+    <text class="elabel" x="861" y="200" text-anchor="middle">RELATED_TO</text>
+
+    <path d="M 800 261 L 730 335" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="760" y="290" width="104" height="20" rx="10"/>
+    <text class="elabel" x="812" y="304" text-anchor="middle">IN_COMMUNITY</text>
+
+    <path d="M 635 381 C 605 425, 745 425, 715 383" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agov-arrow)"/>
+    <rect class="ebadge" x="618" y="408" width="116" height="20" rx="10"/>
+    <text class="elabel" x="676" y="422" text-anchor="middle">SUB_COMMUNITY_OF</text>
+
+    <path d="M 375 353 C 445 353, 445 118, 510 118" stroke="#9ca3af" stroke-width="2" fill="none" stroke-dasharray="5 4"/>
+    <rect x="398" y="220" width="114" height="20" rx="10" fill="#f3f4f6" stroke="#9ca3af" stroke-width="1"/>
+    <text x="455" y="234" text-anchor="middle" font-size="10" font-weight="bold" fill="#6b7280">partition_id</text>
+
+    <line x1="40" y1="490" x2="80" y2="490" stroke="#4ade80" stroke-width="2" marker-end="url(#agov-arrow)"/>
+    <text class="note" x="92" y="494">stored edge (relationship type in a label or type field)</text>
+    <line x1="470" y1="490" x2="510" y2="490" stroke="#9ca3af" stroke-width="2" stroke-dasharray="5 4"/>
+    <text class="note" x="522" y="494">shared-property link (joined by partition_id), not an edge</text>
+  </g>
+</svg>

--- a/site/content/images/AutoGraph-Knowledge-Graph.svg
+++ b/site/content/images/AutoGraph-Knowledge-Graph.svg
@@ -1,0 +1,71 @@
+<svg viewBox="0 0 820 480"
+     xmlns="http://www.w3.org/2000/svg"
+     style="display:block;width:100%;max-width:820px;margin:0 auto">
+  <style>
+    .agkg text { font-family: sans-serif; }
+    .agkg .vtx { fill: #b9f5a0; stroke: #4ade80; stroke-width: 1.5; }
+    .agkg .card:hover .vtx { fill: #ffffff; stroke: #22c55e; }
+    .agkg .vtitle { font-size: 16px; font-weight: bold; fill: #0b2e1e; }
+    .agkg .vsub { font-size: 11px; font-style: italic; fill: #14532d; }
+    .agkg .elabel { font-size: 11px; font-weight: bold; fill: #0b2e1e; }
+    .agkg .ebadge { fill: #ecfccb; stroke: #4ade80; stroke-width: 1; }
+    .agkg .note { font-size: 11px; fill: #666; }
+  </style>
+  <defs>
+    <marker id="agkg-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="userSpaceOnUse">
+      <polygon points="0 0,10 4,0 8" fill="#4ade80"/>
+    </marker>
+  </defs>
+  <g class="agkg">
+    <rect width="820" height="480" fill="#f3f4f6" rx="6"/>
+    <text x="410" y="30" text-anchor="middle" font-size="17" font-weight="bold" fill="#0b2e1e">Knowledge graph — {project}_kg</text>
+
+    <g class="card">
+      <rect class="vtx" x="45" y="95" width="195" height="72" rx="14"/>
+      <text class="vtitle" x="142" y="125" text-anchor="middle">Documents</text>
+      <text class="vsub" x="142" y="145" text-anchor="middle">full text</text>
+    </g>
+
+    <g class="card">
+      <rect class="vtx" x="312" y="95" width="195" height="72" rx="14"/>
+      <text class="vtitle" x="409" y="125" text-anchor="middle">Chunks</text>
+      <text class="vsub" x="409" y="145" text-anchor="middle">tokens, content</text>
+    </g>
+
+    <g class="card">
+      <rect class="vtx" x="580" y="95" width="190" height="72" rx="14"/>
+      <text class="vtitle" x="675" y="125" text-anchor="middle">Entities</text>
+      <text class="vsub" x="675" y="145" text-anchor="middle">name, type, desc</text>
+    </g>
+
+    <g class="card">
+      <rect class="vtx" x="580" y="320" width="190" height="72" rx="14"/>
+      <text class="vtitle" x="675" y="350" text-anchor="middle">Communities</text>
+      <text class="vsub" x="675" y="370" text-anchor="middle">report, level</text>
+    </g>
+
+    <path d="M 312 131 L 240 131" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agkg-arrow)"/>
+    <rect class="ebadge" x="232" y="71" width="88" height="22" rx="11"/>
+    <text class="elabel" x="276" y="86" text-anchor="middle">PART_OF</text>
+
+    <path d="M 580 131 L 507 131" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agkg-arrow)"/>
+    <rect class="ebadge" x="491" y="71" width="106" height="22" rx="11"/>
+    <text class="elabel" x="544" y="86" text-anchor="middle">MENTIONED_IN</text>
+
+    <path d="M 712 95 C 752 52, 808 128, 766 158" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agkg-arrow)"/>
+    <rect class="ebadge" x="716" y="58" width="92" height="22" rx="11"/>
+    <text class="elabel" x="762" y="73" text-anchor="middle">RELATED_TO</text>
+
+    <path d="M 675 167 L 675 320" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agkg-arrow)"/>
+    <rect class="ebadge" x="620" y="232" width="110" height="22" rx="11"/>
+    <text class="elabel" x="675" y="247" text-anchor="middle">IN_COMMUNITY</text>
+
+    <path d="M 630 392 C 600 445, 750 445, 720 394" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#agkg-arrow)"/>
+    <rect class="ebadge" x="615" y="430" width="120" height="22" rx="11"/>
+    <text class="elabel" x="675" y="445" text-anchor="middle">SUB_COMMUNITY_OF</text>
+
+    <text class="note" x="300" y="430" text-anchor="middle">All five relationships live in one edge</text>
+    <text class="note" x="300" y="448" text-anchor="middle">collection, {project}_Relations — the</text>
+    <text class="note" x="300" y="466" text-anchor="middle">relationship type is stored in a type field.</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced AutoGraph architecture documentation to clarify the two-graph pipeline model (corpus graph vs. knowledge graph) and how partitions connect
  * Added embedded diagrams for both graphs
  * Expanded explanations of node/edge fields, including relationship direction and where relationship-type information is stored
  * Added a “Things people misread” section to correct common misunderstandings about pipeline behavior and configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->