### PR TITLE
Toolchain: Don't run 3.11 in scheduled workflow anymore

### DIFF
--- a/.circleci/generate_config.py
+++ b/.circleci/generate_config.py
@@ -96,8 +96,8 @@ def workflow_generate(config):
 
     for i in range(len(versions)):
         version = versions[i]["name"]
-        if args.workflow in ["generate-scheduled", "generate-oasisctl"] and version == "3.10":
-            continue # compilation can be skipped, 3.10 nightly images no longer available
+        if args.workflow in ["generate-scheduled", "generate-oasisctl"] and version in ["3.10", "3.11"]:
+            continue # Skip compilation, 3.10 nightly images no longer available and >= 3.11.14-3 non-public
         branch = args.arangodb_branches[i]
         if branch == "undefined":
             continue
@@ -186,6 +186,8 @@ def workflow_generate_scheduled(config):
 
     for i in range(len(versions)):
         version = versions[i]["name"]
+        if version in ["3.10", "3.11"]
+            continue # Skip compilation, 3.10 nightly images no longer available and >= 3.11.14-3 non-public
         
         compileJob = {
             "compile-linux": {

--- a/.circleci/generate_config.py
+++ b/.circleci/generate_config.py
@@ -186,7 +186,7 @@ def workflow_generate_scheduled(config):
 
     for i in range(len(versions)):
         version = versions[i]["name"]
-        if version in ["3.10", "3.11"]
+        if version in ["3.10", "3.11"]:
             continue # Skip compilation, 3.10 nightly images no longer available and >= 3.11.14-3 non-public
         
         compileJob = {


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow generation to skip compilation for ArangoDB versions **3.10** and **3.11** in additional scheduled workflow scenarios (including generate-scheduled and generate-oasisctl paths).
  * Extended the same version skip behavior to the scheduled workflow job builder, improving consistency of workflow execution across supported versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->