### PR TITLE
DOC-920 | Add structured data markup

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/partials/head.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/head.html
@@ -12,6 +12,7 @@
 
   {{ partialCached "stylesheet.html" . -}}
   {{ partial "meta.html" . -}}
+  {{ partial "structured-data.html" . -}}
 
   {{ partialCached "favicon.html" . -}}
   {{ partialCached "javascript.html" . -}}

--- a/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
@@ -1,0 +1,56 @@
+{{- /*
+  Structured data (JSON-LD) for rich snippets / Google rich results.
+
+  - Home page  -> WebSite
+  - Docs pages -> TechArticle (Google treats this as Article)
+
+  Opt a single page out with `schema: none` in the front matter.
+*/ -}}
+{{- $pageDescription := .Description | default .Site.Params.description | markdownify | plainify | htmlUnescape -}}
+{{- $publisher := dict
+    "@type" "Organization"
+    "name" "ArangoDB"
+    "url" "https://arango.ai/"
+    "logo" (dict "@type" "ImageObject" "url" (absURL "Arango_logo.png")) -}}
+{{- $schema := dict -}}
+
+{{- if .IsHome -}}
+  {{- $schema = dict
+      "@context" "https://schema.org"
+      "@type" "WebSite"
+      "name" .Site.Title
+      "url" .Site.BaseURL
+      "description" $pageDescription
+      "publisher" $publisher -}}
+{{- else if .IsPage -}}
+  {{- if ne (lower (.Params.schema | default "")) "none" -}}
+    {{- $author := $publisher -}}
+    {{- with .Params.author -}}
+      {{- $author = dict "@type" "Person" "name" . -}}
+    {{- end -}}
+
+    {{- $schema = dict
+        "@context" "https://schema.org"
+        "@type" "TechArticle"
+        "headline" (.Title | markdownify | plainify | htmlUnescape)
+        "description" $pageDescription
+        "url" .Permalink
+        "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
+        "inLanguage" (.Language.Lang | default "en")
+        "author" $author
+        "publisher" $publisher -}}
+
+    {{- if not .Lastmod.IsZero -}}
+      {{- $schema = merge $schema (dict "dateModified" (.Lastmod.Format "2006-01-02T15:04:05-07:00")) -}}
+    {{- end -}}
+    {{- if not .Date.IsZero -}}
+      {{- $schema = merge $schema (dict "datePublished" (.Date.Format "2006-01-02T15:04:05-07:00")) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $schema }}
+<script type="application/ld+json">
+{{ jsonify (dict "indent" "  ") $schema | safeJS }}
+</script>
+{{- end -}}

--- a/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
@@ -31,10 +31,11 @@
       "inLanguage" (.Language.Lang | default "en")
       "author" $publisher
       "publisher" $publisher -}}
+{{- end -}}
 
-  {{- if not .Lastmod.IsZero -}}
-    {{- $schema = merge $schema (dict "dateModified" (.Lastmod.Format "2006-01-02T15:04:05-07:00")) -}}
-  {{- end -}}
+{{- /* dateModified applies to both WebSite and TechArticle. */ -}}
+{{- if and $schema (not .Lastmod.IsZero) -}}
+  {{- $schema = merge $schema (dict "dateModified" (.Lastmod.Format "2006-01-02T15:04:05-07:00")) -}}
 {{- end -}}
 
 {{- if $schema }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
@@ -1,16 +1,14 @@
 {{- /*
   Structured data (JSON-LD) for rich snippets / Google rich results.
 
-  - Home page  -> WebSite
-  - Docs pages -> TechArticle (Google treats this as Article)
-
-  Opt a single page out with `schema: none` in the front matter.
+  - Home page          -> WebSite
+  - Docs & list pages  -> TechArticle (Google treats this as Article)
 */ -}}
 {{- $pageDescription := .Description | default .Site.Params.description | markdownify | plainify | htmlUnescape -}}
 {{- $publisher := dict
     "@type" "Organization"
-    "name" "ArangoDB"
-    "url" "https://arango.ai/"
+    "name" "Arango"
+    "url" "https://arango.ai"
     "logo" (dict "@type" "ImageObject" "url" (absURL "Arango_logo.png")) -}}
 {{- $schema := dict -}}
 
@@ -22,30 +20,27 @@
       "url" .Site.BaseURL
       "description" $pageDescription
       "publisher" $publisher -}}
-{{- else if .IsPage -}}
-  {{- if ne (lower (.Params.schema | default "")) "none" -}}
-    {{- $author := $publisher -}}
-    {{- with .Params.author -}}
-      {{- $author = dict "@type" "Person" "name" . -}}
-    {{- end -}}
+{{- else if or .IsPage .IsSection -}}
+  {{- /* Mirror the document <title>: append the site title for context,
+         matching head.html (e.g. "Edge :: ArangoDB Documentation"). */ -}}
+  {{- $title := .Title | markdownify | plainify | htmlUnescape -}}
+  {{- $headline := $title -}}
+  {{- if and $title (ne $title .Site.Title) -}}
+    {{- $headline = printf "%s %s %s" $title (.Site.Params.titleSeparator | default "::") .Site.Title -}}
+  {{- end -}}
+  {{- $schema = dict
+      "@context" "https://schema.org"
+      "@type" "TechArticle"
+      "headline" $headline
+      "description" $pageDescription
+      "url" .Permalink
+      "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
+      "inLanguage" (.Language.Lang | default "en")
+      "author" $publisher
+      "publisher" $publisher -}}
 
-    {{- $schema = dict
-        "@context" "https://schema.org"
-        "@type" "TechArticle"
-        "headline" (.Title | markdownify | plainify | htmlUnescape)
-        "description" $pageDescription
-        "url" .Permalink
-        "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
-        "inLanguage" (.Language.Lang | default "en")
-        "author" $author
-        "publisher" $publisher -}}
-
-    {{- if not .Lastmod.IsZero -}}
-      {{- $schema = merge $schema (dict "dateModified" (.Lastmod.Format "2006-01-02T15:04:05-07:00")) -}}
-    {{- end -}}
-    {{- if not .Date.IsZero -}}
-      {{- $schema = merge $schema (dict "datePublished" (.Date.Format "2006-01-02T15:04:05-07:00")) -}}
-    {{- end -}}
+  {{- if not .Lastmod.IsZero -}}
+    {{- $schema = merge $schema (dict "dateModified" (.Lastmod.Format "2006-01-02T15:04:05-07:00")) -}}
   {{- end -}}
 {{- end -}}
 

--- a/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/structured-data.html
@@ -21,17 +21,10 @@
       "description" $pageDescription
       "publisher" $publisher -}}
 {{- else if or .IsPage .IsSection -}}
-  {{- /* Mirror the document <title>: append the site title for context,
-         matching head.html (e.g. "Edge :: ArangoDB Documentation"). */ -}}
-  {{- $title := .Title | markdownify | plainify | htmlUnescape -}}
-  {{- $headline := $title -}}
-  {{- if and $title (ne $title .Site.Title) -}}
-    {{- $headline = printf "%s %s %s" $title (.Site.Params.titleSeparator | default "::") .Site.Title -}}
-  {{- end -}}
   {{- $schema = dict
       "@context" "https://schema.org"
       "@type" "TechArticle"
-      "headline" $headline
+      "headline" (.Title | markdownify | plainify | htmlUnescape)
       "description" $pageDescription
       "url" .Permalink
       "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON-LD structured data generation (rich snippets) to the documentation theme.
  * Automatically outputs schema for the homepage (WebSite) and content pages (TechArticle), including organization publisher details and author/publisher attribution.
  * Uses page description with a site fallback, sets language with an English default, conditionally includes `dateModified` when available, and only renders the structured-data script when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->