### PR TITLE
Toolchain: Fully skip generation for 3.11

### DIFF
--- a/.circleci/generate_config.py
+++ b/.circleci/generate_config.py
@@ -304,8 +304,8 @@ export GENERATORS='<< parameters.generators >>'\n"
 
     for i in range(len(versions)):
         version = versions[i]["name"]
-        if args.workflow in ["generate-scheduled", "generate-oasisctl"] and version == "3.10":
-            continue # 3.10 nightly images no longer available
+        if args.workflow in ["generate-scheduled", "generate-oasisctl"] and version in ["3.10", "3.11"]:
+            continue # Skip generation, 3.10 nightly images no longer available and >= 3.11.14-3 non-public
         branch = args.arangodb_branches[i]
 
         if args.workflow != "generate": #generate scheduled etc.


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled run handling by skipping launch command generation for additional unsupported database versions.
  * Updated release behavior to avoid using unavailable or non-public images, reducing failures in affected workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->