### PR TITLE
FIx headline rendering for metrics shortcode

### DIFF
--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
@@ -17,7 +17,7 @@
 
 {{ range $metric := $metricGroup }}
 
-#### {{ strings.TrimRight ".\r\n" $metric.help }}
+#### {{ strings.TrimRight " ." (replaceRE "[\\s]*?[\\r\\n]+" " " $metric.help) }}
 
 {{ if eq $metric.type "histogram" -}}
 `{{ $metric.name }}` (basename)<br>

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
@@ -17,7 +17,7 @@
 
 {{ range $metric := $metricGroup }}
 
-#### {{ strings.TrimRight " ." (replaceRE "[\\s]*?[\\r\\n]+" " " $metric.help) }}
+#### {{ strings.TrimRight " ." (replaceRE "[\\s]*?[\\r\\n]+" " " $metric.help) }} {#{{ $metric.name }}}
 
 {{ if eq $metric.type "histogram" -}}
 `{{ $metric.name }}` (basename)<br>


### PR DESCRIPTION
### Description

Collapse linebreaks to spaces and properly trim `.` from help text

The YAML source uses `help: |` instead of `help: >-` so line breaks and trailing spaces are preserved, which we can fix on our end

Fixes this issue:

<img width="2080" height="645" alt="grafik" src="https://github.com/user-attachments/assets/ef05f971-c2c3-477d-836f-eb42842ccabf" />

Fixed:

https://deploy-preview-1050--docs-hugo.netlify.app/arangodb/stable/develop/http-api/monitoring/metrics/#number-of-times-a-server-side-dump-thread-was-blocked-because-it-honored-the-server-side-memory-limit-for-dumps

---

**Open question**:
Should we use the metric names like `arangodb_dump_threads_blocked_total` rather than the helptext to generate the fragment identifier? The anchors gets quite long and changing the helptext changes it...

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric help-text formatting by normalizing whitespace and removing trailing spaces for cleaner headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->