### PR TITLE
DOC-941 | Rclone upgrades

### DIFF
--- a/site/content/arangodb/3.11/components/tools/arangobackup/examples.md
+++ b/site/content/arangodb/3.11/components/tools/arangobackup/examples.md
@@ -149,8 +149,7 @@ credentials for the remote site. Here is an example:
     "env_auth": "false",
     "access_key_id": "XXXXXXXXXXXXXXXXXXXX",
     "secret_access_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-    "region": "xx-xxxx-x",
-    "acl": "private"
+    "region": "xx-xxxx-x"
   }
 }
 ```
@@ -286,10 +285,18 @@ The file `my-s3.json` could look like this:
     "access_key_id": "XXXXXXXXXXXXXXXXXXXX",
     "secret_access_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "region": "xx-xxxx-x",
-    "acl": "private"
+    "acl": ""
   }
 }
 ```
+
+{{< info >}}
+AWS buckets created since April 2023 default to _Bucket owner enforced_
+Object Ownership, which rejects requests that include an ACL header.
+Omit the `acl` key (or set it to `""`) in the configuration for such buckets.
+The `acl` key may still be required for some S3-compatible providers and for
+older AWS buckets that have ACLs explicitly re-enabled.
+{{< /info >}}
 
 More examples and details for S3 configurations can be found at
 [rclone.org/s3/](https://rclone.org/s3/).
@@ -306,7 +313,7 @@ The file `my-local.json` could look like this:
 {
   "my-local": {
     "type": "local",
-    "copy-links": "false",
+    "copy_links": "false",
     "links": "false",
     "one_file_system": "false"
   }

--- a/site/content/arangodb/3.12/components/tools/arangobackup/examples.md
+++ b/site/content/arangodb/3.12/components/tools/arangobackup/examples.md
@@ -147,8 +147,7 @@ credentials for the remote site. Here is an example:
     "env_auth": "false",
     "access_key_id": "XXXXXXXXXXXXXXXXXXXX",
     "secret_access_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-    "region": "xx-xxxx-x",
-    "acl": "private"
+    "region": "xx-xxxx-x"
   }
 }
 ```
@@ -284,10 +283,18 @@ The file `my-s3.json` could look like this:
     "access_key_id": "XXXXXXXXXXXXXXXXXXXX",
     "secret_access_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "region": "xx-xxxx-x",
-    "acl": "private"
+    "acl": ""
   }
 }
 ```
+
+{{< info >}}
+AWS buckets created since April 2023 default to _Bucket owner enforced_
+Object Ownership, which rejects requests that include an ACL header.
+Omit the `acl` key (or set it to `""`) in the configuration for such buckets.
+The `acl` key may still be required for some S3-compatible providers and for
+older AWS buckets that have ACLs explicitly re-enabled.
+{{< /info >}}
 
 More examples and details for S3 configurations can be found at
 [rclone.org/s3/](https://rclone.org/s3/).
@@ -304,7 +311,7 @@ The file `my-local.json` could look like this:
 {
   "my-local": {
     "type": "local",
-    "copy-links": "false",
+    "copy_links": "false",
     "links": "false",
     "one_file_system": "false"
   }

--- a/site/content/arangodb/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -1056,6 +1056,57 @@ For details, see:
 - [HTTP interface for inverted indexes](../../develop/http-api/indexes/inverted.md)
 - [`arangosearch` View properties](../../indexes-and-search/arangosearch/arangosearch-views-reference.md#view-properties)
 
+## Rclone upgrades possibly requiring configuration changes
+
+<small>Introduced in: v3.12.9-2</small>
+
+Rclone is used by ArangoDB for uploading and downloading Hot Backups to and from
+object storage, often using cloud provider services like AWS's S3 or S3-compatible
+offerings.
+
+To transfer Hot Backups this way, rclone requires a configuration file to
+specify the provider, region, and so on. The configuration is typically
+backwards compatible, but behavioral changes on the provider side or of
+technical nature may require that you modify the configuration.
+
+The version of the bundled rclone has been updated in the ArangoDB hotfix releases
+3.12.9-2 and 3.12.9-4. These and later versions may therefore require action
+regarding the rclone configuration:
+
+| ArangoDB version | Rclone version    |
+|:-----------------|:------------------|
+| v3.12.9          | v1.65.2           |
+| v3.12.9-1        | v1.65.2           |
+| v3.12.9-2        | v1.73.5 (updated) |
+| v3.12.9-3        | v1.73.5           |
+| v3.12.9-4        | v1.74.3 (updated) |
+
+You should check for the following things in particular:
+
+- If you use AWS S3 and a region other than `us-east-1`, you need to either specify the
+  region in the `location_constraint` (e.g. `location_constraint = "eu-central-1"`),
+  set `no_check_bucket = "true"`, or both.
+
+  Otherwise, rclone makes a check with an unspecified location constraint which
+  AWS rejects (IllegalLocationConstraintException). This is caused by an upgrade
+  to the AWS SDK v2 in rclone v1.68.0.
+
+- If you use an S3-compatible provider like GCS, Ceph, MinIO, Wasabi, or older
+  gateways, uploads may fail unless you set `use_data_integrity_protections = false`.
+
+  The upgrade to the AWS SDK v2 in rlcone v1.68.0 changed the default algorithm
+  for data integrity checksums to CRC32/CRC64. While this is supported by AWS,
+  other S3-compatible providers may still expect MD5 and therefore fail. Later
+  rclone versions may automatically account for this quirk for certain providers.
+
+- If you use an S3-compatible provider, there may be quirks that rclone should
+  automatically handle for known providers. For example, `use_x_id` is disabled
+  for GCS. Other options that are auto-set per provider are `sign_accept_encoding`
+  and `use_multipart_uploads`.
+
+  You might need to force specific settings in case your provider is not known
+  to rlcone and therefore doesn't handle specific quirks on its own.
+
 ## HTTP RESTful API
 
 ### JavaScript-based traversal using `/_api/traversal` removed

--- a/site/content/arangodb/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.12/incompatible-changes-in-3-12.md
@@ -1084,17 +1084,17 @@ regarding the rclone configuration:
 You should check for the following things in particular:
 
 - If you use AWS S3 and a region other than `us-east-1`, you need to either specify the
-  region in the `location_constraint` (e.g. `location_constraint = "eu-central-1"`),
-  set `no_check_bucket = "true"`, or both.
+  region in the `location_constraint` (e.g. `"location_constraint": "eu-central-1"`),
+  set `"no_check_bucket": "true"`, or both.
 
   Otherwise, rclone makes a check with an unspecified location constraint which
   AWS rejects (IllegalLocationConstraintException). This is caused by an upgrade
   to the AWS SDK v2 in rclone v1.68.0.
 
 - If you use an S3-compatible provider like GCS, Ceph, MinIO, Wasabi, or older
-  gateways, uploads may fail unless you set `use_data_integrity_protections = false`.
+  gateways, uploads may fail unless you set `"use_data_integrity_protections": "false"`.
 
-  The upgrade to the AWS SDK v2 in rlcone v1.68.0 changed the default algorithm
+  The upgrade to the AWS SDK v2 in rclone v1.68.0 changed the default algorithm
   for data integrity checksums to CRC32/CRC64. While this is supported by AWS,
   other S3-compatible providers may still expect MD5 and therefore fail. Later
   rclone versions may automatically account for this quirk for certain providers.
@@ -1105,7 +1105,7 @@ You should check for the following things in particular:
   and `use_multipart_uploads`.
 
   You might need to force specific settings in case your provider is not known
-  to rlcone and therefore doesn't handle specific quirks on its own.
+  to rclone and therefore doesn't handle specific quirks on its own.
 
 ## HTTP RESTful API
 

--- a/site/content/arangodb/4.0/components/tools/arangobackup/examples.md
+++ b/site/content/arangodb/4.0/components/tools/arangobackup/examples.md
@@ -147,8 +147,7 @@ credentials for the remote site. Here is an example:
     "env_auth": "false",
     "access_key_id": "XXXXXXXXXXXXXXXXXXXX",
     "secret_access_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-    "region": "xx-xxxx-x",
-    "acl": "private"
+    "region": "xx-xxxx-x"
   }
 }
 ```
@@ -284,10 +283,18 @@ The file `my-s3.json` could look like this:
     "access_key_id": "XXXXXXXXXXXXXXXXXXXX",
     "secret_access_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     "region": "xx-xxxx-x",
-    "acl": "private"
+    "acl": ""
   }
 }
 ```
+
+{{< info >}}
+AWS buckets created since April 2023 default to _Bucket owner enforced_
+Object Ownership, which rejects requests that include an ACL header.
+Omit the `acl` key (or set it to `""`) in the configuration for such buckets.
+The `acl` key may still be required for some S3-compatible providers and for
+older AWS buckets that have ACLs explicitly re-enabled.
+{{< /info >}}
 
 More examples and details for S3 configurations can be found at
 [rclone.org/s3/](https://rclone.org/s3/).
@@ -304,7 +311,7 @@ The file `my-local.json` could look like this:
 {
   "my-local": {
     "type": "local",
-    "copy-links": "false",
+    "copy_links": "false",
     "links": "false",
     "one_file_system": "false"
   }

--- a/site/content/arangodb/4.0/release-notes/version-4.0/incompatible-changes-in-4-0.md
+++ b/site/content/arangodb/4.0/release-notes/version-4.0/incompatible-changes-in-4-0.md
@@ -200,17 +200,17 @@ regarding the rclone configuration:
 You should check for the following things in particular:
 
 - If you use AWS S3 and a region other than `us-east-1`, you need to either specify the
-  region in the `location_constraint` (e.g. `location_constraint = "eu-central-1"`),
-  set `no_check_bucket = "true"`, or both.
+  region in the `location_constraint` (e.g. `"location_constraint": "eu-central-1"`),
+  set `"no_check_bucket": "true"`, or both.
 
   Otherwise, rclone makes a check with an unspecified location constraint which
   AWS rejects (IllegalLocationConstraintException). This is caused by an upgrade
   to the AWS SDK v2 in rclone v1.68.0.
 
 - If you use an S3-compatible provider like GCS, Ceph, MinIO, Wasabi, or older
-  gateways, uploads may fail unless you set `use_data_integrity_protections = false`.
+  gateways, uploads may fail unless you set `"use_data_integrity_protections": "false"`.
 
-  The upgrade to the AWS SDK v2 in rlcone v1.68.0 changed the default algorithm
+  The upgrade to the AWS SDK v2 in rclone v1.68.0 changed the default algorithm
   for data integrity checksums to CRC32/CRC64. While this is supported by AWS,
   other S3-compatible providers may still expect MD5 and therefore fail. Later
   rclone versions may automatically account for this quirk for certain providers.
@@ -221,7 +221,7 @@ You should check for the following things in particular:
   and `use_multipart_uploads`.
 
   You might need to force specific settings in case your provider is not known
-  to rlcone and therefore doesn't handle specific quirks on its own.
+  to rclone and therefore doesn't handle specific quirks on its own.
 
 ## HTTP RESTful API
 

--- a/site/content/arangodb/4.0/release-notes/version-4.0/incompatible-changes-in-4-0.md
+++ b/site/content/arangodb/4.0/release-notes/version-4.0/incompatible-changes-in-4-0.md
@@ -172,6 +172,57 @@ You can get more detailed information for monitoring ArangoDB via the
 [`/_admin/metrics` endpoint](../../develop/http-api/monitoring/metrics.md)
 in Prometheus format.
 
+## Rclone upgrades possibly requiring configuration changes
+
+<small>Introduced in: v3.12.9-2</small>
+
+Rclone is used by ArangoDB for uploading and downloading Hot Backups to and from
+object storage, often using cloud provider services like AWS's S3 or S3-compatible
+offerings.
+
+To transfer Hot Backups this way, rclone requires a configuration file to
+specify the provider, region, and so on. The configuration is typically
+backwards compatible, but behavioral changes on the provider side or of
+technical nature may require that you modify the configuration.
+
+The version of the bundled rclone has been updated in the ArangoDB hotfix releases
+3.12.9-2 and 3.12.9-4. These and later versions may therefore require action
+regarding the rclone configuration:
+
+| ArangoDB version | Rclone version    |
+|:-----------------|:------------------|
+| v3.12.9          | v1.65.2           |
+| v3.12.9-1        | v1.65.2           |
+| v3.12.9-2        | v1.73.5 (updated) |
+| v3.12.9-3        | v1.73.5           |
+| v3.12.9-4        | v1.74.3 (updated) |
+
+You should check for the following things in particular:
+
+- If you use AWS S3 and a region other than `us-east-1`, you need to either specify the
+  region in the `location_constraint` (e.g. `location_constraint = "eu-central-1"`),
+  set `no_check_bucket = "true"`, or both.
+
+  Otherwise, rclone makes a check with an unspecified location constraint which
+  AWS rejects (IllegalLocationConstraintException). This is caused by an upgrade
+  to the AWS SDK v2 in rclone v1.68.0.
+
+- If you use an S3-compatible provider like GCS, Ceph, MinIO, Wasabi, or older
+  gateways, uploads may fail unless you set `use_data_integrity_protections = false`.
+
+  The upgrade to the AWS SDK v2 in rlcone v1.68.0 changed the default algorithm
+  for data integrity checksums to CRC32/CRC64. While this is supported by AWS,
+  other S3-compatible providers may still expect MD5 and therefore fail. Later
+  rclone versions may automatically account for this quirk for certain providers.
+
+- If you use an S3-compatible provider, there may be quirks that rclone should
+  automatically handle for known providers. For example, `use_x_id` is disabled
+  for GCS. Other options that are auto-set per provider are `sign_accept_encoding`
+  and `use_multipart_uploads`.
+
+  You might need to force specific settings in case your provider is not known
+  to rlcone and therefore doesn't handle specific quirks on its own.
+
 ## HTTP RESTful API
 
 ### `overwrite` option removed from document API


### PR DESCRIPTION
### Description

- Add entry to Incompatible changes due to upgraded rclone & potentially required config changes
- Apply rclone-related changes from #999 regarding the `acl` key

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `arangobackup` rclone examples across supported versions with corrected S3 ACL guidance and the `copy_links` option name.
  * Added guidance for AWS S3 buckets using “Bucket owner enforced” object ownership.
  * Documented configuration adjustments that may be required after bundled rclone upgrades, including AWS region settings, checksum compatibility, and provider-specific options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->