### PR TITLE
Fix HTTP API rendering

### DIFF
--- a/site/layouts/_default/_markup/render-codeblock-aql.html
+++ b/site/layouts/_default/_markup/render-codeblock-aql.html
@@ -1,1 +1,0 @@
-{{ transform.Highlight (trim .Inner "\n") .Type }}

--- a/site/layouts/_default/_markup/render-codeblock-curl.html
+++ b/site/layouts/_default/_markup/render-codeblock-curl.html
@@ -1,1 +1,0 @@
-{{ transform.Highlight (trim .Inner "\n") .Type }}

--- a/site/layouts/_default/_markup/render-codeblock-js.html
+++ b/site/layouts/_default/_markup/render-codeblock-js.html
@@ -1,1 +1,0 @@
-{{ transform.Highlight (trim .Inner "\n") .Type }}

--- a/site/layouts/_default/_markup/render-codeblock-openapi.html
+++ b/site/layouts/_default/_markup/render-codeblock-openapi.html
@@ -1,1 +1,0 @@
-{{ transform.Highlight (trim .Inner "\n") .Type }}


### PR DESCRIPTION
### Description

PR #1034 accidentally committed four project-level render hooks under `site/layouts/_default/_markup/ (openapi, aql, curl, js)` which caused caused every openapi/curl/aql/js code block to render as a raw syntax-highlighted fence. This PR fixes that.
