### PR TITLE
DOC-941 | DOC-904 | Rclone upgrade 3.11

### DIFF
--- a/site/content/arangodb/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/arangodb/3.11/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -646,6 +646,54 @@ means you may find more results than before.
 
 Also see [Geo-spatial functions in AQL](../../aql/functions/geo.md).
 
+## Rclone upgrade possibly requiring configuration changes
+
+<small>Introduced in: v3.11.14-4</small>
+
+Rclone is used by ArangoDB for uploading and downloading Hot Backups to and from
+object storage, often using cloud provider services like AWS's S3 or S3-compatible
+offerings.
+
+To transfer Hot Backups this way, rclone requires a configuration file to
+specify the provider, region, and so on. The configuration is typically
+backwards compatible, but behavioral changes on the provider side or of
+technical nature may require that you modify the configuration.
+
+The version of the bundled rclone has been updated in the ArangoDB hotfix release
+3.11.14-4. This and later versions may therefore require action
+regarding the rclone configuration:
+
+| ArangoDB version | Rclone version    |
+|:-----------------|:------------------|
+| v3.11.14-3       | v1.62.2           |
+| v3.11.14-4       | v1.73.5 (updated) |
+
+You should check for the following things in particular:
+
+- If you use AWS S3 and a region other than `us-east-1`, you need to either specify the
+  region in the `location_constraint` (e.g. `"location_constraint": "eu-central-1"`),
+  set `"no_check_bucket": "true"`, or both.
+
+  Otherwise, rclone makes a check with an unspecified location constraint which
+  AWS rejects (IllegalLocationConstraintException). This is caused by an upgrade
+  to the AWS SDK v2 in rclone v1.68.0.
+
+- If you use an S3-compatible provider like GCS, Ceph, MinIO, Wasabi, or older
+  gateways, uploads may fail unless you set `"use_data_integrity_protections": "false"`.
+
+  The upgrade to the AWS SDK v2 in rclone v1.68.0 changed the default algorithm
+  for data integrity checksums to CRC32/CRC64. While this is supported by AWS,
+  other S3-compatible providers may still expect MD5 and therefore fail. Later
+  rclone versions may automatically account for this quirk for certain providers.
+
+- If you use an S3-compatible provider, there may be quirks that rclone should
+  automatically handle for known providers. For example, `use_x_id` is disabled
+  for GCS. Other options that are auto-set per provider are `sign_accept_encoding`
+  and `use_multipart_uploads`.
+
+  You might need to force specific settings in case your provider is not known
+  to rclone and therefore doesn't handle specific quirks on its own.
+
 ## JavaScript API
 
 ### Database creation

--- a/site/content/arangodb/3.12/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -646,6 +646,54 @@ means you may find more results than before.
 
 Also see [Geo-spatial functions in AQL](../../aql/functions/geo.md).
 
+## Rclone upgrade possibly requiring configuration changes
+
+<small>Introduced in: v3.11.14-4</small>
+
+Rclone is used by ArangoDB for uploading and downloading Hot Backups to and from
+object storage, often using cloud provider services like AWS's S3 or S3-compatible
+offerings.
+
+To transfer Hot Backups this way, rclone requires a configuration file to
+specify the provider, region, and so on. The configuration is typically
+backwards compatible, but behavioral changes on the provider side or of
+technical nature may require that you modify the configuration.
+
+The version of the bundled rclone has been updated in the ArangoDB hotfix release
+3.11.14-4. This and later versions may therefore require action
+regarding the rclone configuration:
+
+| ArangoDB version | Rclone version    |
+|:-----------------|:------------------|
+| v3.11.14-3       | v1.62.2           |
+| v3.11.14-4       | v1.73.5 (updated) |
+
+You should check for the following things in particular:
+
+- If you use AWS S3 and a region other than `us-east-1`, you need to either specify the
+  region in the `location_constraint` (e.g. `"location_constraint": "eu-central-1"`),
+  set `"no_check_bucket": "true"`, or both.
+
+  Otherwise, rclone makes a check with an unspecified location constraint which
+  AWS rejects (IllegalLocationConstraintException). This is caused by an upgrade
+  to the AWS SDK v2 in rclone v1.68.0.
+
+- If you use an S3-compatible provider like GCS, Ceph, MinIO, Wasabi, or older
+  gateways, uploads may fail unless you set `"use_data_integrity_protections": "false"`.
+
+  The upgrade to the AWS SDK v2 in rclone v1.68.0 changed the default algorithm
+  for data integrity checksums to CRC32/CRC64. While this is supported by AWS,
+  other S3-compatible providers may still expect MD5 and therefore fail. Later
+  rclone versions may automatically account for this quirk for certain providers.
+
+- If you use an S3-compatible provider, there may be quirks that rclone should
+  automatically handle for known providers. For example, `use_x_id` is disabled
+  for GCS. Other options that are auto-set per provider are `sign_accept_encoding`
+  and `use_multipart_uploads`.
+
+  You might need to force specific settings in case your provider is not known
+  to rclone and therefore doesn't handle specific quirks on its own.
+
 ## JavaScript API
 
 ### Database creation

--- a/site/content/arangodb/4.0/release-notes/version-3.11/incompatible-changes-in-3-11.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.11/incompatible-changes-in-3-11.md
@@ -646,6 +646,54 @@ means you may find more results than before.
 
 Also see [Geo-spatial functions in AQL](../../aql/functions/geo.md).
 
+## Rclone upgrade possibly requiring configuration changes
+
+<small>Introduced in: v3.11.14-4</small>
+
+Rclone is used by ArangoDB for uploading and downloading Hot Backups to and from
+object storage, often using cloud provider services like AWS's S3 or S3-compatible
+offerings.
+
+To transfer Hot Backups this way, rclone requires a configuration file to
+specify the provider, region, and so on. The configuration is typically
+backwards compatible, but behavioral changes on the provider side or of
+technical nature may require that you modify the configuration.
+
+The version of the bundled rclone has been updated in the ArangoDB hotfix release
+3.11.14-4. This and later versions may therefore require action
+regarding the rclone configuration:
+
+| ArangoDB version | Rclone version    |
+|:-----------------|:------------------|
+| v3.11.14-3       | v1.62.2           |
+| v3.11.14-4       | v1.73.5 (updated) |
+
+You should check for the following things in particular:
+
+- If you use AWS S3 and a region other than `us-east-1`, you need to either specify the
+  region in the `location_constraint` (e.g. `"location_constraint": "eu-central-1"`),
+  set `"no_check_bucket": "true"`, or both.
+
+  Otherwise, rclone makes a check with an unspecified location constraint which
+  AWS rejects (IllegalLocationConstraintException). This is caused by an upgrade
+  to the AWS SDK v2 in rclone v1.68.0.
+
+- If you use an S3-compatible provider like GCS, Ceph, MinIO, Wasabi, or older
+  gateways, uploads may fail unless you set `"use_data_integrity_protections": "false"`.
+
+  The upgrade to the AWS SDK v2 in rclone v1.68.0 changed the default algorithm
+  for data integrity checksums to CRC32/CRC64. While this is supported by AWS,
+  other S3-compatible providers may still expect MD5 and therefore fail. Later
+  rclone versions may automatically account for this quirk for certain providers.
+
+- If you use an S3-compatible provider, there may be quirks that rclone should
+  automatically handle for known providers. For example, `use_x_id` is disabled
+  for GCS. Other options that are auto-set per provider are `sign_accept_encoding`
+  and `use_multipart_uploads`.
+
+  You might need to force specific settings in case your provider is not known
+  to rclone and therefore doesn't handle specific quirks on its own.
+
 ## JavaScript API
 
 ### Database creation


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Incompatible Changes**
  * Updated the bundled rclone version in ArangoDB 3.11.14-4.
  * Hot Backup transfers may require updated object-storage configuration.
  * AWS S3 users may need to review region and location settings.
  * S3-compatible providers may require checksum and provider-specific option adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->