### PR TITLE
Vector indexes: Add `numberOfDocsPerCentroid` and section about resource management

### DIFF
--- a/site/content/arangodb/3.12/develop/http-api/indexes/vector.md
+++ b/site/content/arangodb/3.12/develop/http-api/indexes/vector.md
@@ -168,6 +168,21 @@ paths:
                         creation but may yield worse search results.
                       type: integer
                       default: 25
+                    numberOfDocsPerCentroid:
+                      description: |
+                        How many vectors per centroid to include in the random sample used for
+                        training. It must be `1` or greater.
+
+                        Up to v3.12.9, this is not configurable and a fixed value of `256` per
+                        centroid is used instead.
+
+                        The training does not use the full dataset but a sample bounded to
+                        `nLists` × `numberOfDocsPerCentroid` vectors. A larger value can improve the
+                        training quality but increases the memory and time required for training.
+                        See [Resource usage during index creation](../../../indexes-and-search/indexing/working-with-indexes/vector-indexes.md#resource-usage-during-index-creation)
+                        for details.
+                      type: integer
+                      default: 100
                     factory:
                       description: |
                         You can specify an index factory string that is
@@ -289,6 +304,7 @@ paths:
                       - nLists
                       - trainingIterations
                       - defaultNProbe
+                      - numberOfDocsPerCentroid
                     properties:
                       metric:
                         description: |
@@ -312,6 +328,10 @@ paths:
                           The default number of neighboring centroids to consider
                           in search queries.
                         type: integer
+                      numberOfDocsPerCentroid:
+                        description: |
+                          How many vectors per centroid are included in the random
+                          sample used for training (introduced in v3.12.10).
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified
@@ -422,6 +442,7 @@ paths:
                       - nLists
                       - trainingIterations
                       - defaultNProbe
+                      - numberOfDocsPerCentroid
                     properties:
                       metric:
                         description: |
@@ -445,6 +466,10 @@ paths:
                           The default number of neighboring centroids to consider
                           in search queries.
                         type: integer
+                      numberOfDocsPerCentroid:
+                        description: |
+                          How many vectors per centroid are included in the random
+                          sample used for training (introduced in v3.12.10).
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified

--- a/site/content/arangodb/3.12/develop/http-api/indexes/vector.md
+++ b/site/content/arangodb/3.12/develop/http-api/indexes/vector.md
@@ -184,6 +184,7 @@ paths:
                         for details.
                       type: integer
                       default: 100
+                      minimum: 1
                     factory:
                       description: |
                         You can specify an index factory string that is

--- a/site/content/arangodb/3.12/develop/http-api/indexes/vector.md
+++ b/site/content/arangodb/3.12/develop/http-api/indexes/vector.md
@@ -332,6 +332,7 @@ paths:
                         description: |
                           How many vectors per centroid are included in the random
                           sample used for training (introduced in v3.12.10).
+                        type: integer
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified
@@ -470,6 +471,7 @@ paths:
                         description: |
                           How many vectors per centroid are included in the random
                           sample used for training (introduced in v3.12.10).
+                        type: integer
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified

--- a/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
+++ b/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
@@ -25,6 +25,11 @@ Once enabled for a deployment, it cannot be disabled anymore because it
 permanently changes how the data is managed by the RocksDB storage engine
 (it adds an additional column family).
 
+Enabling the feature has no impact on the performance of your deployment. It
+only adds an additional RocksDB column family that stays empty and idle until
+you actually create a vector index. Regular workloads that don't use vector
+indexes are unaffected.
+
 To restore a dump that contains vector indexes, the `--vector-index`
 startup option needs to be enabled on the deployment you want to restore to.
 {{< /warning >}}

--- a/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
+++ b/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
@@ -203,9 +203,10 @@ documents, so unlike training, its cost grows with the number of vectors. It is
 mostly CPU-bound and also determines the final on-disk size of the index.
 
 In short, the number of groups (`nLists`) and the vector `dimension` drive the
-training cost, while the number of documents drives the indexing cost and the
-index size. On a cluster, these counts apply per shard, as each shard trains and
-builds its own index.
+training cost, while the number of documents drives the indexing cost. The index
+size grows with the number of documents and the vector `dimension`, and also
+depends on the encoding (the `factory` option). On a cluster, these counts apply
+per shard, as each shard trains and builds its own index.
 
 ## Interfaces
 

--- a/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
+++ b/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
@@ -130,6 +130,16 @@ centroids and the quality of vector search thus degrades.
   - **trainingIterations** (number, _optional_): The number of iterations in the
     training process. Default: `25`. Smaller values lead to a faster index
     creation but may yield worse search results. 
+  - **numberOfDocsPerCentroid** (number, _optional_, introduced in v3.12.9):
+    How many vectors per centroid to include in the random sample used for
+    training. Default: `100`. The training does not use the full dataset but a
+    sample bounded to `nLists` × `numberOfDocsPerCentroid` vectors. A larger
+    value can improve the training quality but increases the memory and time
+    required for training. See [Resource usage during index creation](#resource-usage-during-index-creation)
+    for details. It must be `1` or greater.
+
+    Up to v3.12.8, this is not configurable and a fixed value of `256` per
+    centroid is used instead.
   - **factory** (string, _optional_): You can specify an index factory string that is
     forwarded to the underlying Faiss library, allowing you to combine different
     advanced options. Examples:
@@ -142,6 +152,55 @@ centroids and the quality of vector search thus degrades.
     If you don't specify an index factory, the value is equivalent to
     `IVF<nLists>,Flat`. For more information on how to create these custom
     indexes, see the [Faiss Wiki](https://github.com/facebookresearch/faiss/wiki/The-index-factory).
+
+## Resource usage during index creation
+
+Building a vector index temporarily increases the CPU and memory usage of the
+server. Knowing what happens during the build lets you anticipate how much
+additional load to expect. The index is built in two phases.
+
+**1. Training**
+
+The index first learns how to partition the vector space into `nLists` groups,
+each represented by a centroid. To do so, it takes a random sample of your
+vectors and runs an iterative clustering algorithm over that sample. The full
+dataset is not loaded into memory. Instead, the number of vectors pulled into
+memory for training is bounded per group and never exceeds the number of vectors
+that actually exist. From v3.12.9 onward, this bound is `numberOfDocsPerCentroid`
+vectors per group (`100` by default and configurable), so up to
+`nLists` × `numberOfDocsPerCentroid` vectors in total. Up to v3.12.8, a fixed
+value of `256` per group is used instead.
+
+The sample is held in memory as plain 32-bit floating-point numbers, so you can
+estimate its peak memory as:
+
+```
+nLists × numberOfDocsPerCentroid × dimension × 4 bytes
+```
+
+For example, with `nLists` set to `1000`, the default `numberOfDocsPerCentroid`
+of `100`, and a `dimension` of `768`, the sample occupies about 290 MB (up to
+v3.12.8, the same `nLists` and `dimension` uses `256` per group and occupies
+about 750 MB). The clustering computation needs some more memory on top of that.
+Training is CPU-bound, and a larger `nLists`, `numberOfDocsPerCentroid`, or
+`dimension` makes it take longer.
+
+Because the sample size does not depend on how many documents you have, the
+memory needed for training stays roughly the same whether the collection holds
+a hundred thousand or a hundred million vectors (as long as there are at least
+`nLists` × `numberOfDocsPerCentroid` of them).
+
+**2. Indexing**
+
+Once the centroids are known, every vector is read, assigned to its nearest
+centroid, and encoded into the index. This phase makes a full pass over all
+documents, so unlike training, its cost grows with the number of vectors. It is
+mostly CPU-bound and also determines the final on-disk size of the index.
+
+In short, the number of groups (`nLists`) and the vector `dimension` drive the
+training cost, while the number of documents drives the indexing cost and the
+index size. On a cluster, these counts apply per shard, as each shard trains and
+builds its own index.
 
 ## Interfaces
 

--- a/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
+++ b/site/content/arangodb/3.12/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
@@ -135,16 +135,18 @@ centroids and the quality of vector search thus degrades.
   - **trainingIterations** (number, _optional_): The number of iterations in the
     training process. Default: `25`. Smaller values lead to a faster index
     creation but may yield worse search results. 
-  - **numberOfDocsPerCentroid** (number, _optional_, introduced in v3.12.9):
+  - **numberOfDocsPerCentroid** (number, _optional_, introduced in v3.12.10):
     How many vectors per centroid to include in the random sample used for
-    training. Default: `100`. The training does not use the full dataset but a
-    sample bounded to `nLists` × `numberOfDocsPerCentroid` vectors. A larger
-    value can improve the training quality but increases the memory and time
-    required for training. See [Resource usage during index creation](#resource-usage-during-index-creation)
-    for details. It must be `1` or greater.
+    training. It must be `1` or greater. Default: `100`.
 
-    Up to v3.12.8, this is not configurable and a fixed value of `256` per
+    Up to v3.12.9, this is not configurable and a fixed value of `256` per
     centroid is used instead.
+
+    The training does not use the full dataset but a sample bounded to
+    `nLists` × `numberOfDocsPerCentroid` vectors. A larger value can improve the
+    training quality but increases the memory and time required for training.
+    See [Resource usage during index creation](#resource-usage-during-index-creation)
+    for details.
   - **factory** (string, _optional_): You can specify an index factory string that is
     forwarded to the underlying Faiss library, allowing you to combine different
     advanced options. Examples:
@@ -162,51 +164,53 @@ centroids and the quality of vector search thus degrades.
 
 Building a vector index temporarily increases the CPU and memory usage of the
 server. Knowing what happens during the build lets you anticipate how much
-additional load to expect. The index is built in two phases.
+additional load to expect.
 
-**1. Training**
+The index is built in two phases:
 
-The index first learns how to partition the vector space into `nLists` groups,
-each represented by a centroid. To do so, it takes a random sample of your
-vectors and runs an iterative clustering algorithm over that sample. The full
-dataset is not loaded into memory. Instead, the number of vectors pulled into
-memory for training is bounded per group and never exceeds the number of vectors
-that actually exist. From v3.12.9 onward, this bound is `numberOfDocsPerCentroid`
-vectors per group (`100` by default and configurable), so up to
-`nLists` × `numberOfDocsPerCentroid` vectors in total. Up to v3.12.8, a fixed
-value of `256` per group is used instead.
+1. **Training**
 
-The sample is held in memory as plain 32-bit floating-point numbers, so you can
-estimate its peak memory as:
+   The index first learns how to partition the vector space into `nLists` groups,
+   each represented by a centroid. To do so, it takes a random sample of your
+   vectors and runs an iterative clustering algorithm over that sample. The full
+   dataset is not loaded into memory. Instead, the number of vectors pulled into
+   memory for training is bounded per group and never exceeds the number of vectors
+   that actually exist. From v3.12.10 onward, this bound is `numberOfDocsPerCentroid`
+   vectors per group (`100` by default and configurable), so up to
+   `nLists` × `numberOfDocsPerCentroid` vectors in total. Up to v3.12.9, a fixed
+   value of `256` per group is used instead.
 
-```
-nLists × numberOfDocsPerCentroid × dimension × 4 bytes
-```
+   The sample is held in memory as plain 32-bit floating-point numbers, so you can
+   estimate its peak memory as:
 
-For example, with `nLists` set to `1000`, the default `numberOfDocsPerCentroid`
-of `100`, and a `dimension` of `768`, the sample occupies about 290 MB (up to
-v3.12.8, the same `nLists` and `dimension` uses `256` per group and occupies
-about 750 MB). The clustering computation needs some more memory on top of that.
-Training is CPU-bound, and a larger `nLists`, `numberOfDocsPerCentroid`, or
-`dimension` makes it take longer.
+   ```
+   nLists × numberOfDocsPerCentroid × dimension × 4 bytes
+   ```
 
-Because the sample size does not depend on how many documents you have, the
-memory needed for training stays roughly the same whether the collection holds
-a hundred thousand or a hundred million vectors (as long as there are at least
-`nLists` × `numberOfDocsPerCentroid` of them).
+   For example, with `nLists` set to `1000`, the default `numberOfDocsPerCentroid`
+   of `100`, and a `dimension` of `768`, the sample occupies about 290 MB. Up to
+   v3.12.9, the same `nLists` and `dimension` uses `256` per group and occupies
+   about 750 MB. The clustering computation needs some more memory on top of that.
+   Training is CPU-bound, and a larger `nLists`, `numberOfDocsPerCentroid`, or
+   `dimension` makes it take longer.
 
-**2. Indexing**
+   Because the sample size does not depend on how many documents you have, the
+   memory needed for training stays roughly the same whether the collection holds
+   a hundred thousand or a hundred million vectors (as long as there are at least
+   `nLists` × `numberOfDocsPerCentroid` of them).
 
-Once the centroids are known, every vector is read, assigned to its nearest
-centroid, and encoded into the index. This phase makes a full pass over all
-documents, so unlike training, its cost grows with the number of vectors. It is
-mostly CPU-bound and also determines the final on-disk size of the index.
+2. **Indexing**
+
+   Once the centroids are known, every vector is read, assigned to its nearest
+   centroid, and encoded into the index. This phase makes a full pass over all
+   documents, so unlike training, its cost grows with the number of vectors. It is
+   mostly CPU-bound and also determines the final on-disk size of the index.
 
 In short, the number of groups (`nLists`) and the vector `dimension` drive the
 training cost, while the number of documents drives the indexing cost. The index
 size grows with the number of documents and the vector `dimension`, and also
-depends on the encoding (the `factory` option). On a cluster, these counts apply
-per shard, as each shard trains and builds its own index.
+depends on the encoding (the `factory` option). In cluster deployments, these
+counts apply per shard, as each shard trains and builds its own index.
 
 ## Interfaces
 

--- a/site/content/arangodb/3.12/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.12/api-changes-in-3-12.md
@@ -647,6 +647,17 @@ vector embedding field are not counted toward this threshold.
 Check the `trainingState` to see if the
 index is `"ready"` and `errorMessage` for the reason if it's not.
 
+---
+
+<small>Introduced in: v3.12.10</small>
+
+A new option to let you configure how many vectors per centroid to include in
+the random sample used for training the index has been added. You can set
+`numberOfDocsPerCentroid` in the `params` object to change the default of `100`.
+
+Up to v3.12.9, this is not configurable and a fixed value of `256` per centroid
+is used instead.
+
 ##### Changed consolidation defaults for inverted indexes
 
 <small>Introduced in: v3.12.6</small>

--- a/site/content/arangodb/3.12/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/arangodb/3.12/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1713,6 +1713,22 @@ vector embedding field are not counted toward this threshold.
 Check the `trainingState` to see if the
 index is `"ready"` and `errorMessage` for the reason if it's not.
 
+---
+
+<small>Introduced in: v3.12.10</small>
+
+A new option to let you configure how many vectors per centroid to include in
+the random sample used for training the index has been added. You can set
+`numberOfDocsPerCentroid` in the `params` object to change the default of `100`.
+
+Up to v3.12.9, this is not configurable and a fixed value of `256` per centroid
+is used instead.
+
+A larger value can improve the training quality but increases the memory and
+time required for training. See
+[Resource usage during index creation](../../indexes-and-search/indexing/working-with-indexes/vector-indexes.md#resource-usage-during-index-creation)
+for details.
+
 ## Server options
 
 ### Effective and available startup options

--- a/site/content/arangodb/4.0/develop/http-api/indexes/vector.md
+++ b/site/content/arangodb/4.0/develop/http-api/indexes/vector.md
@@ -168,6 +168,21 @@ paths:
                         creation but may yield worse search results.
                       type: integer
                       default: 25
+                    numberOfDocsPerCentroid:
+                      description: |
+                        How many vectors per centroid to include in the random sample used for
+                        training. It must be `1` or greater.
+
+                        Up to v3.12.9, this is not configurable and a fixed value of `256` per
+                        centroid is used instead.
+
+                        The training does not use the full dataset but a sample bounded to
+                        `nLists` × `numberOfDocsPerCentroid` vectors. A larger value can improve the
+                        training quality but increases the memory and time required for training.
+                        See [Resource usage during index creation](../../../indexes-and-search/indexing/working-with-indexes/vector-indexes.md#resource-usage-during-index-creation)
+                        for details.
+                      type: integer
+                      default: 100
                     factory:
                       description: |
                         You can specify an index factory string that is
@@ -289,6 +304,7 @@ paths:
                       - nLists
                       - trainingIterations
                       - defaultNProbe
+                      - numberOfDocsPerCentroid
                     properties:
                       metric:
                         description: |
@@ -312,6 +328,10 @@ paths:
                           The default number of neighboring centroids to consider
                           in search queries.
                         type: integer
+                      numberOfDocsPerCentroid:
+                        description: |
+                          How many vectors per centroid are included in the random
+                          sample used for training (introduced in v3.12.10).
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified
@@ -422,6 +442,7 @@ paths:
                       - nLists
                       - trainingIterations
                       - defaultNProbe
+                      - numberOfDocsPerCentroid
                     properties:
                       metric:
                         description: |
@@ -445,6 +466,10 @@ paths:
                           The default number of neighboring centroids to consider
                           in search queries.
                         type: integer
+                      numberOfDocsPerCentroid:
+                        description: |
+                          How many vectors per centroid are included in the random
+                          sample used for training (introduced in v3.12.10).
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified

--- a/site/content/arangodb/4.0/develop/http-api/indexes/vector.md
+++ b/site/content/arangodb/4.0/develop/http-api/indexes/vector.md
@@ -184,6 +184,7 @@ paths:
                         for details.
                       type: integer
                       default: 100
+                      minimum: 1
                     factory:
                       description: |
                         You can specify an index factory string that is

--- a/site/content/arangodb/4.0/develop/http-api/indexes/vector.md
+++ b/site/content/arangodb/4.0/develop/http-api/indexes/vector.md
@@ -332,6 +332,7 @@ paths:
                         description: |
                           How many vectors per centroid are included in the random
                           sample used for training (introduced in v3.12.10).
+                        type: integer
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified
@@ -470,6 +471,7 @@ paths:
                         description: |
                           How many vectors per centroid are included in the random
                           sample used for training (introduced in v3.12.10).
+                        type: integer
                       factory:
                         description: |
                           The Faiss index factory string, if one was specified

--- a/site/content/arangodb/4.0/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
+++ b/site/content/arangodb/4.0/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
@@ -180,9 +180,10 @@ documents, so unlike training, its cost grows with the number of vectors. It is
 mostly CPU-bound and also determines the final on-disk size of the index.
 
 In short, the number of groups (`nLists`) and the vector `dimension` drive the
-training cost, while the number of documents drives the indexing cost and the
-index size. On a cluster, these counts apply per shard, as each shard trains and
-builds its own index.
+training cost, while the number of documents drives the indexing cost. The index
+size grows with the number of documents and the vector `dimension`, and also
+depends on the encoding (the `factory` option). On a cluster, these counts apply
+per shard, as each shard trains and builds its own index.
 
 ## Interfaces
 

--- a/site/content/arangodb/4.0/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
+++ b/site/content/arangodb/4.0/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
@@ -118,6 +118,13 @@ centroids and the quality of vector search thus degrades.
   - **trainingIterations** (number, _optional_): The number of iterations in the
     training process. Default: `25`. Smaller values lead to a faster index
     creation but may yield worse search results. 
+  - **numberOfDocsPerCentroid** (number, _optional_): How many vectors per
+    centroid to include in the random sample used for training. Default: `100`.
+    The training does not use the full dataset but a sample bounded to
+    `nLists` × `numberOfDocsPerCentroid` vectors. A larger value can improve the
+    training quality but increases the memory and time required for training.
+    See [Resource usage during index creation](#resource-usage-during-index-creation)
+    for details. It must be `1` or greater.
   - **factory** (string, _optional_): You can specify an index factory string that is
     forwarded to the underlying Faiss library, allowing you to combine different
     advanced options. Examples:
@@ -130,6 +137,52 @@ centroids and the quality of vector search thus degrades.
     If you don't specify an index factory, the value is equivalent to
     `IVF<nLists>,Flat`. For more information on how to create these custom
     indexes, see the [Faiss Wiki](https://github.com/facebookresearch/faiss/wiki/The-index-factory).
+
+## Resource usage during index creation
+
+Building a vector index temporarily increases the CPU and memory usage of the
+server. Knowing what happens during the build lets you anticipate how much
+additional load to expect. The index is built in two phases.
+
+**1. Training**
+
+The index first learns how to partition the vector space into `nLists` groups,
+each represented by a centroid. To do so, it takes a random sample of your
+vectors and runs an iterative clustering algorithm over that sample. The full
+dataset is not loaded into memory. Instead, the number of vectors pulled into
+memory for training is bounded to at most `numberOfDocsPerCentroid` per group
+(`100` by default), so up to `nLists` × `numberOfDocsPerCentroid` vectors in
+total, but never more than the number of vectors that actually exist.
+
+The sample is held in memory as plain 32-bit floating-point numbers, so you can
+estimate its peak memory as:
+
+```
+nLists × numberOfDocsPerCentroid × dimension × 4 bytes
+```
+
+For example, with `nLists` set to `1000`, the default `numberOfDocsPerCentroid`
+of `100`, and a `dimension` of `768`, the sample occupies about 290 MB. The
+clustering computation needs some more memory on top of that. Training is
+CPU-bound, and a larger `nLists`, `numberOfDocsPerCentroid`, or `dimension`
+makes it take longer.
+
+Because the sample size does not depend on how many documents you have, the
+memory needed for training stays roughly the same whether the collection holds
+a hundred thousand or a hundred million vectors (as long as there are at least
+`nLists` × `numberOfDocsPerCentroid` of them).
+
+**2. Indexing**
+
+Once the centroids are known, every vector is read, assigned to its nearest
+centroid, and encoded into the index. This phase makes a full pass over all
+documents, so unlike training, its cost grows with the number of vectors. It is
+mostly CPU-bound and also determines the final on-disk size of the index.
+
+In short, the number of groups (`nLists`) and the vector `dimension` drive the
+training cost, while the number of documents drives the indexing cost and the
+index size. On a cluster, these counts apply per shard, as each shard trains and
+builds its own index.
 
 ## Interfaces
 

--- a/site/content/arangodb/4.0/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
+++ b/site/content/arangodb/4.0/indexes-and-search/indexing/working-with-indexes/vector-indexes.md
@@ -118,13 +118,18 @@ centroids and the quality of vector search thus degrades.
   - **trainingIterations** (number, _optional_): The number of iterations in the
     training process. Default: `25`. Smaller values lead to a faster index
     creation but may yield worse search results. 
-  - **numberOfDocsPerCentroid** (number, _optional_): How many vectors per
-    centroid to include in the random sample used for training. Default: `100`.
+  - **numberOfDocsPerCentroid** (number, _optional_, introduced in v3.12.10):
+    How many vectors per centroid to include in the random sample used for
+    training. It must be `1` or greater. Default: `100`.
+
+    Up to v3.12.9, this is not configurable and a fixed value of `256` per
+    centroid is used instead.
+
     The training does not use the full dataset but a sample bounded to
     `nLists` × `numberOfDocsPerCentroid` vectors. A larger value can improve the
     training quality but increases the memory and time required for training.
     See [Resource usage during index creation](#resource-usage-during-index-creation)
-    for details. It must be `1` or greater.
+    for details.
   - **factory** (string, _optional_): You can specify an index factory string that is
     forwarded to the underlying Faiss library, allowing you to combine different
     advanced options. Examples:
@@ -142,48 +147,53 @@ centroids and the quality of vector search thus degrades.
 
 Building a vector index temporarily increases the CPU and memory usage of the
 server. Knowing what happens during the build lets you anticipate how much
-additional load to expect. The index is built in two phases.
+additional load to expect.
 
-**1. Training**
+The index is built in two phases:
 
-The index first learns how to partition the vector space into `nLists` groups,
-each represented by a centroid. To do so, it takes a random sample of your
-vectors and runs an iterative clustering algorithm over that sample. The full
-dataset is not loaded into memory. Instead, the number of vectors pulled into
-memory for training is bounded to at most `numberOfDocsPerCentroid` per group
-(`100` by default), so up to `nLists` × `numberOfDocsPerCentroid` vectors in
-total, but never more than the number of vectors that actually exist.
+1. **Training**
 
-The sample is held in memory as plain 32-bit floating-point numbers, so you can
-estimate its peak memory as:
+   The index first learns how to partition the vector space into `nLists` groups,
+   each represented by a centroid. To do so, it takes a random sample of your
+   vectors and runs an iterative clustering algorithm over that sample. The full
+   dataset is not loaded into memory. Instead, the number of vectors pulled into
+   memory for training is bounded per group and never exceeds the number of vectors
+   that actually exist. From v3.12.10 onward, this bound is `numberOfDocsPerCentroid`
+   vectors per group (`100` by default and configurable), so up to
+   `nLists` × `numberOfDocsPerCentroid` vectors in total. Up to v3.12.9, a fixed
+   value of `256` per group is used instead.
 
-```
-nLists × numberOfDocsPerCentroid × dimension × 4 bytes
-```
+   The sample is held in memory as plain 32-bit floating-point numbers, so you can
+   estimate its peak memory as:
 
-For example, with `nLists` set to `1000`, the default `numberOfDocsPerCentroid`
-of `100`, and a `dimension` of `768`, the sample occupies about 290 MB. The
-clustering computation needs some more memory on top of that. Training is
-CPU-bound, and a larger `nLists`, `numberOfDocsPerCentroid`, or `dimension`
-makes it take longer.
+   ```
+   nLists × numberOfDocsPerCentroid × dimension × 4 bytes
+   ```
 
-Because the sample size does not depend on how many documents you have, the
-memory needed for training stays roughly the same whether the collection holds
-a hundred thousand or a hundred million vectors (as long as there are at least
-`nLists` × `numberOfDocsPerCentroid` of them).
+   For example, with `nLists` set to `1000`, the default `numberOfDocsPerCentroid`
+   of `100`, and a `dimension` of `768`, the sample occupies about 290 MB. Up to
+   v3.12.9, the same `nLists` and `dimension` uses `256` per group and occupies
+   about 750 MB. The clustering computation needs some more memory on top of that.
+   Training is CPU-bound, and a larger `nLists`, `numberOfDocsPerCentroid`, or
+   `dimension` makes it take longer.
 
-**2. Indexing**
+   Because the sample size does not depend on how many documents you have, the
+   memory needed for training stays roughly the same whether the collection holds
+   a hundred thousand or a hundred million vectors (as long as there are at least
+   `nLists` × `numberOfDocsPerCentroid` of them).
 
-Once the centroids are known, every vector is read, assigned to its nearest
-centroid, and encoded into the index. This phase makes a full pass over all
-documents, so unlike training, its cost grows with the number of vectors. It is
-mostly CPU-bound and also determines the final on-disk size of the index.
+2. **Indexing**
+
+   Once the centroids are known, every vector is read, assigned to its nearest
+   centroid, and encoded into the index. This phase makes a full pass over all
+   documents, so unlike training, its cost grows with the number of vectors. It is
+   mostly CPU-bound and also determines the final on-disk size of the index.
 
 In short, the number of groups (`nLists`) and the vector `dimension` drive the
 training cost, while the number of documents drives the indexing cost. The index
 size grows with the number of documents and the vector `dimension`, and also
-depends on the encoding (the `factory` option). On a cluster, these counts apply
-per shard, as each shard trains and builds its own index.
+depends on the encoding (the `factory` option). In cluster deployments, these
+counts apply per shard, as each shard trains and builds its own index.
 
 ## Interfaces
 

--- a/site/content/arangodb/4.0/release-notes/version-3.12/api-changes-in-3-12.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.12/api-changes-in-3-12.md
@@ -647,6 +647,17 @@ vector embedding field are not counted toward this threshold.
 Check the `trainingState` to see if the
 index is `"ready"` and `errorMessage` for the reason if it's not.
 
+---
+
+<small>Introduced in: v3.12.10</small>
+
+A new option to let you configure how many vectors per centroid to include in
+the random sample used for training the index has been added. You can set
+`numberOfDocsPerCentroid` in the `params` object to change the default of `100`.
+
+Up to v3.12.9, this is not configurable and a fixed value of `256` per centroid
+is used instead.
+
 ##### Changed consolidation defaults for inverted indexes
 
 <small>Introduced in: v3.12.6</small>

--- a/site/content/arangodb/4.0/release-notes/version-3.12/whats-new-in-3-12.md
+++ b/site/content/arangodb/4.0/release-notes/version-3.12/whats-new-in-3-12.md
@@ -1713,6 +1713,22 @@ vector embedding field are not counted toward this threshold.
 Check the `trainingState` to see if the
 index is `"ready"` and `errorMessage` for the reason if it's not.
 
+---
+
+<small>Introduced in: v3.12.10</small>
+
+A new option to let you configure how many vectors per centroid to include in
+the random sample used for training the index has been added. You can set
+`numberOfDocsPerCentroid` in the `params` object to change the default of `100`.
+
+Up to v3.12.9, this is not configurable and a fixed value of `256` per centroid
+is used instead.
+
+A larger value can improve the training quality but increases the memory and
+time required for training. See
+[Resource usage during index creation](../../indexes-and-search/indexing/working-with-indexes/vector-indexes.md#resource-usage-during-index-creation)
+for details.
+
 ## Server options
 
 ### Effective and available startup options


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the `numberOfDocsPerCentroid` vector index training sampling parameter (introduced in v3.12.10), including default (`100`), constraints, and how it bounds the training sample (`nLists × numberOfDocsPerCentroid`), replacing the earlier fixed value (`256`).
  * Updated vector index HTTP API documentation and schemas to include the new parameter in create and response payloads.
  * Added “Resource usage during index creation” guidance, covering training vs. indexing phases and how CPU/memory scale with key parameters and document count.
  * Clarified the feature enablement note that there’s no performance impact beyond an idle internal storage component until a vector index is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->