### PR TITLE
Hugo 0.164 / future-proofing

### DIFF
--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -72,12 +72,6 @@ caches:
   assets:
     dir: :resourceDir/_gen
     maxAge: -1
-  getcsv:
-    dir: :cacheDir/:project
-    maxAge: 0
-  getjson:
-    dir: :cacheDir/:project
-    maxAge: -1
   getresource:
     dir: :cacheDir/:project
     maxAge: 0

--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -82,6 +82,13 @@ caches:
     dir: :cacheDir/modules
     maxAge: -1
 
+security:
+  http:
+    methods:
+      - (?i)POST
+    urls:
+      - ^http://192\.168\.(?:129|130)\.129:8080/
+
 params:
   arangoproxyUrl: "http://192.168.129.129:8080"
   description: >-

--- a/site/config/_default/config.yaml
+++ b/site/config/_default/config.yaml
@@ -1,5 +1,5 @@
 baseURL: "https://docs.arango.ai/"
-languageCode: "en-us"
+locale: "en-us"
 title: "Arango Documentation"
 theme: "arangodb-docs-theme"
 timeout: "200000000"

--- a/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/breadcrumbs.html
@@ -29,7 +29,7 @@
 
 {{ define "getVersionLong" -}}
   {{ $coreVersion := .coreVersion -}}
-  {{ $versions := index site.Data.versions "/arangodb/" -}}
+  {{ $versions := index hugo.Data.versions "/arangodb/" -}}
   {{ range $i, $version := $versions -}}
     {{ if or (eq $coreVersion $version.name) (eq $coreVersion $version.alias) -}}
       {{ $version.version -}}

--- a/site/themes/arangodb-docs-theme/layouts/partials/javascript.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/javascript.html
@@ -2,7 +2,7 @@
 <script src="{{"js/clipboard.min.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}" defer></script>
 <script src="{{"js/featherlight.min.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}" defer></script>
 
-{{ $versions := index site.Data.versions "/arangodb/" -}}
+{{ $versions := index hugo.Data.versions "/arangodb/" -}}
 <script>
   var versions = {{ $versions }}
 </script>

--- a/site/themes/arangodb-docs-theme/layouts/partials/meta.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/meta.html
@@ -22,7 +22,7 @@
   <meta name="docsearch:version" content="{{ $coreVersion }}">
 {{- else }}
   {{- $shortVersions := slice }}
-  {{- $versions := index site.Data.versions "/arangodb/" }}
+  {{- $versions := index hugo.Data.versions "/arangodb/" }}
   {{- range $version := $versions }}
     {{- $shortVersions = $shortVersions | append $version.name }}
     {{- if ne $version.name $version.alias }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/page-alias-map.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/page-alias-map.html
@@ -1,5 +1,5 @@
 {{ $pathMap := dict -}}
-{{ range $page := .Site.AllPages -}}
+{{ range $page := .Site.Pages -}}
   {{ $pagePath := $page.Path -}}
   {{ if $pagePath -}}
     {{ $pagePathNoExt := $pagePath -}}

--- a/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/examples/example.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/examples/example.html
@@ -14,7 +14,7 @@
 {{ if not $pageVersion }}
   {{ $pageVersion = (partialCached "version-short.html" $context.Page.RelPermalink $context.Page.RelPermalink) }}
 {{ end }}
-{{ $dataFolderByVersion := index site.Data $pageVersion }}
+{{ $dataFolderByVersion := index hugo.Data $pageVersion }}
 {{ $cache := index $dataFolderByVersion "cache"}}
 {{ $cacheFound :=  index $cache $cacheEntry }}
 

--- a/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/version.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/shortcodes/version.html
@@ -1,6 +1,6 @@
 {{- $page := .page }}
 {{- if hasPrefix $page.Path "/arangodb/" }}
-  {{- $versions := index site.Data.versions "/arangodb/" }}
+  {{- $versions := index hugo.Data.versions "/arangodb/" }}
   {{- $coreVersion := index (split $page.Path "/") 2 }}
   {{- range $i, $version := $versions }}
     {{- if or (eq $coreVersion $version.name) (eq $coreVersion $version.alias) }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/toc.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/toc.html
@@ -9,7 +9,7 @@
         {{- $splitPath := split $path "/" }}
         {{- $versionAlias := index $splitPath 1 }}
         {{- if or (eq $versionAlias "stable") (eq $versionAlias "devel") }}
-          {{- $versionName := (index (where (index site.Data.versions "/arangodb/") "alias" $versionAlias) 0).name }}
+          {{- $versionName := (index (where (index hugo.Data.versions "/arangodb/") "alias" $versionAlias) 0).name }}
           {{- $path = $path | replaceRE (printf "^arangodb/%s/" $versionAlias) (printf "arangodb/%s/" $versionName) }}
         {{- end }}
       {{- end }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/version-noindex-map.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/version-noindex-map.html
@@ -1,6 +1,6 @@
 {{- $versionNameOrAlias := . }}
 {{- $noindexMap := dict }}
-{{- $versions := index site.Data.versions "/arangodb/" }}
+{{- $versions := index hugo.Data.versions "/arangodb/" }}
 {{- range $i, $version := $versions }}
   {{- $noindex := or $version.deprecated $version.inDevelopment }}
   {{- $noindexMap = merge $noindexMap (dict

--- a/site/themes/arangodb-docs-theme/layouts/partials/version-selector.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/version-selector.html
@@ -1,6 +1,6 @@
 <select class="version-selector" name="Version selector">
   <optgroup label="Version">
-    {{ $versions := index site.Data.versions "/arangodb/" -}}
+    {{ $versions := index hugo.Data.versions "/arangodb/" -}}
     {{ range $i, $version := $versions -}}
       <option value="{{ $version.alias }}"{{/* if eq $version.alias "stable" }} selected{{ end */}}>
         {{- $version.name }}

--- a/site/themes/arangodb-docs-theme/layouts/partials/version-short-map.html
+++ b/site/themes/arangodb-docs-theme/layouts/partials/version-short-map.html
@@ -1,6 +1,6 @@
 {{- $versionNameOrAlias := . }}
 {{- $versionsMap := dict }}
-{{- $versions := index site.Data.versions "/arangodb/" }}
+{{- $versions := index hugo.Data.versions "/arangodb/" }}
 {{- range $i, $version := $versions }}
   {{- $versionsMap = merge $versionsMap (dict
     $version.name $version.name

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/card.html
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/card.html
@@ -1,7 +1,7 @@
 {{- $title := .Get "title" }}
 {{- $link := .Get "link" }}
 {{- $image := resources.GetMatch (printf "images/%s" ( .Get "icon" )) }}
-{{- $versions := index .Site.Data.versions "/arangodb/" }}
+{{- $versions := index hugo.Data.versions "/arangodb/" }}
 {{- $stableVersion := (index (where $versions "alias" "stable") 0).name }}
 {{- /* TODO: Check if relative links are resolved in the context of the linking page */}}
 {{- partial "shortcodes/card.html" (dict

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/error-codes.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/error-codes.md
@@ -2,7 +2,7 @@
 {{- if not $pageVersion }}
   {{- $pageVersion = (partialCached "version-short.html" .Page.RelPermalink .Page.RelPermalink) }}
 {{- end }}
-{{- $dataFolderByVersion := index site.Data $pageVersion }}
+{{- $dataFolderByVersion := index hugo.Data $pageVersion }}
 {{- $data := index $dataFolderByVersion "errors" }}
 {{- $basePage := .Page.RelPermalink }}
 {{- range $data }}

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/exit-codes.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/exit-codes.md
@@ -2,7 +2,7 @@
 {{- if not $pageVersion }}
   {{- $pageVersion = (partialCached "version-short.html" .Page.RelPermalink .Page.RelPermalink) }}
 {{- end }}
-{{- $dataFolderByVersion := index site.Data $pageVersion }}
+{{- $dataFolderByVersion := index hugo.Data $pageVersion }}
 {{- $data := index $dataFolderByVersion "exitcodes" }}
 {{- $basePage := .Page.RelPermalink }}
 {{- range $data }}

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/full-version.html
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/full-version.html
@@ -1,5 +1,5 @@
 {{ $ver := (.Get 0) -}}
-{{- $versions := (where (index .Site.Data.versions "/arangodb/") "name" $ver) -}}
+{{- $versions := (where (index hugo.Data.versions "/arangodb/") "name" $ver) -}}
 {{ if $versions -}}
   {{ (index $versions 0).version | htmlEscape -}}
 {{ else -}}

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/metrics.md
@@ -3,7 +3,7 @@
 {{- if not $pageVersion }}
   {{- $pageVersion = (partialCached "version-short.html" .Page.RelPermalink .Page.RelPermalink) }}
 {{- end }}
-{{- $dataFolderByVersion := index site.Data $pageVersion }}
+{{- $dataFolderByVersion := index hugo.Data $pageVersion }}
 {{- $allMetricsFile := index $dataFolderByVersion "allMetrics" }}
 {{- if not $allMetricsFile }}{{ errorf "Could not find %q in %q data folder" "allMetrics" $pageVersion}}{{ end }}
 {{- $metricGroups := newScratch }}

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/optimizer-rules.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/optimizer-rules.md
@@ -3,7 +3,7 @@
   {{ $pageVersion = (partialCached "version-short.html" .Page.RelPermalink .Page.RelPermalink) -}}
 {{ end -}}
 
-{{ $dataFolderByVersion := index site.Data $pageVersion -}}
+{{ $dataFolderByVersion := index hugo.Data $pageVersion -}}
 {{ $rules := index $dataFolderByVersion "optimizer-rules" }}
 
 {{ with $rules -}}

--- a/site/themes/arangodb-docs-theme/layouts/shortcodes/program-options.md
+++ b/site/themes/arangodb-docs-theme/layouts/shortcodes/program-options.md
@@ -4,7 +4,7 @@
 {{- if not $pageVersion }}
   {{- $pageVersion = (partialCached "version-short.html" .Page.RelPermalink .Page.RelPermalink) }}
 {{- end }}
-{{- $dataFolderByVersion := index site.Data $pageVersion }}
+{{- $dataFolderByVersion := index hugo.Data $pageVersion }}
 {{- $options := index $dataFolderByVersion $program }}
 {{- if not $options }}{{ errorf "Could not find %q in %q data folder" $program $pageVersion }}{{ end }}
 {{- $osMap := dict "linux" "Linux" "macos" "macOS" "windows" "Windows" }}


### PR DESCRIPTION
### Description

Replace deprecated and removed functionality and adjust for tighter security.

alpine:edge has 0.160.1 at the moment, but the latest hugo could be built like this:

```
RUN apk add build-base
RUN CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@latest
RUN cp -a /root/go/bin/hugo /usr/local/bin
```

This would need another build stage to not include all of the build tools in the image, however. Probably better to fetch the latest Hugo release directly from GitHub?

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 
