### PR TITLE
DOC-925 | Add Node.js 22 base image (API only)

### DIFF
--- a/site/content/platform-suite/container-manager/_index.md
+++ b/site/content/platform-suite/container-manager/_index.md
@@ -68,8 +68,9 @@ You may consider using AI tools for this.
   provide Docker image URLs to deploy running services.
 
 - **Multiple Runtimes**: For code-based deployments, supported runtime
-  environments include Python with optional CUDA/GPU support. For image-based
-  deployments, you can use any runtime packaged in your Docker image.
+  environments include Python with optional CUDA/GPU support, as well as Node.js.
+  For image-based deployments, you can use any runtime packaged in your
+  Docker image.
 
 - **Version Management**: Maintain and deploy multiple versions of the same
   service with easy updates.
@@ -96,6 +97,7 @@ Deploy services using runtime environments and resources tailored to your needs.
 
 **Code-based deployments (Bring Your Own Code):**
 - **Python 3.12** (base, PyTorch, and cuGraph variants available)
+- **Node.js 22** (base variant)
 
 **Container-based deployments (Bring Your Own Container):**
 - Any runtime or language packaged in your container image

--- a/site/content/platform-suite/container-manager/deploy-api.md
+++ b/site/content/platform-suite/container-manager/deploy-api.md
@@ -98,6 +98,7 @@ curl -X POST "https://<EXTERNAL_ENDPOINT>:8529/_platform/acp/v1/uds" \
 | `py12base` | Python 3.12 base runtime |
 | `py12torch` | Python 3.12 with PyTorch |
 | `py12cugraph` | Python 3.12 with cuGraph |
+| `node22base` | Node.js 22 base runtime |
 
 ## Deploy an Image-Based Service
 

--- a/site/content/platform-suite/container-manager/package-code.md
+++ b/site/content/platform-suite/container-manager/package-code.md
@@ -48,6 +48,7 @@ follow the steps below.
 1. Create a project structure with your application code and entry point script.
 2. Add a dependency configuration file:
    - For Python: Create a `pyproject.toml` with your dependencies and Python version requirement.
+   - For Node.js: Create a `package.json` with your dependencies and a start script.
 3. Use `uv` for Python projects (recommended):
    - Ensure your `pyproject.toml` specifies `requires-python` matching your target runtime
      (e.g., `">=3.12"` for the `py12*` base images).
@@ -81,6 +82,39 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
 ]
+```
+
+**Create the archive:**
+```bash
+tar -czf myservice.tar.gz myproject/
+```
+
+## Example: Node.js Project
+
+**Project structure:**
+```
+myproject/
+├── package.json
+├── index.js
+└── config.json
+```
+
+**Example `package.json`:**
+```json
+{
+  "name": "my-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "express": "^5.0.0"
+  }
+}
 ```
 
 **Create the archive:**

--- a/site/content/platform-suite/container-manager/package-code.md
+++ b/site/content/platform-suite/container-manager/package-code.md
@@ -64,7 +64,7 @@ follow the steps below.
 ## Example: Python Project
 
 **Project structure:**
-```
+```text
 myproject/
 ├── pyproject.toml
 ├── main.py
@@ -91,7 +91,7 @@ tar -czf myservice.tar.gz myproject/
 ## Example: Node.js Project
 
 **Project structure:**
-```
+```text
 myproject/
 ├── package.json
 ├── index.js


### PR DESCRIPTION
### Description

<!-- Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory** -->

#### Upstream PRs

<!-- Docker Hub images or GitHub pull request links from the arangodb/arangodb repository -->

- 3.10: 
- 3.11: 
- 3.12: 
- 4.0: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Node.js 22 as a supported runtime for code-based deployments.
  * Added the `node22base` option for API deployments.
  * Clarified Python support with optional CUDA/GPU acceleration and noted that image-based deployments can use any runtime packaged in the Docker image.

* **Documentation**
  * Added Node.js manual packaging guidance, including `package.json` setup, an example project structure, and archive creation commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->